### PR TITLE
WIP: try to fix static array

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -337,3 +337,19 @@ end
 @adjoint function +(A::AbstractMatrix, S::UniformScaling)
   return A + S, Δ->(Δ, (λ=sum(view(Δ, diagind(Δ))),))
 end
+
+
+# StaticArrays
+using StaticArrays
+
+# I'm not quite sure how to test this, but
+# f(x) = SArray{Tuple{2, 2}, Float64, 2}(x, x, x, x)
+# _, back = forward(f, 0.1)
+# back(@SArray(rand(2, 2)))
+# seems correct
+
+@adjoint function StaticArrays.SArray{S, T, N, L}(x::NTuple{L, T}) where {S, T, N, L}
+  return SArray{S, T, N, L}(x), function (Δ)
+    return (Tuple(Δ), )
+  end
+end


### PR DESCRIPTION
I'm not sure if this is correct. but it looks like working. But I also tried to define

```julia
@adjoint function StaticArrays.SArray{S, T, N, L}(x::AbstractArray) where {S, T, N, L}
  return SArray{S, T, N, L}(x), function (Δ)
    return (Δ, )
  end
end
```

which is never called, I guess is because no matter what you feed into `SArray` it will be converted to a tuple first?

And maybe it is better to use `Requires`?