### PR TITLE
getindex(tuple, range)

### DIFF
--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -84,6 +84,9 @@ literal_indexed_iterate(x, ::Val{i}, state) where i = Base.indexed_iterate(x, i,
 @adjoint getindex(xs::NTuple{N,Any}, i::Integer) where N =
   (xs[i], Δ -> (ntuple(j -> i == j ? Δ : nothing, Val(N)), nothing))
 
+@adjoint getindex(xs::NTuple{N,Any}, r::AbstractUnitRange) where N =
+  (xs[r], Δ -> (ntuple(j -> j in r ? Δ[findfirst(isequal(j), r)] : nothing, Val(N)), nothing))
+
 function _forward(cx::Context, ::typeof(literal_indexed_iterate), xs::Tuple, ::Val{i}) where i
   y, b = _forward(cx, literal_getindex, xs, Val(i))
   back(::Nothing) = nothing

--- a/test/features.jl
+++ b/test/features.jl
@@ -294,3 +294,13 @@ function pow_simd(x, n)
 end
 
 @test_broken gradient(pow_simd, 2, 3) == (12,nothing)
+
+@testset "tuple getindex" begin
+  @test gradient(x -> size(x)[2], ones(2,2,2)) == (nothing,)
+  @test gradient(x -> sum(size(x)[1:2]), ones(2,2,2)) == (nothing,)
+  @test gradient(x -> sum(size(x)[1:2:3]), ones(2,2,2,2)) == (nothing,)
+  @test gradient(x -> sum(size(x)[[1,2,1]]), ones(2,2,2)) == (nothing,)
+
+  @test gradient((x,y,z) -> sum((x,y,z)[1:2]), 7, 8.8, 9.9) == (1.0, 1.0, nothing)
+  @test gradient((x,y,z) -> sum((x,y,z)[[1,2,1]]), 1,2,3) == (2, 1, nothing)
+end


### PR DESCRIPTION
Fixes #263, closes #280. 

Changes what error you get from [this example](https://github.com/FluxML/Flux.jl/issues/820#issuecomment-515703945) in Flux#820. 

If I understand right `Zygote.literal_getindex` is only called when the index is a literal integer, so this is only for normal `getindex`.