### PR TITLE
WIP: Replace Zygote's Cassette-style transform with actual Cassette

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -15,6 +15,14 @@ git-tree-sha1 = "055eb2690182ebc31087859c3dd8598371d3ef9e"
 uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 version = "0.5.3"
 
+[[Cassette]]
+deps = ["InteractiveUtils", "LinearAlgebra", "Test"]
+git-tree-sha1 = "93bd4a23e2f3de79672279abda7ea1404b988649"
+repo-rev = "jr/cycle"
+repo-url = "https://github.com/jrevels/Cassette.jl.git"
+uuid = "7057c7e9-c182-5462-911a-8362d720325c"
+version = "0.1.4+"
+
 [[CommonSubexpressions]]
 deps = ["Test"]
 git-tree-sha1 = "efdaf19ab11c7889334ca247ff4c9f7c322817b0"
@@ -48,7 +56,7 @@ uuid = "b552c78f-8df3-52c6-915a-8e097449b14b"
 version = "0.0.7"
 
 [[Distributed]]
-deps = ["LinearAlgebra", "Random", "Serialization", "Sockets"]
+deps = ["Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[ForwardDiff]]

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -17,7 +17,7 @@ version = "0.5.3"
 
 [[Cassette]]
 deps = ["InteractiveUtils", "LinearAlgebra", "Test"]
-git-tree-sha1 = "93bd4a23e2f3de79672279abda7ea1404b988649"
+git-tree-sha1 = "727f69974847e5fa5a29069fea1f782b459a8370"
 repo-rev = "jr/cycle"
 repo-url = "https://github.com/jrevels/Cassette.jl.git"
 uuid = "7057c7e9-c182-5462-911a-8362d720325c"

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,5 +1,3 @@
-# This file is machine-generated - editing it directly is not advised
-
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
@@ -17,9 +15,7 @@ version = "0.5.3"
 
 [[Cassette]]
 deps = ["InteractiveUtils", "LinearAlgebra", "Test"]
-git-tree-sha1 = "727f69974847e5fa5a29069fea1f782b459a8370"
-repo-rev = "jr/cycle"
-repo-url = "https://github.com/jrevels/Cassette.jl.git"
+path = "/Users/jarrettrevels/.julia/dev/Cassette"
 uuid = "7057c7e9-c182-5462-911a-8362d720325c"
 version = "0.1.4+"
 
@@ -56,7 +52,7 @@ uuid = "b552c78f-8df3-52c6-915a-8e097449b14b"
 version = "0.0.7"
 
 [[Distributed]]
-deps = ["Random", "Serialization", "Sockets"]
+deps = ["LinearAlgebra", "Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[ForwardDiff]]
@@ -67,12 +63,14 @@ version = "0.10.1"
 
 [[IRTools]]
 deps = ["InteractiveUtils", "MacroTools", "Test"]
-path = "../IRTools"
+git-tree-sha1 = "768a3dd81e45494eca34b49aff744cc1b74e9cdd"
+repo-rev = "master"
+repo-url = "https://github.com/MikeInnes/IRTools.jl.git"
 uuid = "7869d1d1-7146-5819-86e3-90919afe41df"
-version = "0.1.0"
+version = "0.1.1"
 
 [[InteractiveUtils]]
-deps = ["Markdown"]
+deps = ["LinearAlgebra", "Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[LibGit2]]
@@ -179,7 +177,7 @@ uuid = "30578b45-9adc-5946-b283-645ec420af67"
 version = "0.4.0"
 
 [[UUIDs]]
-deps = ["Random", "SHA"]
+deps = ["Random"]
 uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [[Unicode]]

--- a/Project.toml
+++ b/Project.toml
@@ -2,6 +2,7 @@ name = "Zygote"
 uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [deps]
+Cassette = "7057c7e9-c182-5462-911a-8362d720325c"
 DiffRules = "b552c78f-8df3-52c6-915a-8e097449b14b"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 IRTools = "7869d1d1-7146-5819-86e3-90919afe41df"

--- a/REQUIRE
+++ b/REQUIRE
@@ -7,3 +7,4 @@ NaNMath
 Requires
 SpecialFunctions
 IRTools
+Cassette

--- a/src/Zygote.jl
+++ b/src/Zygote.jl
@@ -15,6 +15,8 @@ using IRTools
 using MacroTools, Requires
 using MacroTools: @forward
 
+using Cassette
+
 export Params, gradient, derivative, forward, @code_grad
 
 include("tools/idset.jl")

--- a/src/Zygote.jl
+++ b/src/Zygote.jl
@@ -27,6 +27,7 @@ include("tools/fillarray.jl")
 
 include("compiler/reverse.jl")
 include("compiler/emit.jl")
+include("compiler/emit_new.jl")
 include("compiler/interface.jl")
 
 include("forward/Forward.jl")

--- a/src/Zygote.jl
+++ b/src/Zygote.jl
@@ -1,6 +1,7 @@
 module Zygote
 
-using LinearAlgebra
+using LinearAlgebra, Cassette
+using Cassette: Reflection
 
 # This flag enables Zygote to grab extra type inference information during
 # compiles. When control flow is present, this can give gradient code a

--- a/src/compiler/emit.jl
+++ b/src/compiler/emit.jl
@@ -128,19 +128,3 @@ function _lookup_grad(T)
 end
 
 stacklines(T::Type) = stacklines(Adjoint(IRCode(meta(T))))
-
-function zygote_pass(::Type{C}, m::Reflection) where C
-  T = m.signature
-  va = varargs(m.method, length(T.parameters))
-  forw, back = stacks!(Adjoint(IRCode(m), varargs = va), T)
-  argnames!(m, Symbol("#self#"), :ctx, :f, :args)
-  forw = varargs!(m, forw, 3)
-  forw = slots!(pis!(inlineable!(forw)))
-  return IRTools.update!(m, forw)
-end
-
-# add(a, b) = a+b
-# ctx = Cassette.disablehooks(ZygoteContext())
-# m = Cassette.reflect((typeof(add),Int,Int))
-#
-# zygote_pass(typeof(ctx), Cassette.reflect((typeof(add),Int,Int)))

--- a/src/compiler/emit.jl
+++ b/src/compiler/emit.jl
@@ -128,3 +128,19 @@ function _lookup_grad(T)
 end
 
 stacklines(T::Type) = stacklines(Adjoint(IRCode(meta(T))))
+
+function zygote_pass(::Type{C}, m::Reflection) where C
+  T = m.signature
+  va = varargs(m.method, length(T.parameters))
+  forw, back = stacks!(Adjoint(IRCode(m), varargs = va), T)
+  argnames!(m, Symbol("#self#"), :ctx, :f, :args)
+  forw = varargs!(m, forw, 3)
+  forw = slots!(pis!(inlineable!(forw)))
+  return IRTools.update!(m, forw)
+end
+
+# add(a, b) = a+b
+# ctx = Cassette.disablehooks(ZygoteContext())
+# m = Cassette.reflect((typeof(add),Int,Int))
+#
+# zygote_pass(typeof(ctx), Cassette.reflect((typeof(add),Int,Int)))

--- a/src/compiler/emit_new.jl
+++ b/src/compiler/emit_new.jl
@@ -1,0 +1,47 @@
+#=
+TODO:
+
+- All transforms of the form `f(args...)` to `Zygote._forward(ctx, f, args...)`
+should simply be removed; Cassette will do the equivalent for you.
+
+- All emitted calls that Zygote does not want to be overdubbed should be wrapped
+in `Expr(:nooverdub)` (see Cassette docs for details).
+=#
+
+function zygote_pass(::Type{C}, r::Reflection) where C
+  T = r.signature
+  va = varargs(r.method, length(T.parameters))
+  forw, back = stacks!(Adjoint(IRCode(r), varargs = va), T)
+  argnames!(r, Symbol("#self#"), :ctx, :f, :args)
+  forw = varargs!(r, forw, 3)
+  forw = slots!(pis!(inlineable!(forw)))
+  return IRTools.update!(r, forw)
+end
+
+#=
+Example invocation of the above:
+
+julia> using Zygote, Cassette
+
+julia> ctx = Cassette.disablehooks(Zygote.ZygoteContext());
+
+julia> r = Cassette.reflect((typeof(hypot), Int, Int, Int));
+
+julia> Zygote.zygote_pass(typeof(ctx), r)
+CodeInfo(
+570 1 ─       $(Expr(:meta, :inline))                                          │
+    │   %2  = (Zygote._forward)(ctx, Base.Generator, Base.Math.abs2, args)     │
+    │   %3  = (Base.getindex)(%2, 1)                                           │
+    │         (Base.getindex)(%2, 2)                                           │
+    │   %5  = (Zygote._forward)(ctx, Base.Math.sum, %3)                        │
+    │   %6  = (Base.getindex)(%5, 1)                                           │
+    │         (Base.getindex)(%5, 2)                                           │
+    │   %8  = (Zygote._forward)(ctx, Base.Math.sqrt, %6)                       │
+    │   %9  = (Base.getindex)(%8, 1)                                           │
+    │         (Base.getindex)(%8, 2)                                           │
+    │   %11 = (Base.tuple)()                                                   │
+    │   %12 = (Zygote.Pullback{Tuple{typeof(hypot),Int64,Int64,Int64},T} where T)(%11)
+    │   %13 = (Base.tuple)(%9, %12)                                            │
+    └──       return %13                                                       │
+)
+=#

--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -1,10 +1,13 @@
-mutable struct Context
+
+Cassette.@context ZygoteContext
+
+mutable struct ContextCache
   cache::Union{IdDict{Any,Any},Nothing}
 end
 
-Context() = Context(nothing)
+ContextCache() = ContextCache(nothing)
 
-cache(cx::Context) = cx.cache == nothing ? (cx.cache = IdDict()) : cx.cache
+cache(cx::ContextCache) = cx.cache == nothing ? (cx.cache = IdDict()) : cx.cache
 
 struct Pullback{S,T}
   t::T
@@ -28,7 +31,7 @@ end
 
 # Wrappers
 
-_forward(f, args...) = _forward(Context(), f, args...)
+_forward(f, args...) = _forward(ContextCache(), f, args...)
 
 tailmemaybe(::Nothing) = nothing
 tailmemaybe(x::Tuple) = Base.tail(x)
@@ -67,7 +70,7 @@ Base.show(io::IO, ps::Grads) = print(io, "Grads(...)")
 @forward Grads.grads Base.setindex!, Base.getindex, Base.haskey
 
 function forward(f, ps::Params)
-  cx = Context()
+  cx = ContextCache()
   y, back = _forward(cx, f)
   y, function (Δ)
     for p in ps
@@ -81,7 +84,7 @@ end
 # Reflection
 
 # function code_grad(f, T)
-#   forw = code_typed(_forward, Tuple{Context,Typeof(f),T.parameters...})[1]
+#   forw = code_typed(_forward, Tuple{ContextCache,Typeof(f),T.parameters...})[1]
 #   Y, J = forw[2].parameters
 #   back = typed_meta(Tuple{J,Y}, optimize=true)
 #   back = back.code=>back.ret

--- a/src/compiler/interface2.jl
+++ b/src/compiler/interface2.jl
@@ -1,6 +1,6 @@
 ignore(T) = all(T -> T <: Type, T.parameters)
 
-@generated function _forward(ctx::Context, f, args...)
+@generated function _forward(ctx::ContextCache, f, args...)
   T = Tuple{f,args...}
   ignore(T) && return :(f(args...), Pullback{$T}(()))
   g = try _lookup_grad(T) catch e e end

--- a/src/compiler/reverse.jl
+++ b/src/compiler/reverse.jl
@@ -215,13 +215,14 @@ function blockinfo(pr::Primal)
       for (c, x) in zip(ex.edges, ex.values)
         x in pr.wrt && push!(@get!(info[b].phis, c, []), x)
       end
-    elseif iscall(ex, Zygote, :_forward)
-      y = isassert(pr.forw, i) ? SSAValue(i+3) : SSAValue(i+1)
-      push!(info[b].grads, y)
-      for x in ex.args[3:end]
-        x in pr.wrt && push!(info[b].partials, x)
-      end
     end
+    # elseif iscall(ex, Zygote, :_forward)
+    #   y = isassert(pr.forw, i) ? SSAValue(i+3) : SSAValue(i+1)
+    #   push!(info[b].grads, y)
+    #   for x in ex.args[3:end]
+    #     x in pr.wrt && push!(info[b].partials, x)
+    #   end
+    # end
   end
   worklist = collect(1:length(pr.forw.cfg.blocks))
   while !isempty(worklist)
@@ -291,22 +292,23 @@ function reverse_ir(pr::Primal)
           @assert !haskey(phis, (newblock(pr, b), newblock(pr, c), x)) "not implemented"
           phis[(newblock(pr, b), newblock(pr, c), x)] = Δ
         end
-      elseif iscall(ex, Zygote, :_forward)
-        # TODO remove with type hacks above
-        y = isassert(pr.forw, i) ? SSAValue(i+3) : SSAValue(i+1)
-        J = Alpha(i+2)
-        dy = insert_node!(ir, j, Any, xcall(Zygote, :accum))
-        ir.lines[j] = pr.forw.lines[i]
-        dxs = insert_node!(ir, j, Any, Expr(:call, J, dy))
-        ir.lines[j] = pr.forw.lines[i]
-        grads[y] = dy
-        for (a, x) in enumerate(ex.args[3:end])
-          x in pr.wrt || continue
-          dx = insert_node!(ir, j, Any, xgradindex(dxs, a))
-          ir.lines[j] = pr.forw.lines[i]
-          push!(partials[x], dx)
-        end
       end
+      # elseif iscall(ex, Zygote, :_forward)
+      #   # TODO remove with type hacks above
+      #   y = isassert(pr.forw, i) ? SSAValue(i+3) : SSAValue(i+1)
+      #   J = Alpha(i+2)
+      #   dy = insert_node!(ir, j, Any, xcall(Zygote, :accum))
+      #   ir.lines[j] = pr.forw.lines[i]
+      #   dxs = insert_node!(ir, j, Any, Expr(:call, J, dy))
+      #   ir.lines[j] = pr.forw.lines[i]
+      #   grads[y] = dy
+      #   for (a, x) in enumerate(ex.args[3:end])
+      #     x in pr.wrt || continue
+      #     dx = insert_node!(ir, j, Any, xgradindex(dxs, a))
+      #     ir.lines[j] = pr.forw.lines[i]
+      #     push!(partials[x], dx)
+      #   end
+      # end
     end
     if b == 1
       gs = []

--- a/src/compiler/reverse.jl
+++ b/src/compiler/reverse.jl
@@ -130,14 +130,14 @@ is_literal_getproperty(ex) = iscall(ex, Base, :getproperty) && ex.args[3] isa Qu
 function _forward_type(Ts)
   usetyped || return Any
   all(T -> isconcretetype(T) || T <: DataType, Ts) || return Any
-  T = Core.Compiler.return_type(_forward, Tuple{Context,Ts...})
+  T = Core.Compiler.return_type(_forward, Tuple{ContextCache,Ts...})
   return T == Union{} ? Any : T
 end
 
 isvalidtype(jT, yT) = jT <: Tuple && length(jT.parameters) == 2 && jT.parameters[1] <: yT
 
 function record!(ir::IRCode)
-  pushfirst!(ir.argtypes, typeof(_forward), Context)
+  pushfirst!(ir.argtypes, typeof(_forward), ContextCache)
   xs = reachable(ir)
   for i = 1:length(ir.stmts)
     ex = argmap(x -> Argument(x.n+2), ir[SSAValue(i)])

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -57,7 +57,7 @@ end
   end
 end
 
-function _forward(cx::Context, ::typeof(sum), f, xs::AbstractArray)
+function _forward(cx::ContextCache, ::typeof(sum), f, xs::AbstractArray)
   y, back = forward(cx, (xs -> sum(f.(xs))), xs)
   y, ȳ -> (nothing, nothing, back(ȳ)...)
 end

--- a/src/lib/grad.jl
+++ b/src/lib/grad.jl
@@ -27,7 +27,7 @@ function gradm(ex, mut = false)
   args = esc.(named.(args))
   argnames = typeless.(args)
   Ts = esc.(Ts)
-  cx = :($(esc(:__context__))::Context)
+  cx = :($(esc(:__context__))::ContextCache)
   fargs = kw == nothing ? [cx, :($f::$T), args...] : [kw, cx, :($f::$T), args...]
   quote
     @inline Zygote.adjoint($(fargs...)) where $(Ts...) = $(esc(body))
@@ -60,7 +60,7 @@ macro nograd(ex)
   blk = :(;)
   for f in ex.args
     back = MacroTools.@q _ -> ($__source__; nothing)
-    push!(blk.args, :(@inline Zygote._forward(::Context, ::Core.Typeof($(esc(f))), args...) = $(esc(f))(args...), $back))
+    push!(blk.args, :(@inline Zygote._forward(::ContextCache, ::Core.Typeof($(esc(f))), args...) = $(esc(f))(args...), $back))
   end
   return blk
 end

--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -31,7 +31,7 @@ end
 
 @adjoint Base.typeassert(x, T) = Base.typeassert(x, T), Δ -> (Δ, nothing)
 
-function accum_param(cx::Context, x, Δ)
+function accum_param(cx::ContextCache, x, Δ)
   haskey(cache(cx), x) && (cache(cx)[x] = accum(cache(cx)[x],Δ))
   return
 end
@@ -131,7 +131,7 @@ end
   Expr(:tuple, [:($f = Ref{Any}(nothing)) for f in fieldnames(x)]...)
 end
 
-function grad_mut(cx::Context, x)
+function grad_mut(cx::ContextCache, x)
   T = Core.Compiler.return_type(grad_mut, Tuple{typeof(x)})
   ch = cache(cx)
   if haskey(ch, x)

--- a/src/tools/ir.jl
+++ b/src/tools/ir.jl
@@ -95,6 +95,12 @@ xcall(f::Symbol, args...) = xcall(Base, f, args...)
 
 const unreachable = ReturnNode()
 
+function IRCode(meta::Reflection)
+  ir = just_construct_ssa(meta.code_info, deepcopy(meta.code_info.code),
+                          Int(meta.method.nargs)-1, Core.svec(meta.static_params...))
+  return compact!(ir)
+end
+
 # Dominance frontiers
 
 function domfront(cfg, dt = construct_domtree(cfg))

--- a/src/tools/reflection.jl
+++ b/src/tools/reflection.jl
@@ -19,6 +19,10 @@ function argnames!(meta, names...)
   meta.code.slotnames = [names...]
 end
 
+function argnames!(meta::Reflection, names...)
+  meta.code_info.slotnames = [names...]
+end
+
 function spliceargs!(meta, ir::IRCode, args...)
   for i = 1:length(ir.stmts)
     ir[SSAValue(i)] = argmap(x -> Argument(x.n+length(args)), ir[SSAValue(i)])
@@ -81,6 +85,14 @@ function slots!(ir::IRCode)
     end
   end
   return compact!(ir)
+end
+
+function IRTools.update!(meta::Reflection, ir::Core.Compiler.IRCode)
+  Core.Compiler.replace_code_newstyle!(meta.code_info, ir, length(ir.argtypes)-1)
+  meta.code_info.inferred = false
+  meta.code_info.ssavaluetypes = length(meta.code_info.code)
+  IRTools.slots!(meta.code_info)
+  return meta.code_info
 end
 
 @generated function roundtrip(f, args...)


### PR DESCRIPTION
Requires https://github.com/jrevels/Cassette.jl/pull/97, which can be updated alongside this PR if need be.

This PR is literally in its infancy right now, but the plan is roughly:

1. Get Zygote's AD pass running as a Cassette pass. We're halfway there; see `zygote_pass` in `emit_new.jl`. Right now, that function properly accepts Cassette-provided pass input and (as far as we have checked) produces the correct output w.r.t. Zygote's version of overdub. The next step is to tweak Zygote's pass machinery to produce correct output w.r.t. Cassette's overdub (see TODO comments there).

2. Refactor Zygote to utilize e.g. an actual Cassette context instead of Zygote's Cassette-style context, the Cassette-based AD pass from 1, etc.

3. Delete all of the Zygote overdub machinery that should now be handled by Cassette. This step may or may not be totally completed as part of this PR; we'll have to see. I'm not a good judge yet of where Zygote's actual AD parts are intertwined with it's implementation of Cassette-style overdub - if they are easy to decouple we can just do it here, if it's a bigger project it'd probably be better to do as a follow-up.

cc @Keno 