### PR TITLE
Implement fusible forward/reverse-modes AD for broadcasting

### DIFF
--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -552,7 +552,7 @@ end
 
 @testset "broadcast" begin
   if !Zygote.usetyped
-    @test gradient(x -> sum(sin.(x)), Diagonal(randn(3)))[1][2] == 1
+    @test gradient(x -> sum(sin.(x)), Diagonal(randn(3)))[1][2] == 0
   end
 end
 


### PR DESCRIPTION
I implemented the forward-mode -based fused broadcasting AD as I outlined in #336. I also constructed the code in such a way that some of the facility can be used for reverse-mode AD of fused broadcasting.

At the moment this patch is for "early review" (although the test works locally).  The code became rather non-trivial so I think I need to add some comments before asking for a serious review.  But the main idea is similar to `Broadcast.flatten`.

Also, there seems to be no speed improvement (yet).  It's a bit puzzling because the basic strategy is similar to what I used in <https://github.com/tkf/ChainCutters.jl>.  I'll look into it after the direction of the implementation is "approved."

close https://github.com/FluxML/Zygote.jl/issues/336