### PR TITLE
NamedTuple destructuring case #303

### DIFF
--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -75,8 +75,13 @@ using Base: tail
 @adjoint tuple(xs...) = xs, identity
 
 literal_getindex(x, ::Val{i}) where i = getindex(x, i)
-literal_indexed_iterate(x, ::Val{i}) where i = Base.indexed_iterate(x, i)
-literal_indexed_iterate(x, ::Val{i}, state) where i = Base.indexed_iterate(x, i, state)
+literal_indexed_iterate(x, ::Val{i}) where i = indexed_iterate(x, Val(i),1)
+literal_indexed_iterate(x, ::Val{i}, state) where i = indexed_iterate(x, Val(i), state)
+indexed_iterate(t::NamedTuple, ::Val{i}, state) where {i}= ( mygetfield(t, Val(i)), i+1)
+mygetfield( t::NamedTuple{N,T}, ::Val{i} ) where {N,T,i} = getfield(t,i)
+@adjoint function mygetfield( t::NamedTuple{N,T}, ::Val{i} ) where {N,T,i}
+    t[i], Δ -> ( (;nt_nothing(t)...,pair( Val(N[i]),Δ)...),nothing)
+end
 
 @adjoint literal_getindex(xs::NTuple{N,Any}, ::Val{i}) where {N,i} =
   (xs[i], Δ -> (ntuple(j -> i == j ? Δ : nothing, Val(N)), nothing))

--- a/test/features.jl
+++ b/test/features.jl
@@ -304,3 +304,18 @@ end
   @test gradient((x,y,z) -> sum((x,y,z)[1:2]), 7, 8.8, 9.9) == (1.0, 1.0, nothing)
   @test gradient((x,y,z) -> sum((x,y,z)[[1,2,1]]), 1,2,3) == (2, 1, nothing)
 end
+
+@testset "NamedTuples destructuring" begin
+  begin
+    foo( (a,b) ) = a
+    fooTarget( t ) = t.a
+    nt = (a=1.0, b=1.0)
+    @test gradient(foo, nt) == gradient(fooTarget,nt)
+  end
+  begin
+    foo( (a, b, c) ) = b*b + c.a*c.b
+    fooTarget( t ) = t.b * t.b + t.c.a * t.c.b
+    nt = (a=2.0,b=3.0,c=(a=1.0,b=4.0,d=nothing))
+    @test gradient(foo, nt) == gradient(fooTarget,nt)
+  end
+end


### PR DESCRIPTION
Allow the gradient to be computed properly when destructuring NamedTuple

Tested, and type-stable checked with @code_warntype

See case #303 for more info