### PR TITLE
Ignore gradients of findall and findlast

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -6,7 +6,7 @@ using Base.Broadcast: broadcasted, broadcast_shape
 
 @adjoint Array(xs::AbstractArray) = Array(xs), ȳ -> (ȳ,)
 
-@nograd size, length, eachindex, Colon(), findfirst, randn, ones, zeros, one, zero,
+@nograd size, length, eachindex, Colon(), findfirst, findlast, findall, randn, ones, zeros, one, zero,
   print, println, any, all
 
 @adjoint rand(dims::Integer...) = rand(dims...), _ -> nothing

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -678,3 +678,9 @@ end
     end
   end
 end
+
+@testset "@nograd" begin
+  @test gradient(x -> findfirst(ismissing, x), [1, missing]) == (nothing,)
+  @test gradient(x -> findlast(ismissing, x), [1, missing]) == (nothing,)
+  @test gradient(x -> findall(ismissing, x)[1], [1, missing]) == (nothing,)
+end


### PR DESCRIPTION
... as already done for `findfirst`