### PR TITLE
make adjoint for getindex less restrictive

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -24,7 +24,7 @@ _zero(xs::AbstractArray{<:Integer}) = fill!(similar(xs, float(eltype(xs))), fals
 _zero(xs::AbstractArray{<:Number}) = zero(xs)
 _zero(xs::AbstractArray) = Any[nothing for x in xs]
 
-@adjoint function getindex(xs::Array, i...)
+@adjoint function getindex(xs, i...)
   xs[i...], function (Δ)
     Δ′ = _zero(xs)
     Δ′[i...] = Δ


### PR DESCRIPTION
This should allow Tuples (e.g. Chain) to be indexed correctly.
I believe this fixes [#820](https://github.com/FluxML/Flux.jl/issues/820) in Flux.jl and #263.

~~I tested this with a ConvTranspose layer. On cpu, it runs but on gpu it throws a new error. I'm not sure on how to debug this...~~
EDIT: The problem with CuArrays doesn't occur with the Flux#zygote branch, and is most probably unrelated since it also affects regular Conv without changing anything. Also, this pr apparently doesn't fix #263 and perhaps does more harm than good. 

```julia
m = ConvTranspose((2,2), 1=>2, stride=(2,2))|>gpu
input = rand(256, 256, 1, 1)|>gpu

m(input)

Zygote.gradient((m)->sum(m(input)), m)
```
```
ERROR: GPU compilation of #23(CuArrays.CuKernelState, CUDAnative.CuDeviceArray{Tuple{Float32,typeof(∂(identity))},4,CUDAnative.AS.Global}, Base.Broadcast.Broadcasted{Nothing,NTuple{4,Base.OneTo{Int64}},getfield(Zygote, Symbol("##1188#1195")){Zygote.Context,typeof(identity)},Tuple{Base.Broadcast.Extruded{CUDAnative.CuDeviceArray{Float32,4,CUDAnative.AS.Global},NTuple{4,Bool},NTuple{4,Int64}}}}) failed
KernelError: passing and using non-bitstype argument

Argument 4 to your kernel function is of type Base.Broadcast.Broadcasted{Nothing,NTuple{4,Base.OneTo{Int64}},getfield(Zygote, Symbol("##1188#1195")){Zygote.Context,typeof(identity)},Tuple{Base.Broadcast.Extruded{CUDAnative.CuDeviceArray{Float32,4,CUDAnative.AS.Global},NTuple{4,Bool},NTuple{4,Int64}}}}.
That type is not isbits, and such arguments are only allowed when they are unused by the kernel.  .f is of type getfield(Zygote, Symbol("##1188#1195")){Zygote.Context,typeof(identity)} which is not isbits.
    .__context__ is of type Zygote.Context which is not isbits.
      .cache is of type Union{Nothing, IdDict{Any,Any}} which is not isbits.
      .globals is of type Union{Nothing, Dict{GlobalRef,Any}} which is not isbits.


Stacktrace:
 [1] check_invocation(::CUDAnative.CompilerJob, ::LLVM.Function) at C:\Users\jules\.julia\packages\CUDAnative\nItlk\src\compiler\validation.jl:70
 [2] macro expansion at C:\Users\jules\.julia\packages\CUDAnative\nItlk\src\compiler\driver.jl:187 [inlined]
 [3] macro expansion at C:\Users\jules\.julia\packages\TimerOutputs\7zSea\src\TimerOutput.jl:216 [inlined]
 [4] #codegen#121(::Bool, ::Bool, ::Bool, ::Bool, ::Bool, ::Function, ::Symbol, ::CUDAnative.CompilerJob) at C:\Users\jules\.julia\packages\CUDAnative\nItlk\src\compiler\driver.jl:186
 [5] #codegen at .\none:0 [inlined]
 [6] #compile#120(::Bool, ::Bool, ::Bool, ::Bool, ::Bool, ::Function, ::Symbol, ::CUDAnative.CompilerJob) at C:\Users\jules\.julia\packages\CUDAnative\nItlk\src\compiler\driver.jl:47
 [7] #compile at .\none:0 [inlined]
 [8] #compile#119 at C:\Users\jules\.julia\packages\CUDAnative\nItlk\src\compiler\driver.jl:28 [inlined]
 [9] #compile at .\none:0 [inlined] (repeats 2 times)
 [10] macro expansion at C:\Users\jules\.julia\packages\CUDAnative\nItlk\src\execution.jl:388 [inlined]
 [11] #cufunction#161(::Nothing, ::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}, ::typeof(CUDAnative.cufunction), ::getfield(GPUArrays, Symbol("##23#24")), ::Type{Tuple{CuArrays.CuKernelState,CUDAnative.CuDeviceArray{Tuple{Float32,typeof(∂(identity))},4,CUDAnative.AS.Global},Base.Broadcast.Broadcasted{Nothing,NTuple{4,Base.OneTo{Int64}},getfield(Zygote, Symbol("##1188#1195")){Zygote.Context,typeof(identity)},Tuple{Base.Broadcast.Extruded{CUDAnative.CuDeviceArray{Float32,4,CUDAnative.AS.Global},NTuple{4,Bool},NTuple{4,Int64}}}}}}) at C:\Users\jules\.julia\packages\CUDAnative\nItlk\src\execution.jl:356
 [12] cufunction(::Function, ::Type) at C:\Users\jules\.julia\packages\CUDAnative\nItlk\src\execution.jl:356
 [13] macro expansion at C:\Users\jules\.julia\packages\CUDAnative\nItlk\src\execution.jl:174 [inlined]
 [14] macro expansion at .\gcutils.jl:87 [inlined]
 [15] macro expansion at C:\Users\jules\.julia\packages\CUDAnative\nItlk\src\execution.jl:171 [inlined]
 [16] _gpu_call(::CuArrays.CuArrayBackend, ::Function, ::CuArray{Tuple{Float32,typeof(∂(identity))},4}, ::Tuple{CuArray{Tuple{Float32,typeof(∂(identity))},4},Base.Broadcast.Broadcasted{Nothing,NTuple{4,Base.OneTo{Int64}},getfield(Zygote, Symbol("##1188#1195")){Zygote.Context,typeof(identity)},Tuple{Base.Broadcast.Extruded{CuArray{Float32,4},NTuple{4,Bool},NTuple{4,Int64}}}}}, ::Tuple{Tuple{Int64},Tuple{Int64}}) at C:\Users\jules\.julia\packages\CuArrays\PwSdF\src\gpuarray_interface.jl:59
 [17] gpu_call at C:\Users\jules\.julia\packages\GPUArrays\fAX0Q\src\abstract_gpu_interface.jl:151 [inlined]
 [18] gpu_call at C:\Users\jules\.julia\packages\GPUArrays\fAX0Q\src\abstract_gpu_interface.jl:128 [inlined]
 [19] copyto! at C:\Users\jules\.julia\packages\GPUArrays\fAX0Q\src\broadcast.jl:48 [inlined]
 [20] copyto! at .\broadcast.jl:797 [inlined]
 [21] copy at .\broadcast.jl:773 [inlined]
 [22] materialize at .\broadcast.jl:753 [inlined]
 [23] _broadcast(::getfield(Zygote, Symbol("##1188#1195")){Zygote.Context,typeof(identity)}, ::CuArray{Float32,4}) at C:\Users\jules\.julia\packages\Zygote\6K88s\src\lib\broadcast.jl:105
 [24] adjoint at C:\Users\jules\.julia\packages\Zygote\6K88s\src\lib\broadcast.jl:109 [inlined]
 [25] _forward at C:\Users\jules\.julia\packages\Zygote\6K88s\src\lib\grad.jl:44 [inlined]
 [26] adjoint at C:\Users\jules\.julia\packages\Zygote\6K88s\src\lib\lib.jl:126 [inlined]
 [27] _forward at C:\Users\jules\.julia\packages\Zygote\6K88s\src\lib\grad.jl:44 [inlined]
 [28] broadcasted at .\broadcast.jl:1161 [inlined]
 [29] _forward(::Zygote.Context, ::typeof(Base.Broadcast.broadcasted), ::typeof(identity), ::CuArray{Float32,4}) at C:\Users\jules\.julia\packages\Zygote\6K88s\src\compiler\interface2.jl:0
 [30] ConvTranspose at C:\Users\jules\.julia\packages\Flux\qXNjB\src\layers\conv.jl:123 [inlined]
 [31] _forward(::Zygote.Context, ::ConvTranspose{2,4,typeof(identity),TrackedArray{…,CuArray{Float32,4}},TrackedArray{…,CuArray{Float32,1}}}, ::CuArray{Float32,4}) at C:\Users\jules\.julia\packages\Zygote\6K88s\src\compiler\interface2.jl:0
 [32] #52 at .\none:1 [inlined]
 [33] _forward(::Zygote.Context, ::getfield(Main, Symbol("##52#53")), ::ConvTranspose{2,4,typeof(identity),TrackedArray{…,CuArray{Float32,4}},TrackedArray{…,CuArray{Float32,1}}}) at C:\Users\jules\.julia\packages\Zygote\6K88s\src\compiler\interface2.jl:0
 [34] _forward(::Function, ::ConvTranspose{2,4,typeof(identity),TrackedArray{…,CuArray{Float32,4}},TrackedArray{…,CuArray{Float32,1}}}) at C:\Users\jules\.julia\packages\Zygote\6K88s\src\compiler\interface.jl:31
 [35] forward(::Function, ::ConvTranspose{2,4,typeof(identity),TrackedArray{…,CuArray{Float32,4}},TrackedArray{…,CuArray{Float32,1}}}) at C:\Users\jules\.julia\packages\Zygote\6K88s\src\compiler\interface.jl:37
 [36] gradient(::Function, ::ConvTranspose{2,4,typeof(identity),TrackedArray{…,CuArray{Float32,4}},TrackedArray{…,CuArray{Float32,1}}}) at C:\Users\jules\.julia\packages\Zygote\6K88s\src\compiler\interface.jl:46
 [37] top-level scope at none:0
```