### PR TITLE
Parameterize cache on whether or not is has a cache

### DIFF
--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -1,9 +1,10 @@
-mutable struct Context
-  cache::Union{IdDict{Any,Any},Nothing}
+mutable struct Context{T<:Union{IdDict{Any,Any},Nothing}}
+  cache::T
 end
 
-Context() = Context(nothing)
+Context() = Context{Union{IdDict{Any,Any},Nothing}}(nothing)
 
+cache(cs::Context{Nothing}) = error("Cache not enabled for this context")
 cache(cx::Context) = cx.cache == nothing ? (cx.cache = IdDict()) : cx.cache
 
 struct J{S,T}

--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -31,6 +31,7 @@ end
 
 @grad Base.typeassert(x, T) = Base.typeassert(x, T), Δ -> (Δ, nothing)
 
+accum_param(cx::Context{Nothing}, x, Δ) = nothing
 function accum_param(cx::Context, x, Δ)
   haskey(cache(cx), x) && (cache(cx)[x] = accum(cache(cx)[x],Δ))
   return


### PR DESCRIPTION
Otherwise, in order to get rid of all the ObjectId related code,
SROA would have to see the allocation of the context and be able
to eliminate it. It's much easier on the compiler if we don't
generate it in the first place when we don't need it.