### PR TITLE
Some limited definitions for nested AD

### DIFF
--- a/src/lib/base.jl
+++ b/src/lib/base.jl
@@ -16,7 +16,7 @@ end
   d[k], function (Δ)
     grad = grad_mut(__context__, d)
     grad[k] = accum(get(grad, k, nothing), Δ)
-    return (grad, nothing)
+    return (nobacksies(:getindex, grad), nothing)
   end
 end
 

--- a/src/lib/real.jl
+++ b/src/lib/real.jl
@@ -19,6 +19,10 @@ end
 
 @adjoint Base.convert(T::Type{<:Real}, x::Real) = convert(T, x), Δ -> (nothing, Δ)
 
+for T in Base.uniontypes(Core.BuiltinInts)
+    @adjoint (::Type{T})(x::Core.BuiltinInts) = T(x), Δ -> (Δ,)
+end
+
 @adjoint Base.:+(xs...) = +(xs...), Δ -> map(_ -> Δ, xs)
 
 @adjoint function sincos(x)

--- a/test/features.jl
+++ b/test/features.jl
@@ -240,3 +240,29 @@ end
 if VERSION >= v"1.1"
   @test Zygote.@code_adjoint(f(1)) isa Zygote.Adjoint
 end
+@test Zygote.@code_adjoint(f(1)) isa Zygote.Adjoint
+
+# Basic nested
+f_nested(x) = x^4
+@test f_nested''(1.0) = 12.0
+
+# Nested AD for `sum`
+@test gradient([1.0, 2.0]) do x
+    gradient(x) do x
+        sin(sum(x))
+    end[1][1]
+end == -sin(3.0)
+
+# Nested AD for getindex
+@test gradient([1.0, 2.0]) do x
+   gradient(x) do x
+       sin(x[1])
+   end[1][1]
+end == -sin(1.0)
+
+# Third-order AD
+
+# Currently disabled pending improvements to Base and Zygote
+if false
+    @test sin'''(1.0) == -sin(1.0)
+end


### PR DESCRIPTION
This adds a bunch of definitions to make nested AD work and adds tests
for second-order AD. Unfortunately by the time we get to third-order AD,
the types get so large that base decides to go on vacation while it thinks
about whether or not it might be willing to compile a function with a type
of such complexity. Additionally, Zygote introduces some unnecessary stacks,
which then prevent higher order AD. I plan to work on both of those issues,
but in the meantime, here are the changes to Zygote required to make this
work.