### PR TITLE
Fix adjoint for Symmetric and add Hermitian

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -362,7 +362,7 @@ end
 
 function _symmetric_back(Δ, uplo)
   L, U, D = LowerTriangular(Δ), UpperTriangular(Δ), Diagonal(Δ)
-  return uplo == 'U' ? U + transpose(L) - D : L + transpose(U) - D
+  return uplo == 'U' ? U .+ transpose(L) - D : L .+ transpose(U) - D
 end
 _symmetric_back(Δ::Diagonal, uplo) = Δ
 _symmetric_back(Δ::UpperTriangular, uplo) = collect(uplo == 'U' ? Δ : transpose(Δ))
@@ -378,13 +378,13 @@ end
 _extract_imag(x) = (x->complex(0, imag(x))).(x)
 function _hermitian_back(Δ, uplo)
   isreal(Δ) && return _symmetric_back(Δ, uplo)
-  L, U, rD = LowerTriangular(Δ), UpperTriangular(Δ), real(Diagonal(Δ))
-  return uplo == 'U' ? U + L' - rD : L + U' - rD
+  L, U, rD = LowerTriangular(Δ), UpperTriangular(Δ), real.(Diagonal(Δ))
+  return uplo == 'U' ? U .+ L' - rD : L .+ U' - rD
 end
-_hermitian_back(Δ::Diagonal, uplo) = real(Δ)
+_hermitian_back(Δ::Diagonal, uplo) = real.(Δ)
 function _hermitian_back(Δ::LinearAlgebra.AbstractTriangular, uplo)
   isreal(Δ) && return _symmetric_back(Δ, uplo)
