### PR TITLE
Pin IRTools version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 
 [compat]
-IRTools = "0.2"
+IRTools = "=0.2.2"
 NNlib = "0.6"
 julia = "1"
 


### PR DESCRIPTION
The latest IRTools causes errors when loading `Zygote`. This PR tries to fix this.