### PR TITLE
Fix ldiv for adjoint of triangular

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -252,12 +252,20 @@ end
   return Y, Δ->(-Y' * Δ * Y' + (I - A * Y) * Δ' * Y * Y' + Y' * Y * Δ' * (I - Y * A),)
 end
 
-@adjoint function \(A::Union{Diagonal, AbstractTriangular}, B::AbstractVecOrMat)
+@adjoint function \(
+  A::Union{
+    Diagonal,
+    AbstractTriangular,
+    LinearAlgebra.Adjoint{<:Any, <:AbstractTriangular},
+    Transpose{<:Any, <:AbstractTriangular},
+  },
+  B::AbstractVecOrMat,
+)
   Y = A \ B
   return Y, function(Ȳ)
     B̄ = A' \ Ȳ
     return (-B̄ * Y', B̄)
-  end 
+  end
 end
 
 @adjoint function /(A::AbstractMatrix, B::Union{Diagonal, AbstractTriangular})

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -252,6 +252,7 @@ end
   return Y, Δ->(-Y' * Δ * Y' + (I - A * Y) * Δ' * Y * Y' + Y' * Y * Δ' * (I - Y * A),)
 end
 
+# When `A` is guaranteed to be square, definitely use the simple expression for the adjoint.
 @adjoint function \(
   A::Union{
     Diagonal,


### PR DESCRIPTION
Makes sure that if you take the `adjoint` or `transpose` of a triangular matrix, the appropriate adjoint rule is used.