### PR TITLE
Constructors for Zeros and Ones

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -13,6 +13,8 @@ using FillArrays
 # Array Constructors
 @adjoint (::Type{T})(x::T) where T<:Array = T(x), ȳ -> (ȳ,)
 @adjoint (::Type{T})(x::Number, sz) where {T <: Fill} = Fill(x, sz), Δ -> (sum(Δ), nothing)
+@adjoint (::Type{T})(sz) where {T<:Zeros} = Zeros(sz), Δ->(nothing,)
+@adjoint (::Type{T})(sz) where {T<:Ones} = Ones(sz), Δ->(nothing,)
 
 _zero(xs::AbstractArray{<:Integer}) = fill!(similar(xs, float(eltype(xs))), false)
 _zero(xs::AbstractArray{<:Number}) = zero(xs)

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -453,5 +453,6 @@ end
 
 @testset "FillArrays" begin
   gradcheck(x->sum(Fill(x[], (2, 2))), [0.1])
+  @test first(Zygote.gradient(sz->sum(Ones(sz)), 6)) === nothing
+  @test first(Zygote.gradient(sz->sum(Zeros(sz)), 6)) === nothing
 end
-


### PR DESCRIPTION
Make it possible to properly ignore `Zeros` and `Ones`