### PR TITLE
Fix up multiplication and scalar cholesky

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -108,8 +108,11 @@ end
 
 # LinAlg
 
-@adjoint a::AbstractVecOrMat * b::AbstractVecOrMat = a * b,
-  Δ -> (Δ * transpose(b), transpose(a) * Δ)
+@adjoint function(a::AbstractVecOrMat * b::AbstractVecOrMat)
+  return a * b, function(Δ)
+    return (reshape(Δ * transpose(b), size(a)), reshape(transpose(a) * Δ, size(b)))
+  end
+end
 
 @adjoint transpose(x) = transpose(x), Δ -> (transpose(Δ),)
 @adjoint Base.adjoint(x) = x', Δ -> (Δ',)
@@ -169,6 +172,11 @@ end
     end
     return (UpperTriangular(Σ̄),)
   end
+end
+
+@adjoint function cholesky(Σ::Real)
+  C = cholesky(Σ)
+  return C, Δ::NamedTuple->(Δ.factors[1, 1] / (2 * C.U[1, 1]),)
 end
 
 # Various sensitivities for `literal_getproperty`, depending on the 2nd argument.

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -128,6 +128,13 @@ end
   rng, N = MersenneTwister(123456), 5
   A = randn(rng, N, N)
   @test gradtest(A->logdet(cholesky(A' * A + 1e-6I)), A)
+  @testset "cholesky - scalar" begin
+    y, back = Zygote.forward(cholesky, 5.0 * ones(1, 1))
+    y′, back′ = Zygote.forward(cholesky, 5.0)
+    C̄ = randn(rng, 1, 1)
+    @test back′((factors=C̄,))[1] isa Real
+    @test back′((factors=C̄,))[1] ≈ back((factors=C̄,))[1][1, 1]
+  end
 end
 
 using Distances
@@ -220,4 +227,9 @@ end
   @test Zygote.gradient(x->sum(one(x)), randn(3, 3))[1] isa Nothing
   @test Zygote.gradient(x->sum(zeros(size(x))), randn(7))[1] isa Nothing
   @test Zygote.gradient(x->sum(zero(x)), randn(3))[1] isa Nothing
+end
+
+@testset "* sizing" begin
+  @test size(Zygote.gradient((x, y)->sum(x * y), randn(1, 1), randn(1, 10))[1]) == (1, 1)
+  @test size(Zygote.gradient((x, y)->sum(x * y), randn(1, 1), randn(1, 10))[2]) == (1, 10)
 end


### PR DESCRIPTION
- Multiplication: there was an issue whereby multiplication returns stuff of the wrong size. This PR simply reshapes stuff to be the appropriate size. e.g. if you don't reshape, you might get an `N`-vector rather than an `N x 1`-matrix. This can cause issues if you're expecting a matrix rather than a vector.
- `cholesky(::Real)`: pretty self-explanatory.