### PR TITLE
Restrict type pars for mean adjoint

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -134,7 +134,9 @@ end
   end
 end
 
-@adjoint mean(xs; dims = :) = mean(xs, dims=dims), Δ -> (_backmean(xs,Δ,dims),)
+@adjoint function mean(xs::AbstractArray; dims = :)
+  return mean(xs, dims=dims), Δ -> (_backmean(xs,Δ,dims),)
+end
 _backmean(xs, Δ, ::Colon) = zero(xs) .+ Δ ./ length(xs)
 _backmean(xs, Δ, dims) = zero(xs) .+ Δ ./ mapreduce(i -> size(xs,i),*,dims)
 


### PR DESCRIPTION
The current `@adjoint` for `mean` doesn't restrict the type of the first argument. This causes problems for packages that define `mean` for non-`AbstractArray`-like objects. This PR fixes this problem by constraining the types of the arguments in `mean`'s `@adjoint`.