### PR TITLE
Fix adjoint for *(::Adjoint, ::Vector)

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -200,6 +200,12 @@ end
   return A * x, Δ::AbstractVector->(Δ * x', A' * Δ)
 end
 
+@adjoint function *(x::Union{Transpose{<:Any, <:AbstractVector},
+                             LinearAlgebra.Adjoint{<:Any, <:AbstractVector}},
+                    y::AbstractVector)
+  return x * y, Δ->(Δ * y', x' * Δ)
+end
+
 @adjoint function(a::AbstractVector * x::AbstractMatrix)
   return a * x, Δ::AbstractMatrix->(vec(Δ * x'), a' * Δ)
 end

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -172,6 +172,7 @@ end
     @test gradtest(*, randn(rng, M, P), randn(rng, P))
     @test gradtest(*, randn(rng, M, 1), randn(rng, 1, Q))
     @test gradtest(*, randn(rng, M), randn(rng, 1, Q))
+    @test gradtest(*, randn(rng, 10)', randn(rng, 10))
 
     let
       y, back = Zygote.forward(*, randn(rng, M, P), randn(rng, P))


### PR DESCRIPTION
By design, this returns a scalar, tripping the type limitation on
the method for AbstractMatrix.