### PR TITLE
Add failing and passing tests hvp

### DIFF
--- a/test/failing.jl
+++ b/test/failing.jl
@@ -1,0 +1,23 @@
+using Zygote, Test, LinearAlgebra
+using Zygote: Params, gradient, forward
+
+x = randn(3)
+v = randn(3)
+H = randn(3,3); H = H+H'
+
+f(x) = (H = [ -0.466054  -1.67757   0.227333
+ -1.67757   -0.7407    1.90789
+  0.227333   1.90789  -1.10871 ]; transpose(x)*(H*x))      # i'H*i function to take hessian of
+
+val,back = forward(f,x)
+@test_skip gradient(f,x)
+@test_skip back(x)
+
+g(x)     = 0.5*x'*(H*x)
+val,back = forward(g,x)
+@test_skip back(x)
+
+@test_skip gradtest(2) do x
+  H = [1 0.5; 0.5 2]
+  0.5*(x'*(H*x))
+end

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -85,3 +85,8 @@ end
 
   @test gradtest(x -> minimum(x, dims=[1, 2]), rand(2, 3, 4))
 end
+
+@testset "hessian-vector-product" begin
+  H = [1 0.5; 0.5 2]
+  @test gradtest(x->0.5*(x'*(H*x)),2)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,4 +15,8 @@ end
   include("compiler.jl")
 end
 
+@testset "Failing" begin
+  include("failing.jl")
+end
+
 end


### PR DESCRIPTION
This PR adds a file with tests that are currently failing. They are decorated with [`@test_skip`](https://docs.julialang.org/en/v1/stdlib/Test/#Test.@test_skip)

It also adds a test which is now passing, indicating #5 can be closed