### PR TITLE
Adjoint for PermutedDimsArray

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -35,8 +35,13 @@ end
 
 @adjoint collect(x::Array) = collect(x), Δ -> (Δ,)
 
+@adjoint permutedims(xs) = permutedims(xs), Δ -> (permutedims(Δ),)
+
 @adjoint permutedims(xs, dims) = permutedims(xs, dims),
   Δ -> (permutedims(Δ, invperm(dims)), nothing)
+
+@adjoint PermutedDimsArray(xs, dims) = PermutedDimsArray(xs, dims),
+  Δ -> (PermutedDimsArray(Δ, invperm(dims)), nothing)
 
 @adjoint reshape(xs, dims...) = reshape(xs, dims...),
   Δ -> (reshape(Δ, size(xs)),map(_->nothing,dims)...)

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -75,7 +75,9 @@ end
   end
 end
 
+@test gradtest(x -> permutedims(x), rand(2,3))
 @test gradtest(x -> permutedims(x, [3,1,2]), rand(4,5,6))
+@test gradtest(x -> PermutedDimsArray(x, (3,1,2)), rand(4,5,6))
 
 @test gradtest(x -> repeat(x; inner=2), rand(5))
 @test gradtest(x -> repeat(x; inner=2, outer=3), rand(5))


### PR DESCRIPTION
This treats the lazy `PermutedDimsArray` exactly like `permutedims`. I also added a line for `permutedims(x)` without `dims`, although perhaps this is not necessary, as this already works:
```
julia> rr = rand(2,2);

julia> Zygote.gradient(x -> sum(sin, transpose(x)), rr)
([0.949851 0.970093; 0.842615 0.96526],)

julia> Zygote.gradient(x -> sum(sin, permutedims(x)), rr)
([0.949851 0.970093; 0.842615 0.96526],)

julia> Zygote.gradient(x -> sum(sin, PermutedDimsArray(x,(2,1))), rr)
ERROR: MethodError: no method matching (::Zygote.Jnew{PermutedDimsArray{Float64,2,(2, 1),(2, 1),Array{Float64,2}},Nothing,false})(::Array{Float64,2})
```