### PR TITLE
Non-scalar getindex

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -22,9 +22,10 @@ using Base.Broadcast: broadcasted, broadcast_shape
 @adjoint (::Type{T})(sz) where {T<:Zeros} = Zeros(sz), Δ->(nothing,)
 @adjoint (::Type{T})(sz) where {T<:Ones} = Ones(sz), Δ->(nothing,)
 
-_zero(xs::AbstractArray{<:Number}, T=float(eltype(xs))) = fill!(similar(xs, T), false)
+_zero(xs::AbstractArray{<:Number}, T=float(eltype(xs))) =
+    fill!(similar(xs, T, size(xs)), false)
 _zero(xs::AbstractArray, T=Any) = Union{Nothing, T}[nothing for x in xs]
-_wrap(dx, x) = dx
+_makelike(dx, x) = dx
 
 @adjoint getindex(x::AbstractArray, inds...) = x[inds...], ∇getindex(x, inds)
 
@@ -38,7 +39,7 @@ _wrap(dx, x) = dx
     dx = _zero(x, eltype(dy))
     @views dx[inds...] .+= dy
   end
-  (_wrap(dx, x), map(_->nothing, inds)...)
+  (_makelike(dx, x), map(_->nothing, inds)...)
 end
 
 @adjoint! setindex!(xs::AbstractArray, x...) = setindex!(xs, x...),
@@ -365,8 +366,7 @@ end
 # ===================
 
 for AT in [:Diagonal, :LowerTriangular, :UpperTriangular]
-    @eval _zero(xs::$AT{<:Number}, T=float(eltype(xs))) = fill!(similar(xs, T, size(xs)), false)
-    @eval _wrap(dx, x::$AT) = $AT(dx) # for getindex
+    @eval _makelike(dx, x::$AT) = $AT(dx) # for getindex
 end
 
 @adjoint LinearAlgebra.LowerTriangular(A) = LowerTriangular(A), Δ->(LowerTriangular(Δ),)
@@ -386,7 +386,6 @@ function _symmetric_back(Δ, uplo)
   return uplo == 'U' ? U .+ transpose(L) - D : L .+ transpose(U) - D
 end
 _symmetric_back(Δ::Diagonal, uplo) = Δ
-_symmetric_back(Δ::Symmetric, uplo) = collect(uplo == 'U' ? UpperTriangular(Δ) : LowerTriangular(Δ))
 _symmetric_back(Δ::UpperTriangular, uplo) = collect(uplo == 'U' ? Δ : transpose(Δ))
 _symmetric_back(Δ::LowerTriangular, uplo) = collect(uplo == 'U' ? transpose(Δ) : Δ)
 
