### PR TITLE
Setup coverage using Codecov.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,1 +1,1 @@
-comment: false
+comment: off

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ jobs:
 
 ## uncomment the following lines to override the default test script
 script:
- - julia --color=yes -e 'using Pkg; Pkg.activate(); Pkg.instantiate(); Pkg.test()'
+ - julia --color=yes -e 'using Pkg; Pkg.activate(); Pkg.instantiate(); Pkg.test(; coverage=true)'
 
 # coverage
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,3 +43,8 @@ jobs:
 ## uncomment the following lines to override the default test script
 script:
  - julia --color=yes -e 'using Pkg; Pkg.activate(); Pkg.instantiate(); Pkg.test()'
+
+# coverage
+after_success:
+  - julia --project=test/coverage -e 'using Pkg; Pkg.instantiate()'
+  - julia --project=test/coverage test/coverage/coverage.jl

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,8 @@ jobs:
 #  - if [ $TRAVIS_OS_NAME = osx ]; then brew install gcc; fi
 
 ## uncomment the following lines to override the default test script
-script:
- - julia --color=yes -e 'using Pkg; Pkg.activate(); Pkg.instantiate(); Pkg.test(; coverage=true)'
+# script:
+#  - julia --color=yes -e 'using Pkg; Pkg.activate(); Pkg.instantiate(); Pkg.test(; coverage=true)'
 
 # coverage
 after_success:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 <img width="400px" src="https://raw.githubusercontent.com/FluxML/fluxml.github.io/master/zygote.png"/>
 </p>
 
-[![Build Status](https://travis-ci.org/FluxML/Zygote.jl.svg?branch=master)](https://travis-ci.org/FluxML/Zygote.jl) [![Dev Docs](https://img.shields.io/badge/docs-dev-blue.svg)](https://fluxml.ai/Zygote.jl/dev)
+[![Build Status](https://travis-ci.org/FluxML/Zygote.jl.svg?branch=master)](https://travis-ci.org/FluxML/Zygote.jl)
+[![Dev Docs](https://img.shields.io/badge/docs-dev-blue.svg)](https://fluxml.ai/Zygote.jl/dev)
+[![codecov.io](http://codecov.io/github/FluxML/Zygote.jl/coverage.svg?branch=master)](http://codecov.io/github/FluxML/Zygote.jl?branch=master)
+
 
 `] add Zygote#master`
 

--- a/test/coverage/Project.toml
+++ b/test/coverage/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+Coverage = "a2441757-f6aa-5fb2-8edb-039e3f45d037"

--- a/test/coverage/coverage.jl
+++ b/test/coverage/coverage.jl
@@ -1,0 +1,9 @@
+# only push coverage from one bot
+get(ENV, "TRAVIS_OS_NAME", nothing)       == "linux" || exit(0)
+get(ENV, "TRAVIS_JULIA_VERSION", nothing) == "1.1"   || exit(0)
+
+using Coverage
+
+cd(joinpath(@__DIR__, "..", "..")) do
+    Codecov.submit(Codecov.process_folder())
+end


### PR DESCRIPTION
Using a project-based setup (current best practice), running coverage
on Julia 1.1.

Assumes that the associated tooling is enabled (Github app, Coverage).