### PR TITLE
forwarddiff(f, xs...)

### DIFF
--- a/test/features.jl
+++ b/test/features.jl
@@ -248,6 +248,10 @@ end == (1,)
   forwarddiff(x -> x^2, x)
 end == (10,)
 
+@test gradient(5,7) do x,y
+  forwarddiff((x,y) -> x^2 + 3y, x,y)
+end == (10, 3)
+
 @test gradient(1) do x
   if true
   elseif true

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -1059,6 +1059,17 @@ end
   @test gradcheck(x -> sum(sum(diag.([x] .* a))), b)
 end
 
+using Zygote: forwarddiff
+
+@testset "forwarddiff" begin
+  f(x) = exp.(x ./ 2)
+  @test gradtest(x -> sum(forwarddiff(f,x)), (4,))
+  g(x,y) = (x .+ y').^2
+  @test gradtest(x -> sum(forwarddiff(g,x,x)), (3,3))
+  h(x,y,z) = @. x + 2y * z^3
+  @test gradtest(x -> sum(forwarddiff(h,x,2x,3x)), (2,3))
+end
+
 using Zygote: Buffer
 
 @testset "Buffer" begin


### PR DESCRIPTION
This should make `Zygote.forwarddiff(f,x,y)` work, by simply evaluating `f` twice. 

Test failure is Unexpected Pass `Expression: (((sin')')')(1.0) == -(cos(1.0))` at test/features.jl:155. I don't think that's my doing?