### PR TITLE
Basic sum(abs2, X)

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -100,8 +100,8 @@ function _forward(cx::Context, ::typeof(sum), f, xs::AbstractArray)
   y, ȳ -> (nothing, nothing, back(ȳ)...)
 end
 
-@adjoint function sum(::typeof(abs2), X::AbstractArray)
-  return sum(abs2, X), Δ::Number->(nothing, (2Δ) .* X,)
+@adjoint function sum(::typeof(abs2), X::AbstractArray; dims = :)
+  return sum(abs2, X; dims=dims), Δ::Union{Number, AbstractArray}->(nothing, ((2Δ) .* X))
 end
 
 @adjoint function prod(xs; dims = :)

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -100,6 +100,10 @@ function _forward(cx::Context, ::typeof(sum), f, xs::AbstractArray)
   y, ȳ -> (nothing, nothing, back(ȳ)...)
 end
 
+@adjoint function sum(::typeof(abs2), X::AbstractArray)
+  return sum(abs2, X), Δ::Number->(nothing, (2Δ) .* X,)
+end
+
 @adjoint function prod(xs; dims = :)
   if dims === (:)
     prod(xs), Δ -> (prod(xs) ./ xs .* Δ,)

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -38,6 +38,7 @@ Random.seed!(0)
 @test gradtest((w, x) -> transpose(w)*x, randn(5,5), randn(5,5))
 
 @test gradtest(x -> sum(x, dims = (2, 3)), (3,4,5))
+@test gradtest(x -> sum(abs2, x), randn(4, 3, 2))
 @test gradtest(x -> prod(x, dims = (2, 3)), (3,4,5))
 @test gradtest(x -> prod(x), (3,4,5))
 

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -39,6 +39,7 @@ Random.seed!(0)
 
 @test gradtest(x -> sum(x, dims = (2, 3)), (3,4,5))
 @test gradtest(x -> sum(abs2, x), randn(4, 3, 2))
+@test gradtest(x -> sum(abs2, x; dims=1), randn(4, 3, 2))
 @test gradtest(x -> prod(x, dims = (2, 3)), (3,4,5))
 @test gradtest(x -> prod(x), (3,4,5))
 


### PR DESCRIPTION
Most mapreduce-style functions require that you track the output of the function being mapped. This isn't the case for `sum(abs2, X)`, so we can optimise for this and remove the need to keep track of a temporary.

Will extend to `sum(abs2, X; dims)` before asking for review.

There are definitely other functions for which this is the case, but it would be handy to have this implemented for now as a one-off, hence the PR.