### PR TITLE
fix conj, real

### DIFF
--- a/src/lib/number.jl
+++ b/src/lib/number.jl
@@ -52,6 +52,6 @@ end
 
 @adjoint real(x::Number) = real(x), r̄ -> (real(r̄),)
 @adjoint conj(x::Number) = conj(x), r̄ -> (conj(r̄),)
-@adjoint imag(x::Complex) = imag(x), ī -> (real(ī)*im,)
+@adjoint imag(x::Number) = imag(x), ī -> (real(ī)*im,)
 
 DiffRules._abs_deriv(x::Complex) = x/abs(x)

--- a/src/lib/number.jl
+++ b/src/lib/number.jl
@@ -50,7 +50,8 @@ end
 
 @adjoint (T::Type{<:Complex})(re, im) = T(re, im), c̄ -> (nothing, real(c̄), imag(c̄))
 
-@adjoint real(x::Complex) = real(x), r̄ -> (real(r̄),)
+@adjoint real(x::Number) = real(x), r̄ -> (real(r̄),)
+@adjoint conj(x::Number) = conj(x), r̄ -> (conj(r̄),)
 @adjoint imag(x::Complex) = imag(x), ī -> (real(ī)*im,)
 
 DiffRules._abs_deriv(x::Complex) = x/abs(x)

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -1,3 +1,5 @@
 using Zygote, Test
 
 @test gradient(x -> real(abs(x)*exp(im*angle(x))), 10+20im)[1] ≈ 1
+@test gradient(x -> imag(real(x)+0.3im), 0.3)[1] ≈ 0
+@test gradient(x -> imag(conj(x)+0.3im), 0.3)[1] ≈ -1im

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -3,3 +3,4 @@ using Zygote, Test
 @test gradient(x -> real(abs(x)*exp(im*angle(x))), 10+20im)[1] ≈ 1
 @test gradient(x -> imag(real(x)+0.3im), 0.3)[1] ≈ 0
 @test gradient(x -> imag(conj(x)+0.3im), 0.3)[1] ≈ -1im
+@test gradient(x -> abs((imag(x)+0.3)), 0.3)[1] == 1im


### PR DESCRIPTION
Several corner cases fixed to better support complex numbers.

```julia console
julia> gradient(x->imag(real(x)+0.3im), 0.3)
1.0
(0.0 + 1.0im,)

julia> gradient(x->imag(real(x)+0.3im), 0.3+0im)
1.0
(0.0,)

julia> gradient(x->imag(conj(x)+0.3im), 0.3)
1.0
(0.0 + 1.0im,)

julia> gradient(x->imag(conj(x)+0.3im), 0.3+0im)
1.0
-1.0
(0.0 - 1.0im,)
```

It seems `real` and `conj` backward for real numbers should be defined in a more regorous way.