### PR TITLE
Update `Manifest.toml` to fix missing `IRTools`

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -59,7 +59,9 @@ version = "0.10.1"
 
 [[IRTools]]
 deps = ["InteractiveUtils", "MacroTools", "Test"]
-git-tree-sha1 = "5d3f123ff32a2aed5825ee2eef03ef7e95406b6e"
+git-tree-sha1 = "27f9f843de7b7baaf3e960932a22fd528be30dcc"
+repo-rev = "master"
+repo-url = "https://github.com/MikeInnes/IRTools.jl.git"
 uuid = "7869d1d1-7146-5819-86e3-90919afe41df"
 version = "0.1.1"
 

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -48,7 +48,7 @@ uuid = "b552c78f-8df3-52c6-915a-8e097449b14b"
 version = "0.0.7"
 
 [[Distributed]]
-deps = ["LinearAlgebra", "Random", "Serialization", "Sockets"]
+deps = ["Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[ForwardDiff]]
@@ -59,9 +59,9 @@ version = "0.10.1"
 
 [[IRTools]]
 deps = ["InteractiveUtils", "MacroTools", "Test"]
-path = "../IRTools"
+git-tree-sha1 = "5d3f123ff32a2aed5825ee2eef03ef7e95406b6e"
 uuid = "7869d1d1-7146-5819-86e3-90919afe41df"
-version = "0.1.0"
+version = "0.1.1"
 
 [[InteractiveUtils]]
 deps = ["Markdown"]
@@ -152,9 +152,9 @@ version = "0.7.2"
 
 [[StaticArrays]]
 deps = ["InteractiveUtils", "LinearAlgebra", "Random", "Statistics", "Test"]
-git-tree-sha1 = "97c4bf0f647488dd7ac01ea12be5885f88762938"
+git-tree-sha1 = "1eb114d6e23a817cd3e99abc3226190876d7c898"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "0.10.0"
+version = "0.10.2"
 
 [[Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]


### PR DESCRIPTION
Note that the Julia 1.0.X tests will continue to fail with this, because `IRTools v0.1.1` is not compatible with Julia 1.0.X, and backing it down to `v0.1.0` causes the `Zygote` test suite to segfault Julia 1.0.3.  Our best option is likely to wait until Julia 1.1 is released, then use that for our testing.