### PR TITLE
Skip precompile() when Zygote is imported for compiling downstreams

### DIFF
--- a/src/Zygote.jl
+++ b/src/Zygote.jl
@@ -52,7 +52,7 @@ end
 precompile() = usetyped || include(joinpath(@__DIR__, "precompile.jl"))
 
 # precompile()
-@init precompile()
+@init Requires.isprecompiling() || precompile()
 
 # helps to work around 265-y issues
 function refresh()


### PR DESCRIPTION
IIUC, this is not required when precompiling downstream packages?

Before (ea4d1e894af775a6783f683d851bcfb5c10e25b0):

```julia
julia> using Zygote  # make sure Zygote is precompiled

julia> @time using Example
[ Info: Precompiling Example [7876af07-990d-54b4-ab0e-23690620f79a]
 12.440068 seconds (1.05 M allocations: 50.296 MiB, 0.81% gc time)
```

After:

```julia
julia> @time using Example
[ Info: Precompiling Example [7876af07-990d-54b4-ab0e-23690620f79a]
  2.690000 seconds (487.92 k allocations: 22.979 MiB, 0.33% gc time)
```

where I edited Example.jl so that it imports `Zygote`.