@@ -397,8 +396,7 @@ _symmetric_back(Δ::LowerTriangular, uplo) = collect(uplo == 'U' ? transpose(Δ)
   return S, back
 end
 
-_zero(x::Symmetric{<:Number}, T=float(eltype(x))) = _zero(parent(x), T)
-_wrap(dx, x::Symmetric) = Symmetric(_symmetric_back(dx, x.uplo), Symbol(x.uplo))
+_makelike(dx, x::Symmetric) = Symmetric(_symmetric_back(dx, x.uplo), Symbol(x.uplo))
 
 _extract_imag(x) = (x->complex(0, imag(x))).(x)
 function _hermitian_back(Δ, uplo)
@@ -407,7 +405,6 @@ function _hermitian_back(Δ, uplo)
   return uplo == 'U' ? U .+ L' - rD : L .+ U' - rD
 end
 _hermitian_back(Δ::Diagonal, uplo) = real.(Δ)
-_hermitian_back(Δ::Hermitian, uplo) = collect(uplo == 'U' ? UpperTriangular(Δ) : LowerTriangular(Δ))
 function _hermitian_back(Δ::LinearAlgebra.AbstractTriangular, uplo)
   isreal(Δ) && return _symmetric_back(Δ, uplo)
   ŪL̄ = Δ .- Diagonal(_extract_imag(diag(Δ)))
@@ -425,8 +422,7 @@ end
   return H, back
 end
 
-_zero(x::Hermitian{<:Number}, T=float(eltype(x))) = _zero(parent(x), T)
-_wrap(dx, x::Hermitian) = Hermitian(_hermitian_back(dx, x.uplo), Symbol(x.uplo))
+_makelike(dx, x::Hermitian) = Hermitian(_hermitian_back(dx, x.uplo), Symbol(x.uplo))
 
 @adjoint convert(::Type{R}, A::LinearAlgebra.HermOrSym{T,S}) where {T,S,R<:Array} = convert(R, A),
   Δ -> (nothing, convert(S, Δ),)

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -22,16 +22,22 @@ using Base.Broadcast: broadcasted, broadcast_shape
 @adjoint (::Type{T})(sz) where {T<:Zeros} = Zeros(sz), Δ->(nothing,)
 @adjoint (::Type{T})(sz) where {T<:Ones} = Ones(sz), Δ->(nothing,)
 
-_zero(xs::AbstractArray{<:Integer}) = fill!(similar(xs, float(eltype(xs))), false)
-_zero(xs::AbstractArray{<:Number}) = zero(xs)
-_zero(xs::AbstractArray) = Any[nothing for x in xs]
+_zero(xs::AbstractArray{<:Number}, T=float(eltype(xs))) = fill!(similar(xs, T), false)
+_zero(xs::AbstractArray, T=Any) = Union{Nothing, T}[nothing for x in xs]
 
-@adjoint function getindex(xs::AbstractArray, i...)
-  xs[i...], function (Δ)
-    Δ′ = _zero(xs)
-    Δ′[i...] = Δ
-    (Δ′, map(_ -> nothing, i)...)
+@adjoint getindex(x::AbstractArray, inds...) = x[inds...], ∇getindex(x, inds)
+
+@adjoint view(x::AbstractArray, inds...) = view(x, inds...), ∇getindex(x, inds)
+
+∇getindex(x::AbstractArray, inds) = dy -> begin
+  if inds isa  NTuple{<:Any, Integer}
+    dx = _zero(x, typeof(dy))
+    dx[inds...] = dy
+  else
+    dx = _zero(x, eltype(dy))
+    @views dx[inds...] .+= dy
   end
+  (dx, map(_->nothing, inds)...)
 end
 
 @adjoint! setindex!(xs::AbstractArray, x...) = setindex!(xs, x...),
@@ -40,14 +46,6 @@ end
 for f in [push!, pop!, pushfirst!, popfirst!]
   @eval @adjoint! $f(xs::Vector, x...) =
     push!(xs, x...), _ -> error("Mutating arrays is not supported")
-end
-
-@adjoint function view(x::AbstractArray, inds...; kw...)
-  view(x, inds...; kw...), dy -> begin
-    dx = _zero(x)
-    copyto!(view(dx, inds...; kw...), dy)
-    (dx, map(_->nothing, inds)...)
-  end
 end
 
 # General

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -22,10 +22,8 @@ using Base.Broadcast: broadcasted, broadcast_shape
 @adjoint (::Type{T})(sz) where {T<:Zeros} = Zeros(sz), Δ->(nothing,)
 @adjoint (::Type{T})(sz) where {T<:Ones} = Ones(sz), Δ->(nothing,)
 
-_zero(xs::AbstractArray{<:Number}, T=float(eltype(xs))) =
-    fill!(similar(xs, T, size(xs)), false)
+_zero(xs::AbstractArray{<:Number}, T=float(eltype(xs))) = fill!(similar(xs, T), false)
 _zero(xs::AbstractArray, T=Any) = Union{Nothing, T}[nothing for x in xs]
-_makelike(dx, x) = dx
 
 @adjoint getindex(x::AbstractArray, inds...) = x[inds...], ∇getindex(x, inds)
 
@@ -39,7 +37,7 @@ _makelike(dx, x) = dx
     dx = _zero(x, eltype(dy))
     @views dx[inds...] .+= dy
   end
-  (_makelike(dx, x), map(_->nothing, inds)...)
+  (dx, map(_->nothing, inds)...)
 end
 
 @adjoint! setindex!(xs::AbstractArray, x...) = setindex!(xs, x...),
@@ -365,10 +363,6 @@ end
 # LinAlg Matrix Types
 # ===================
 
-for AT in [:Diagonal, :LowerTriangular, :UpperTriangular]
-    @eval _makelike(dx, x::$AT) = $AT(dx) # for getindex
-end
-
 @adjoint LinearAlgebra.LowerTriangular(A) = LowerTriangular(A), Δ->(LowerTriangular(Δ),)
 @adjoint LinearAlgebra.UpperTriangular(A) = UpperTriangular(A), Δ->(UpperTriangular(Δ),)
 
@@ -396,8 +390,6 @@ _symmetric_back(Δ::LowerTriangular, uplo) = collect(uplo == 'U' ? transpose(Δ)
   return S, back
 end
 
-_makelike(dx, x::Symmetric) = Symmetric(_symmetric_back(dx, x.uplo), Symbol(x.uplo))
-
 _extract_imag(x) = (x->complex(0, imag(x))).(x)
 function _hermitian_back(Δ, uplo)
   isreal(Δ) && return _symmetric_back(Δ, uplo)
@@ -421,8 +413,6 @@ end
   back(Δ::NamedTuple) = (_hermitian_back(Δ.data, H.uplo), nothing)
   return H, back
 end
-
-_makelike(dx, x::Hermitian) = Hermitian(_hermitian_back(dx, x.uplo), Symbol(x.uplo))
 
 @adjoint convert(::Type{R}, A::LinearAlgebra.HermOrSym{T,S}) where {T,S,R<:Array} = convert(R, A),
   Δ -> (nothing, convert(S, Δ),)

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -24,7 +24,7 @@ using Base.Broadcast: broadcasted, broadcast_shape
 
 _zero(xs::AbstractArray{<:Number}, T=float(eltype(xs))) = fill!(similar(xs, T), false)
 _zero(xs::AbstractArray, T=Any) = Union{Nothing, T}[nothing for x in xs]
-_wrap(dx, x) = dx
+_project(dx, x) = dx
 
 @adjoint getindex(x::AbstractArray, inds...) = x[inds...], ∇getindex(x, inds)
 
@@ -38,7 +38,7 @@ _wrap(dx, x) = dx
     dx = _zero(x, eltype(dy))
     @views dx[inds...] .+= dy
   end
-  (_wrap(dx, x), map(_->nothing, inds)...)
+  (_project(dx, x), map(_->nothing, inds)...)
 end
 
 @adjoint! setindex!(xs::AbstractArray, x...) = setindex!(xs, x...),
@@ -366,7 +366,7 @@ end
 
 for AT in [:Diagonal, :LowerTriangular, :UpperTriangular]
     @eval _zero(xs::$AT{<:Number}, T=float(eltype(xs))) = fill!(similar(xs, T, size(xs)), false)
-    @eval _wrap(dx, x::$AT) = $AT(dx) # for getindex
+    @eval _project(dx, x::$AT) = $AT(dx) # for ∇getindex
 end
 
 @adjoint LinearAlgebra.LowerTriangular(A) = LowerTriangular(A), Δ->(LowerTriangular(Δ),)
@@ -386,7 +386,6 @@ function _symmetric_back(Δ, uplo)
   return uplo == 'U' ? U .+ transpose(L) - D : L .+ transpose(U) - D
 end
 _symmetric_back(Δ::Diagonal, uplo) = Δ
-_symmetric_back(Δ::Symmetric, uplo) = collect(uplo == 'U' ? UpperTriangular(Δ) : LowerTriangular(Δ))
 _symmetric_back(Δ::UpperTriangular, uplo) = collect(uplo == 'U' ? Δ : transpose(Δ))
 _symmetric_back(Δ::LowerTriangular, uplo) = collect(uplo == 'U' ? transpose(Δ) : Δ)
 
@@ -398,7 +397,7 @@ _symmetric_back(Δ::LowerTriangular, uplo) = collect(uplo == 'U' ? transpose(Δ)
 end
 
 _zero(x::Symmetric{<:Number}, T=float(eltype(x))) = _zero(parent(x), T)
-_wrap(dx, x::Symmetric) = Symmetric(_symmetric_back(dx, x.uplo), Symbol(x.uplo))
+_project(dx, x::Symmetric) = Symmetric((1//2) .* (dx .+ transpose(dx)), Symbol(x.uplo))
 
 _extract_imag(x) = (x->complex(0, imag(x))).(x)
 function _hermitian_back(Δ, uplo)
@@ -407,7 +406,6 @@ function _hermitian_back(Δ, uplo)
   return uplo == 'U' ? U .+ L' - rD : L .+ U' - rD
 end
 _hermitian_back(Δ::Diagonal, uplo) = real.(Δ)
-_hermitian_back(Δ::Hermitian, uplo) = collect(uplo == 'U' ? UpperTriangular(Δ) : LowerTriangular(Δ))
 function _hermitian_back(Δ::LinearAlgebra.AbstractTriangular, uplo)
   isreal(Δ) && return _symmetric_back(Δ, uplo)
   ŪL̄ = Δ .- Diagonal(_extract_imag(diag(Δ)))
@@ -426,7 +424,7 @@ end
 end
 
 _zero(x::Hermitian{<:Number}, T=float(eltype(x))) = _zero(parent(x), T)
-_wrap(dx, x::Hermitian) = Hermitian(_hermitian_back(dx, x.uplo), Symbol(x.uplo))
+_project(dx, x::Hermitian) = Hermitian((1//2) .* (dx .+ dx'), Symbol(x.uplo))
 
 @adjoint convert(::Type{R}, A::LinearAlgebra.HermOrSym{T,S}) where {T,S,R<:Array} = convert(R, A),
   Δ -> (nothing, convert(S, Δ),)

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -30,7 +30,7 @@ _zero(xs::AbstractArray, T=Any) = Union{Nothing, T}[nothing for x in xs]
 @adjoint view(x::AbstractArray, inds...) = view(x, inds...), ∇getindex(x, inds)
 
 ∇getindex(x::AbstractArray, inds) = dy -> begin
-  if inds isa  NTuple{<:Any, Integer}
+  if inds isa  NTuple{<:Any,Integer}
     dx = _zero(x, typeof(dy))
     dx[inds...] = dy
   else

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -24,7 +24,7 @@ using Base.Broadcast: broadcasted, broadcast_shape
 
 _zero(xs::AbstractArray{<:Number}, T=float(eltype(xs))) = fill!(similar(xs, T), false)
 _zero(xs::AbstractArray, T=Any) = Union{Nothing, T}[nothing for x in xs]
-_project(dx, x) = dx
+_wrap(dx, x) = dx
 
 @adjoint getindex(x::AbstractArray, inds...) = x[inds...], ∇getindex(x, inds)
 
@@ -38,7 +38,7 @@ _project(dx, x) = dx
     dx = _zero(x, eltype(dy))
     @views dx[inds...] .+= dy
   end
-  (_project(dx, x), map(_->nothing, inds)...)
+  (_wrap(dx, x), map(_->nothing, inds)...)
 end
 
 @adjoint! setindex!(xs::AbstractArray, x...) = setindex!(xs, x...),
@@ -366,7 +366,7 @@ end
 
 for AT in [:Diagonal, :LowerTriangular, :UpperTriangular]
     @eval _zero(xs::$AT{<:Number}, T=float(eltype(xs))) = fill!(similar(xs, T, size(xs)), false)
-    @eval _project(dx, x::$AT) = $AT(dx) # for ∇getindex
+    @eval _wrap(dx, x::$AT) = $AT(dx) # for getindex
 end
 
 @adjoint LinearAlgebra.LowerTriangular(A) = LowerTriangular(A), Δ->(LowerTriangular(Δ),)
@@ -386,6 +386,7 @@ function _symmetric_back(Δ, uplo)
   return uplo == 'U' ? U .+ transpose(L) - D : L .+ transpose(U) - D
 end
 _symmetric_back(Δ::Diagonal, uplo) = Δ
+_symmetric_back(Δ::Symmetric, uplo) = collect(uplo == 'U' ? UpperTriangular(Δ) : LowerTriangular(Δ))
 _symmetric_back(Δ::UpperTriangular, uplo) = collect(uplo == 'U' ? Δ : transpose(Δ))
 _symmetric_back(Δ::LowerTriangular, uplo) = collect(uplo == 'U' ? transpose(Δ) : Δ)
 
@@ -397,7 +398,7 @@ _symmetric_back(Δ::LowerTriangular, uplo) = collect(uplo == 'U' ? transpose(Δ)
 end
 
 _zero(x::Symmetric{<:Number}, T=float(eltype(x))) = _zero(parent(x), T)
-_project(dx, x::Symmetric) = Symmetric((1//2) .* (dx .+ transpose(dx)), Symbol(x.uplo))
+_wrap(dx, x::Symmetric) = Symmetric(_symmetric_back(dx, x.uplo), Symbol(x.uplo))
 
 _extract_imag(x) = (x->complex(0, imag(x))).(x)
 function _hermitian_back(Δ, uplo)
@@ -406,6 +407,7 @@ function _hermitian_back(Δ, uplo)
   return uplo == 'U' ? U .+ L' - rD : L .+ U' - rD
 end
 _hermitian_back(Δ::Diagonal, uplo) = real.(Δ)
+_hermitian_back(Δ::Hermitian, uplo) = collect(uplo == 'U' ? UpperTriangular(Δ) : LowerTriangular(Δ))
 function _hermitian_back(Δ::LinearAlgebra.AbstractTriangular, uplo)
   isreal(Δ) && return _symmetric_back(Δ, uplo)
   ŪL̄ = Δ .- Diagonal(_extract_imag(diag(Δ)))
@@ -424,7 +426,7 @@ end
 end
 
 _zero(x::Hermitian{<:Number}, T=float(eltype(x))) = _zero(parent(x), T)
-_project(dx, x::Hermitian) = Hermitian((1//2) .* (dx .+ dx'), Symbol(x.uplo))
+_wrap(dx, x::Hermitian) = Hermitian(_hermitian_back(dx, x.uplo), Symbol(x.uplo))
 
 @adjoint convert(::Type{R}, A::LinearAlgebra.HermOrSym{T,S}) where {T,S,R<:Array} = convert(R, A),
   Δ -> (nothing, convert(S, Δ),)

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -97,14 +97,6 @@ Random.seed!(0)
   # https://github.com/FluxML/Zygote.jl/issues/376
   _, back = Zygote._pullback(x->x[1]*im, randn(2))
   @test back(1.0)[2] == [-im, 0]
-
-  # https://github.com/FluxML/Zygote.jl/issues/402
-  @test gradient(x -> x[1,1] + 10x[1,2], Diagonal(ones(2)))[1] == Diagonal([1.0, 0.0])
-  @test gradient(x -> x[1,1], Diagonal(ones(2)))[1] isa Diagonal
-
-  @test gradient(x -> x[1,1] + 10x[1,2] + 100x[2,1], Symmetric(ones(2,2)))[1] == Symmetric([1 110; 0 0])
-  @test gradient(x -> x[1,1] + 10x[1,2] + 100x[2,1], UpperTriangular(ones(2,2)))[1] == [1 10; 0 0]
-  @test gradient(x -> x[1,1] + 10x[1,2] + 100x[2,1], LowerTriangular(ones(2,2)))[1] == [1 0; 100 0]
 end
 
 @testset "view" begin

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -103,8 +103,14 @@ Random.seed!(0)
   @test gradient(x -> x[1,1], Diagonal(ones(2)))[1] isa Diagonal
 
   @test gradient(x -> x[1,1] + 10x[1,2] + 100x[2,1], Symmetric(ones(2,2)))[1] == Symmetric([1 110; 0 0])
+  @test gradient(x -> x[1,1], Symmetric(ones(2,2)))[1] isa Symmetric
   @test gradient(x -> x[1,1] + 10x[1,2] + 100x[2,1], UpperTriangular(ones(2,2)))[1] == [1 10; 0 0]
   @test gradient(x -> x[1,1] + 10x[1,2] + 100x[2,1], LowerTriangular(ones(2,2)))[1] == [1 0; 100 0]
+
+  @test gradient(x -> Symmetric([x 3x; 5x 7x])[1,1], 13) == (1,)
+  @test gradient(x -> Symmetric([x 3x; 5x 7x])[1,2], 13) == (3,)
+  @test gradient(x -> Symmetric([x 3x; 5x 7x])[2,1], 13) == (3,)
+  @test gradient(x -> Symmetric([x 3x; 5x 7x], :L)[1,2], 13) == (5,)
 end
 
 @testset "view" begin

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -102,15 +102,15 @@ Random.seed!(0)
   @test gradient(x -> x[1,1] + 10x[1,2], Diagonal(ones(2)))[1] == Diagonal([1.0, 0.0])
   @test gradient(x -> x[1,1], Diagonal(ones(2)))[1] isa Diagonal
 
-  @test gradient(x -> x[1,1] + 10x[1,2] + 100x[2,1], Symmetric(ones(2,2)))[1] == Symmetric([1 55; 0 0])
-  @test gradient(x -> x[1,1], Symmetric(ones(Float32,2,2)))[1] isa Symmetric{Float32}
-
+  @test gradient(x -> x[1,1] + 10x[1,2] + 100x[2,1], Symmetric(ones(2,2)))[1] == Symmetric([1 110; 0 0])
+  @test gradient(x -> x[1,1], Symmetric(ones(2,2)))[1] isa Symmetric
   @test gradient(x -> x[1,1] + 10x[1,2] + 100x[2,1], UpperTriangular(ones(2,2)))[1] == [1 10; 0 0]
   @test gradient(x -> x[1,1] + 10x[1,2] + 100x[2,1], LowerTriangular(ones(2,2)))[1] == [1 0; 100 0]
 
-  sym(ul) = x -> (s = Symmetric(x, ul); s[1,1] + 10*s[1,2] + 100*s[2,1])
-  @test gradtest(sym(:U), (2,2))
-  @test gradtest(sym(:L), (3,3))
+  @test gradient(x -> Symmetric([x 3x; 5x 7x])[1,1], 13) == (1,)
+  @test gradient(x -> Symmetric([x 3x; 5x 7x])[1,2], 13) == (3,)
+  @test gradient(x -> Symmetric([x 3x; 5x 7x])[2,1], 13) == (3,)
+  @test gradient(x -> Symmetric([x 3x; 5x 7x], :L)[1,2], 13) == (5,)
 end
 
 @testset "view" begin

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -97,6 +97,14 @@ Random.seed!(0)
   # https://github.com/FluxML/Zygote.jl/issues/376
   _, back = Zygote._pullback(x->x[1]*im, randn(2))
   @test back(1.0)[2] == [-im, 0]
+
+  # https://github.com/FluxML/Zygote.jl/issues/402
+  @test gradient(x -> x[1,1] + 10x[1,2], Diagonal(ones(2)))[1] == Diagonal([1.0, 0.0])
+  @test gradient(x -> x[1,1], Diagonal(ones(2)))[1] isa Diagonal
+
+  @test gradient(x -> x[1,1] + 10x[1,2] + 100x[2,1], Symmetric(ones(2,2)))[1] == Symmetric([1 110; 0 0])
+  @test gradient(x -> x[1,1] + 10x[1,2] + 100x[2,1], UpperTriangular(ones(2,2)))[1] == [1 10; 0 0]
+  @test gradient(x -> x[1,1] + 10x[1,2] + 100x[2,1], LowerTriangular(ones(2,2)))[1] == [1 0; 100 0]
 end
 
 @testset "view" begin

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -103,14 +103,8 @@ Random.seed!(0)
   @test gradient(x -> x[1,1], Diagonal(ones(2)))[1] isa Diagonal
 
   @test gradient(x -> x[1,1] + 10x[1,2] + 100x[2,1], Symmetric(ones(2,2)))[1] == Symmetric([1 110; 0 0])
-  @test gradient(x -> x[1,1], Symmetric(ones(2,2)))[1] isa Symmetric
   @test gradient(x -> x[1,1] + 10x[1,2] + 100x[2,1], UpperTriangular(ones(2,2)))[1] == [1 10; 0 0]
   @test gradient(x -> x[1,1] + 10x[1,2] + 100x[2,1], LowerTriangular(ones(2,2)))[1] == [1 0; 100 0]
-
-  @test gradient(x -> Symmetric([x 3x; 5x 7x])[1,1], 13) == (1,)
-  @test gradient(x -> Symmetric([x 3x; 5x 7x])[1,2], 13) == (3,)
-  @test gradient(x -> Symmetric([x 3x; 5x 7x])[2,1], 13) == (3,)
-  @test gradient(x -> Symmetric([x 3x; 5x 7x], :L)[1,2], 13) == (5,)
 end
 
 @testset "view" begin

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -102,15 +102,15 @@ Random.seed!(0)
   @test gradient(x -> x[1,1] + 10x[1,2], Diagonal(ones(2)))[1] == Diagonal([1.0, 0.0])
   @test gradient(x -> x[1,1], Diagonal(ones(2)))[1] isa Diagonal
 
-  @test gradient(x -> x[1,1] + 10x[1,2] + 100x[2,1], Symmetric(ones(2,2)))[1] == Symmetric([1 110; 0 0])
-  @test gradient(x -> x[1,1], Symmetric(ones(2,2)))[1] isa Symmetric
+  @test gradient(x -> x[1,1] + 10x[1,2] + 100x[2,1], Symmetric(ones(2,2)))[1] == Symmetric([1 55; 0 0])
+  @test gradient(x -> x[1,1], Symmetric(ones(Float32,2,2)))[1] isa Symmetric{Float32}
+
   @test gradient(x -> x[1,1] + 10x[1,2] + 100x[2,1], UpperTriangular(ones(2,2)))[1] == [1 10; 0 0]
   @test gradient(x -> x[1,1] + 10x[1,2] + 100x[2,1], LowerTriangular(ones(2,2)))[1] == [1 0; 100 0]
 
-  @test gradient(x -> Symmetric([x 3x; 5x 7x])[1,1], 13) == (1,)
-  @test gradient(x -> Symmetric([x 3x; 5x 7x])[1,2], 13) == (3,)
-  @test gradient(x -> Symmetric([x 3x; 5x 7x])[2,1], 13) == (3,)
-  @test gradient(x -> Symmetric([x 3x; 5x 7x], :L)[1,2], 13) == (5,)
+  sym(ul) = x -> (s = Symmetric(x, ul); s[1,1] + 10*s[1,2] + 100*s[2,1])
+  @test gradtest(sym(:U), (2,2))
+  @test gradtest(sym(:L), (3,3))
 end
 
 @testset "view" begin

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -78,8 +78,36 @@ Random.seed!(0)
 @test gradtest(logdet, map(x -> x*x', (rand(4, 4),))[1])
 @test gradtest(x -> logabsdet(x)[1], (4, 4))
 
-@test gradtest(x -> view(x,:,2,:), (3,4,5))
-@test gradtest(x -> view(x,1:2,3:4), (3,4))
+@testset "getindex" begin
+  @test gradtest(x -> x[:,2,:], (3,4,5))
+  @test gradtest(x -> x[1:2,3:4], (3,4))
+
+  imat = [1 2; 3 4]
+  @test gradtest(x -> x[:,imat], (3,4))
+  @test gradtest(x -> x[:,[1,2,2]], (3,4))
+  irep = [1 2; 2 2]
+  @test gradtest(x -> x[1,irep], (3,4))
+
+  # https://github.com/invenia/Nabla.jl/issues/139
+  x = rand(3)
+  z = [1,2,3,3]
+  y(x,z) = dot(ones(4), x[z])
+  @test gradient(y, x,z) == ([1,1,2], nothing)
+
+  # https://github.com/FluxML/Zygote.jl/issues/376
+  _, back = Zygote._pullback(x->x[1]*im, randn(2))
+  @test back(1.0)[2] == [-im, 0]
+end
+
+@testset "view" begin
+  @test gradtest(x -> view(x,:,2,:), (3,4,5))
+  @test gradtest(x -> view(x,1:2,3:4), (3,4))
+  @test gradtest(x -> view(x,:,[1,2,2]), (3,4))
+
+  # https://github.com/FluxML/Zygote.jl/issues/272
+  g(x) = view(x,1:2)[1]
+  @test gradient(g, ones(3)) == ([1,0,0],)
+end
 
 @testset "conv" begin
   for spatial_rank in (1, 2, 3)


### PR DESCRIPTION
This should fix the bug described in this [discourse question](https://discourse.julialang.org/t/flux-unable-to-differentiate-an-embedding-layer/26067), a more compact version of which is 
```
using Zygote
ii = rand(1:10, 2)
jj = rand(1:10, 2,2)

Zygote.gradient(x -> sum(x[ii,:]), rand(10,3))
Zygote.gradient(x -> sum(x[jj,:]), rand(10,3)) # DimensionMismatch("tried to assign 2×2×3 array to 4×3 destination")

Zygote.gradient(x -> sum(@view x[jj,:]), rand(10,3)) # fine!
```
I've just copied the gradient from `view`, where `copyto!` does the necessary reshaping. 