### PR TITLE
fix document error

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -58,7 +58,7 @@ julia> function pow(x, n)
        end
 pow (generic function with 1 method)
 
-julia> gradient(x -> pow(x, 3), 5)
+julia> gradient(x -> pow(x, 3.0), 5)
 (75,)
 
 julia> pow2(x, n) = n <= 0 ? 1 : x*pow2(x, n-1)


### PR DESCRIPTION
It will throw an error for Integer input `gradient(x -> pow(x, 3), 5)`

```julia
MethodError: objects of type UInt8 are not callable

Stacktrace:
 [1] pow at ./In[19]:4 [inlined]
 [2] (::typeof(∂(pow)))(::Int64) at /home/math/jc/.julia/packages/Zygote/VeaFW/src/compiler/interface2.jl:0
 [3] #25 at ./In[53]:1 [inlined]
 [4] (::getfield(Zygote, Symbol("##34#35")){typeof(∂(getfield(Main, Symbol("##25#26"))()))})(::Int64) at /home/math/jc/.julia/packages/Zygote/VeaFW/src/compiler/interface.jl:38
 [5] gradient(::Function, ::Int64, ::Vararg{Int64,N} where N) at /home/math/jc/.julia/packages/Zygote/VeaFW/src/compiler/interface.jl:47
 [6] top-level scope at In[53]:1
```