### PR TITLE
Adjoint for literal_pow to support Float16

### DIFF
--- a/src/lib/number.jl
+++ b/src/lib/number.jl
@@ -28,7 +28,7 @@ for (M, f, arity) in DiffRules.diffrules()
   end
 end
 
-@adjoint Base.literal_pow(::typeof(^), x::Real, ::Val{p}) where {p} = x^p, Δ -> (nothing, p * x ^ (p - 1), nothing)
+@adjoint Base.literal_pow(::typeof(^), x::Float16, ::Val{p}) where {p} = x^p, Δ -> (nothing, p * x ^ (p - 1), nothing)
 @adjoint Base.convert(T::Type{<:Real}, x::Real) = convert(T, x), ȳ -> (nothing, ȳ)
 @adjoint (T::Type{<:Real})(x::Real) = T(x), ȳ -> (nothing, ȳ)
 

--- a/src/lib/number.jl
+++ b/src/lib/number.jl
@@ -28,6 +28,7 @@ for (M, f, arity) in DiffRules.diffrules()
   end
 end
 
+@adjoint Base.literal_pow(::typeof(^), x::Real, ::Val{p}) where {p} = x^p, Δ -> (nothing, p * x ^ (p - 1), nothing)
 @adjoint Base.convert(T::Type{<:Real}, x::Real) = convert(T, x), ȳ -> (nothing, ȳ)
 @adjoint (T::Type{<:Real})(x::Real) = T(x), ȳ -> (nothing, ȳ)
 

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -157,8 +157,8 @@ end
   h(x) = 2 .^ x
   @test gradient(f, Float16(-2))[1] == -4
   @test gradient(f, Float32(-2))[1] == -4
-  @test gradient(h, Float16(2))[1] == 2.772588722239781
-  @test gradient(h, Float32(2))[1] == 2.772588722239781
+  @test gradient(h, Float16(2))[1] == 4*log(2)
+  @test gradient(h, Float32(2))[1] == 4*log(2)
 end
 
 @testset "(p)inv" begin

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -152,6 +152,15 @@ end
   @test gradtest(x -> minimum(x, dims=[1, 2]), rand(2, 3, 4))
 end
 
+@testset "literal_pow" begin
+  f(x) = x .^ 2
+  h(x) = 2 .^ x
+  @test gradient(f, Float16(-2))[1] == -4
+  @test gradient(f, Float32(-2))[1] == -4
+  @test gradient(h, Float16(2))[1] == 2.772588722239781
+  @test gradient(h, Float32(2))[1] == 2.772588722239781
+end
+
 @testset "(p)inv" begin
   rng, P, Q = MersenneTwister(123456), 13, 11
   A, B, C = randn(rng, P, Q), randn(rng, P, P), randn(Q, P)


### PR DESCRIPTION
Gradient on `literal_pow` was throwing an error with negative base, when input was Float16 as discussed in this issue https://github.com/FluxML/Zygote.jl/issues/228.  So the adjoint has been overwritten. Now the gradient works on all Floats, without breaking.