### PR TITLE
[WIP] Use ChainRules

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,8 +3,8 @@ uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
 version = "0.3.4"
 
 [deps]
-DiffRules = "b552c78f-8df3-52c6-915a-8e097449b14b"
 ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"
+DiffRules = "b552c78f-8df3-52c6-915a-8e097449b14b"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.3.4"
 
 [deps]
 DiffRules = "b552c78f-8df3-52c6-915a-8e097449b14b"
+ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"

--- a/src/Zygote.jl
+++ b/src/Zygote.jl
@@ -3,6 +3,7 @@ module Zygote
 using LinearAlgebra, Statistics
 using LinearAlgebra: copytri!, AbstractTriangular
 
+using ChainRules
 import ZygoteRules: @adjoint, @adjoint!, AContext, adjoint, _forward
 
 # This flag enables Zygote to grab extra type inference information during

--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -50,7 +50,9 @@ function conventionalize(crules::Tuple)
   function(∇)
     ntuple(length(crules) + 1) do ii
       # first arg is nothing. See TODO above.
-      ii==1 ? nothing : conventionalize1(crule(∇))
+      ii==1 && return nothing
+      crule = crules[ii - 1]
+      conventionalize1(crule(∇))
     end
   end
 end

--- a/test/features.jl
+++ b/test/features.jl
@@ -73,6 +73,10 @@ end
 
 @test gradient(x -> x.re*x.im, 2+3im) == ((re = 3, im = 2),)
 
+# This tests hitting ChainRules, as without ChainRules rrule definition it would be 1
+# TODO: more clear test, that just defines a ChainRule that has a side-effect we can test for
+@test gradient(abs, 0) == (0,)
+
 struct Foo{T}
   a::T
   b::T


### PR DESCRIPTION
my plan is
Step 1) Change Zygote to check for chainrules before doing its normal stuff,
and adapt the stuff it gets back from chainrules to play nice with Zygotes expectations

Step 2) adapt ChainRules and Zygote, so their expectations are more inline with each other and integrate more deeply.

This likely includes adding a macro that is basically @adjoint to ChainRules.
I think `@adjoint function f, y, Δ->-yd i`s
the same as ChainRules’s: `rrule(::typeof(f),...) = (y, Rule(Δ->yd))`
And that that should really have a similar connivence macro

This PR is Step 1.

Major limitations blocking this:
ChainRules does not know how to differentiate WRT the function itself, which matters for closures.


I know this imprinciple works as
without this branch:
```
Zygote.gradient(abs, 0) == (1,)
```

With this branch
``` 
Zygote.gradient(abs, 0) == (0,)
```


The matching PR for Nabla is:
https://github.com/invenia/Nabla.jl/pull/178/