-  ŪL̄ = Δ - Diagonal(_extract_imag(diag(Δ)))
+  ŪL̄ = Δ .- Diagonal(_extract_imag(diag(Δ)))
   if istriu(Δ)
     return collect(uplo == 'U' ? ŪL̄ : ŪL̄')
   else

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -348,10 +348,11 @@ end
     Re = randn(rng, P, P)
     Im = randn(rng, P, P)
     A = complex.(Re, Im)
-    @test gradtest(x->real(Symmetric(complex.(x, Im))), Re)
-    @test gradtest(x->imag(Symmetric(complex.(x, Im))), Re)
-    @test gradtest(x->real(Symmetric(complex.(Re, x))), Im)
-    @test gradtest(x->imag(Symmetric(complex.(Re, x))), Im)
+    @test gradcheck(Re,Im) do Re,Im
+      A = Symmetric(complex.(Re, Im))
+      B = exp.(A)
+      sum(real(B) + imag(B))
+    end
     y, back = Zygote.pullback(Symmetric, A)
 
     @testset "back(::Diagonal)" begin
@@ -375,10 +376,11 @@ end
   Im = randn(rng, P, P)
   A = complex.(Re, Im)
   @testset "uplo=$uplo" for uplo in (:U, :L)
-    @test gradtest(x->real(Hermitian(complex.(x, Im), uplo)), Re)
-    @test gradtest(x->imag(Hermitian(complex.(x, Im), uplo)), Re)
-    @test gradtest(x->real(Hermitian(complex.(Re, x), uplo)), Im)
-    @test gradtest(x->imag(Hermitian(complex.(Re, x), uplo)), Im)
+    @test gradcheck(Re,Im) do Re,Im
+      A = Hermitian(complex.(Re, Im), uplo)
+      B = exp.(A)
+      sum(real(B) + imag(B))
+    end
     y, back = Zygote.pullback(Hermitian, A, uplo)
     _, back_sym = Zygote.pullback(Symmetric, A, uplo)
     @test y isa Hermitian

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -355,7 +355,7 @@ end
       @test gradcheck(Re,Im) do a, b
         c = Symmetric(complex.(a, b), uplo)
         d = exp.(c)
-        sum(real(d) + imag(d))
+        sum(real.(d) + imag.(d))
       end
       y, back = Zygote.pullback(Symmetric, A, uplo)
       @test y isa Symmetric
@@ -385,7 +385,7 @@ end
     @test gradcheck(Re,Im) do a, b
       c = Hermitian(complex.(a, b), uplo)
       d = exp.(c)
-      sum(real(d) + imag(d))
+      sum(real.(d) + imag.(d))
     end
     y, back = Zygote.pullback(Hermitian, A, uplo)
     _, back_sym = Zygote.pullback(Symmetric, A, uplo)

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -351,12 +351,18 @@ end
     Re = randn(rng, P, P)
     Im = randn(rng, P, P)
     A = complex.(Re, Im)
-    @testset "uplo=$uplo" for uplo in (:U, :L)
-      @test gradcheck(Re,Im) do a, b
-        c = Symmetric(complex.(a, b), uplo)
-        d = exp.(c)
-        sum(real.(d) + imag.(d))
+
+    @testset "gradcheck dense" begin
+      for uplo in (:U, :L)
+        @test gradcheck(Re,Im) do a, b
+          c = Symmetric(complex.(a, b), uplo)
+          d = exp.(c)
+          sum(real.(d) + imag.(d))
+        end
       end
+    end
+
+    @testset "uplo=$uplo" for uplo in (:U, :L)
       y, back = Zygote.pullback(Symmetric, A, uplo)
       @test y isa Symmetric
 
@@ -381,12 +387,18 @@ end
   Re = randn(rng, P, P)
   Im = randn(rng, P, P)
   A = complex.(Re, Im)
-  @testset "uplo=$uplo" for uplo in (:U, :L)
-    @test gradcheck(Re,Im) do a, b
-      c = Hermitian(complex.(a, b), uplo)
-      d = exp.(c)
-      sum(real.(d) + imag.(d))
+
+  @testset "gradcheck dense" begin
+    for uplo in (:U, :L)
+      @test gradcheck(Re,Im) do a, b
+        c = Hermitian(complex.(a, b), uplo)
+        d = exp.(c)
+        sum(real.(d) + imag.(d))
+      end
     end
+  end
+
+  @testset "uplo=$uplo" for uplo in (:U, :L)
     y, back = Zygote.pullback(Hermitian, A, uplo)
     _, back_sym = Zygote.pullback(Symmetric, A, uplo)
     @test y isa Hermitian

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -379,8 +379,8 @@ end
     @test gradtest(x->imag(Hermitian(complex.(x, Im), uplo)), Re)
     @test gradtest(x->real(Hermitian(complex.(Re, x), uplo)), Im)
     @test gradtest(x->imag(Hermitian(complex.(Re, x), uplo)), Im)
-    y, back = Zygote.forward(Hermitian, A, uplo)
-    _, back_sym = Zygote.forward(Symmetric, A, uplo)
+    y, back = Zygote.pullback(Hermitian, A, uplo)
+    _, back_sym = Zygote.pullback(Symmetric, A, uplo)
     @test y isa Hermitian
 
     @testset "back" begin

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -352,10 +352,10 @@ end
     Im = randn(rng, P, P)
     A = complex.(Re, Im)
     @testset "uplo=$uplo" for uplo in (:U, :L)
-      @test gradcheck(Re,Im) do Re,Im
-        A = Symmetric(complex.(Re, Im), uplo)
-        B = exp.(A)
-        sum(real(B) + imag(B))
+      @test gradcheck(Re,Im) do a, b
+        c = Symmetric(complex.(a, b), uplo)
+        d = exp.(c)
+        sum(real(d) + imag(d))
       end
       y, back = Zygote.pullback(Symmetric, A, uplo)
       @test y isa Symmetric
@@ -382,10 +382,10 @@ end
   Im = randn(rng, P, P)
   A = complex.(Re, Im)
   @testset "uplo=$uplo" for uplo in (:U, :L)
-    @test gradcheck(Re,Im) do Re,Im
-      A = Hermitian(complex.(Re, Im), uplo)
-      B = exp.(A)
-      sum(real(B) + imag(B))
+    @test gradcheck(Re,Im) do a, b
+      c = Hermitian(complex.(a, b), uplo)
+      d = exp.(c)
+      sum(real(d) + imag(d))
     end
     y, back = Zygote.pullback(Hermitian, A, uplo)
     _, back_sym = Zygote.pullback(Symmetric, A, uplo)

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -327,7 +327,7 @@ end
     rng, P = MersenneTwister(123456), 7
     A = randn(rng, P, P)
     @test gradtest(Symmetric, A)
-    y, back = Zygote.forward(Symmetric, A)
+    y, back = Zygote.pullback(Symmetric, A)
 
     @testset "back(::Diagonal)" begin
       D̄ = Diagonal(randn(rng, P))
@@ -352,7 +352,7 @@ end
     @test gradtest(x->imag(Symmetric(complex.(x, Im))), Re)
     @test gradtest(x->real(Symmetric(complex.(Re, x))), Im)
     @test gradtest(x->imag(Symmetric(complex.(Re, x))), Im)
-    y, back = Zygote.forward(Symmetric, A)
+    y, back = Zygote.pullback(Symmetric, A)
 
     @testset "back(::Diagonal)" begin
       D̄ = Diagonal(complex.(randn(rng, P), randn(rng, P)))


### PR DESCRIPTION
The current adjoint for `Symmetric` assumes `uplo=:U` and gives the wrong adjoint for complex symmetric matrices (it uses `adjoint` where it should use `transpose`).

This PR fixes the above issues and also adds the adjoint for `Hermitian`.