### PR TITLE
Fix and test adjoint for hvcat

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -40,7 +40,7 @@ end
   Δ -> (reshape(Δ, size(xs)),map(_->nothing,dims)...)
 
 @adjoint function hvcat(rows::Tuple{Vararg{Int}}, xs::T...) where T<:Number
-  hvcat(rows, xs...), ȳ -> (nothing, ȳ...)
+  hvcat(rows, xs...), ȳ -> (nothing, permutedims(ȳ)...)
 end
 
 pull_block_vert(sz, Δ, A::AbstractVector) = Δ[sz-length(A)+1:sz]

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -331,6 +331,13 @@ end
   end
 end
 
+@testset "hvcat" begin
+  @test grad(xs -> hvcat((2,2),xs...)[1,1], [1,2,3,4])[1] == (1,0,0,0)
+  @test grad(xs -> hvcat((2,2),xs...)[2,1], [1,2,3,4])[1] == (0,0,1,0)
+  @test grad(xs -> hvcat((2,2),xs...)[1,2], [1,2,3,4])[1] == (0,1,0,0)
+  @test grad(xs -> hvcat((2,2),xs...)[2,2], [1,2,3,4])[1] == (0,0,0,1)
+end
+
 @testset "one(s) and zero(s)" begin
   @test Zygote.gradient(x->sum(ones(size(x))), randn(5))[1] isa Nothing
   @test Zygote.gradient(x->sum(one(x)), randn(3, 3))[1] isa Nothing


### PR DESCRIPTION
This PR fixes the the adjoint for `hvcat`. The issue arises from 
```
julia> (hvcat((2,2),1,2,3,4)...,) == (1,2,3,4)
false
```
which was an implicit assumption in the implementation so far, leading to errors in functions where the arguments appear in matrices such as
```
foo(x) = [x 2x; 3x 4x]
```