### PR TITLE
Handle nothings more gracefully in unzip

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -105,9 +105,10 @@ end
 
 @adjoint getindex(i::Int, j::Int) = i[j], _ -> nothing
 
+unzip(xs::Tuple{Vararg{Nothing}}) = xs
 function unzip(tuples)
-  map(1:length(first(tuples))) do i
-      map(tuple -> tuple[i], tuples)
+  map(1:length(first(x for x in tuples if x !== nothing))) do i
+      map(tuple -> tuple === nothing ? nothing : tuple[i], tuples)
   end
 end
 function ∇map(cx, f, args...)

--- a/test/structures.jl
+++ b/test/structures.jl
@@ -32,3 +32,17 @@ tasks4(x) = fetch(@async x^2)
 @test gradient(tasks4, 5) == (10,)
 
 VERSION > v"1.3-" && include("threads.jl")
+
+# Checking a corner case of map implementation.
+# See: Handle nothings more gracefully in unzip
+#      https://github.com/FluxML/Zygote.jl/pull/321
+let xs = ones(3),
+    ys = ones(3)
+    @test gradient(1) do a
+        p0 = (xs, ys, a)
+        sum(zip(p0[1], p0[2])) do (x, y)
+            p1 = (p0..., x)
+            p1[end]
+        end
+    end === (nothing,)
+end


### PR DESCRIPTION
This PR fixes the following example:

```julia
function f(a)
    p0 = (xs, ys, a)
    sum(zip(p0[1], p0[2])) do (x, y)
        p1 = (p0..., x)
        p1[end]
    end
end

using Zygote
xs = ys = ones(3)
gradient(a -> f(a), 1)
```

Without this patch, above code throws the following exception:

```
ERROR: MethodError: no method matching getindex(::Nothing, ::Int64)
Stacktrace:
 [1] (::Zygote.var"##1845#1847"{Int64})(::Nothing) at /home/takafumi/.julia/dev/Zygote/src/lib/array.jl:110
 [2] map(::Zygote.var"##1845#1847"{Int64}, ::Tuple{Tuple{Nothing,Nothing},Nothing}) at ./tuple.jl:140
 [3] (::Zygote.var"##1844#1846"{Tuple{Tuple{Nothing,Nothing},Nothing}})(::Int64) at /home/takafumi/.julia/dev/Zygote/src/lib/array.jl:109
 [4] iterate at ./generator.jl:47 [inlined]
 [5] _collect at ./array.jl:633 [inlined]
 [6] collect_similar at ./array.jl:562 [inlined]
 [7] map at ./abstractarray.jl:2073 [inlined]
 [8] unzip at /home/takafumi/.julia/dev/Zygote/src/lib/array.jl:109 [inlined]
 [9] (::Zygote.var"##930#934"{Tuple{Zygote.var"##181#back#107"{typeof(identity)},Zygote.var"##181#back#107"{typeof(identity)}}})(::Tuple{Tuple{Nothing},Nothing}) at /home/takafumi/.julia/dev/Zygote/src/lib/array.jl:122
 [10] (::Zygote.var"##2352#back#936"{Zygote.var"##930#934"{Tuple{Zygote.var"##181#back#107"{typeof(identity)},Zygote.var"##181#back#107"{typeof(identity)}}}})(::Tuple{Tuple{Nothing},Nothing}) at /home/takafumi/.julia/packages/ZygoteRules/Jn4LO/src/adjoint.jl:48
 [11] iterate at ./iterators.jl:333 [inlined]
 [12] (::typeof(∂(iterate)))(::Tuple{Tuple{Float64,Nothing},Nothing}) at /home/takafumi/.julia/dev/Zygote/src/compiler/interface2.jl:0
 [13] mapfoldl_impl at ./reduce.jl:47 [inlined]
 [14] (::typeof(∂(mapfoldl_impl)))(::Float64) at /home/takafumi/.julia/dev/Zygote/src/compiler/interface2.jl:0
 [15] mapfoldl_impl at ./reduce.jl:61 [inlined]
 [16] (::typeof(∂(mapfoldl_impl)))(::Float64) at /home/takafumi/.julia/dev/Zygote/src/compiler/interface2.jl:0
 [17] #mapfoldl#186 at ./reduce.jl:72 [inlined]
 [18] (::typeof(∂(#mapfoldl#186)))(::Float64) at /home/takafumi/.julia/dev/Zygote/src/compiler/interface2.jl:0
 [19] mapfoldl at ./reduce.jl:72 [inlined]
 [20] (::typeof(∂(mapfoldl)))(::Float64) at /home/takafumi/.julia/dev/Zygote/src/compiler/interface2.jl:0
 [21] #mapreduce#194 at ./reduce.jl:200 [inlined]
 [22] (::typeof(∂(#mapreduce#194)))(::Float64) at /home/takafumi/.julia/dev/Zygote/src/compiler/interface2.jl:0
 [23] mapreduce at ./reduce.jl:200 [inlined]
 [24] (::typeof(∂(mapreduce)))(::Float64) at /home/takafumi/.julia/dev/Zygote/src/compiler/interface2.jl:0
 [25] sum at ./reduce.jl:395 [inlined]
 [26] (::typeof(∂(sum)))(::Float64) at /home/takafumi/.julia/dev/Zygote/src/compiler/interface2.jl:0
 [27] f at ./REPL[11]:3 [inlined]
 [28] (::typeof(∂(f)))(::Float64) at /home/takafumi/.julia/dev/Zygote/src/compiler/interface2.jl:0
 [29] #33 at ./REPL[14]:1 [inlined]
 [30] (::typeof(∂(#33)))(::Float64) at /home/takafumi/.julia/dev/Zygote/src/compiler/interface2.jl:0
 [31] (::Zygote.var"##32#33"{typeof(∂(#33))})(::Float64) at /home/takafumi/.julia/dev/Zygote/src/compiler/interface.jl:38
 [32] gradient(::Function, ::Int64, ::Vararg{Int64,N} where N) at /home/takafumi/.julia/dev/Zygote/src/compiler/interface.jl:47
 [33] top-level scope at REPL[14]:1
```
