### PR TITLE
Add adjoints for symmetric/hermitian eigen/eigvals

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -447,6 +447,26 @@ end
   Ā = real.(VTF\(VT*F̄/VTF.*X)*VT)
   (Ā, )
 end
+@adjoint function LinearAlgebra.eigen(A::LinearAlgebra.RealHermSymComplexHerm)
+  dU = eigen(A)
+  return dU, function (Δ)
+    d, U = dU
+    d̄, Ū = Δ
+    if Ū === nothing
+      P = Diagonal(d̄)
+    else
+      F = inv.(d' .- d)
+      P = F .* (U' * Ū)
+      if d̄ === nothing
+        P[diagind(P)] .= 0
+      else
+        P[diagind(P)] = d̄
+      end
+    end
+    return (U * P * U',)
+  end
+end
+
 
 Zygote.@adjoint function LinearAlgebra.tr(x::AbstractMatrix)
   # x is a squre matrix checked by tr,

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -467,6 +467,10 @@ end
   end
 end
 
+@adjoint function LinearAlgebra.eigvals(A::LinearAlgebra.RealHermSymComplexHerm)
+  d, U = eigen(A)
+  return d, d̄ -> (U * Diagonal(d̄) * U',)
+end
 
 Zygote.@adjoint function LinearAlgebra.tr(x::AbstractMatrix)
   # x is a squre matrix checked by tr,

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -509,6 +509,14 @@ end
     y2 = eigen(A)
     @test y.values ≈ y2.values
     @test y.vectors ≈ y2.vectors
+    @testset "low rank" begin
+      U = eigvecs(A)
+      A2 = Symmetric(U * Diagonal([randn(rng), zeros(N-1)...]) * U')
+      @test_broken gradtest(collect(A2)) do (x)
+        d, Q = eigen(Symmetric(x))
+        return Q * Diagonal(exp.(d)) * transpose(Q)
+      end
+    end
   end
 
   @testset "eigen(::Hermitian{<:Real})" begin
@@ -522,6 +530,14 @@ end
     y2 = eigen(A)
     @test y.values ≈ y2.values
     @test y.vectors ≈ y2.vectors
+    @testset "low rank" begin
+      U = eigvecs(A)
+      A2 = Hermitian(U * Diagonal([randn(rng), zeros(N-1)...]) * U')
+      @test_broken gradtest(collect(A2)) do (x)
+        d, Q = eigen(Hermitian(x))
+        return Q * Diagonal(exp.(d)) * transpose(Q)
+      end
+    end
   end
 
   @testset "eigen(::Hermitian{<:Complex})" begin
@@ -536,6 +552,15 @@ end
     y2 = eigen(A)
     @test y.values ≈ y2.values
     @test y.vectors ≈ y2.vectors
+    @testset "low rank" begin
+      U = eigvecs(A)
+      A2 = Hermitian(U * Diagonal([randn(rng), zeros(N-1)...]) * U')
+      @test_broken gradtest(reim(collect(A2))...) do a,b
+        d, U = eigen(Hermitian(complex.(a, b)))
+        X = U * Diagonal(exp.(d)) * U'
+        return sum(reim(X))
+      end
+    end
   end
 end
 

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -505,6 +505,10 @@ end
       d, Q = eigen(Symmetric(x))
       return Q * Diagonal(exp.(d)) * transpose(Q)
     end
+    y = Zygote.pullback(eigen, A)[1]
+    y2 = eigen(A)
+    @test y.values ≈ y2.values
+    @test y.vectors ≈ y2.vectors
   end
 
   @testset "eigen(::Hermitian{<:Real})" begin
@@ -514,6 +518,10 @@ end
       d, Q = eigen(Hermitian(x))
       return Q * Diagonal(exp.(d)) * transpose(Q)
     end
+    y = Zygote.pullback(eigen, A)[1]
+    y2 = eigen(A)
+    @test y.values ≈ y2.values
+    @test y.vectors ≈ y2.vectors
   end
 
   @testset "eigen(::Hermitian{<:Real})" begin
@@ -524,6 +532,10 @@ end
       X = U * Diagonal(exp.(d)) * U'
       return real.(X) + imag.(X)
     end
+    y = Zygote.pullback(eigen, Hermitian(A))[1]
+    y2 = eigen(Hermitian(A))
+    @test y.values ≈ y2.values
+    @test y.vectors ≈ y2.vectors
   end
 end
 
@@ -532,12 +544,14 @@ end
     rng, N = MersenneTwister(123), 7
     A = Symmetric(randn(rng, N, N))
     @test gradtest(x->eigvals(Symmetric(x)), collect(A))
+    @test Zygote.pullback(eigvals, A)[1] ≈ eigvals(A)
   end
 
   @testset "eigvals(::Hermitian{<:Real})" begin
     rng, N = MersenneTwister(456), 7
     A = Hermitian(randn(rng, N, N))
     @test gradtest(x->eigvals(Hermitian(x)), collect(A))
+    @test Zygote.pullback(eigvals, A)[1] ≈ eigvals(A)
   end
 
   @testset "eigvals(::Hermitian{<:Complex})" begin
@@ -547,6 +561,7 @@ end
       c = Hermitian(complex.(a, b))
       return eigvals(c)
     end
+    @test Zygote.pullback(eigvals, Hermitian(A))[1] ≈ eigvals(Hermitian(A))
   end
 end
 

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -524,7 +524,7 @@ end
     @test y.vectors ≈ y2.vectors
   end
 
-  @testset "eigen(::Hermitian{<:Real})" begin
+  @testset "eigen(::Hermitian{<:Complex})" begin
     rng, N = MersenneTwister(789), 7
     A = collect(Hermitian(complex.(randn(rng, N, N), randn(rng, N, N))))
     @test gradtest(real.(A), imag.(A)) do a,b

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -526,14 +526,14 @@ end
 
   @testset "eigen(::Hermitian{<:Complex})" begin
     rng, N = MersenneTwister(789), 7
-    A = collect(Hermitian(complex.(randn(rng, N, N), randn(rng, N, N))))
-    @test gradtest(real.(A), imag.(A)) do a,b
+    A = Hermitian(randn(rng, ComplexF64, N, N))
+    @test gradtest(reim(collect(A))...) do a,b
       d, U = eigen(Hermitian(complex.(a, b)))
       X = U * Diagonal(exp.(d)) * U'
-      return real.(X) + imag.(X)
+      return sum(reim(X))
     end
-    y = Zygote.pullback(eigen, Hermitian(A))[1]
-    y2 = eigen(Hermitian(A))
+    y = Zygote.pullback(eigen, A)[1]
+    y2 = eigen(A)
     @test y.values ≈ y2.values
     @test y.vectors ≈ y2.vectors
   end

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -527,6 +527,29 @@ end
   end
 end
 
+@testset "eigvals(::RealHermSymComplexHerm)" begin
+  @testset "eigvals(::Symmetric{<:Real})" begin
+    rng, N = MersenneTwister(123), 7
+    A = Symmetric(randn(rng, N, N))
+    @test gradtest(x->eigvals(Symmetric(x)), collect(A))
+  end
+
+  @testset "eigvals(::Hermitian{<:Real})" begin
+    rng, N = MersenneTwister(456), 7
+    A = Hermitian(randn(rng, N, N))
+    @test gradtest(x->eigvals(Hermitian(x)), collect(A))
+  end
+
+  @testset "eigvals(::Hermitian{<:Complex})" begin
+    rng, N = MersenneTwister(789), 7
+    A, B = randn(rng, N, N), randn(rng, N, N)
+    @test gradtest(A, B) do a,b
+      c = Hermitian(complex.(a, b))
+      return eigvals(c)
+    end
+  end
+end
+
 using Distances
 
 Zygote.refresh()

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -546,7 +546,7 @@ end
     @test gradtest(reim(collect(A))...) do a,b
       d, U = eigen(Hermitian(complex.(a, b)))
       X = U * Diagonal(exp.(d)) * U'
-      return sum(reim(X))
+      return real.(X) .+ imag.(X)
     end
     y = Zygote.pullback(eigen, A)[1]
     y2 = eigen(A)
@@ -558,7 +558,7 @@ end
       @test_broken gradtest(reim(collect(A2))...) do a,b
         d, U = eigen(Hermitian(complex.(a, b)))
         X = U * Diagonal(exp.(d)) * U'
-        return sum(reim(X))
+        return real.(X) .+ imag.(X)
       end
     end
   end

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -497,6 +497,36 @@ end
   end
 end
 
+@testset "eigen(::RealHermSymComplexHerm)" begin
+  @testset "eigen(::Symmetric{<:Real})" begin
+    rng, N = MersenneTwister(123), 7
+    A = Symmetric(randn(rng, N, N))
+    @test gradtest(collect(A)) do (x)
+      d, Q = eigen(Symmetric(x))
+      return Q * Diagonal(exp.(d)) * transpose(Q)
+    end
+  end
+
+  @testset "eigen(::Hermitian{<:Real})" begin
+    rng, N = MersenneTwister(456), 7
+    A = Hermitian(randn(rng, N, N))
+    @test gradtest(collect(A)) do (x)
+      d, Q = eigen(Hermitian(x))
+      return Q * Diagonal(exp.(d)) * transpose(Q)
+    end
+  end
+
+  @testset "eigen(::Hermitian{<:Real})" begin
+    rng, N = MersenneTwister(789), 7
+    A = collect(Hermitian(complex.(randn(rng, N, N), randn(rng, N, N))))
+    @test gradtest(real.(A), imag.(A)) do a,b
+      d, U = eigen(Hermitian(complex.(a, b)))
+      X = U * Diagonal(exp.(d)) * U'
+      return real.(X) + imag.(X)
+    end
+  end
+end
+
 using Distances
 
 Zygote.refresh()


### PR DESCRIPTION
This PR adds adjoints for `eigen` and `eigvals` for `Hermitian` and real `Symmetric` matrices where all eigenvalues are unique. I don't know if/how we can support repeating eigenvalues. jax, TF, and (I think) Theano have the same limitation, but it would be nice if we didn't. 

Indirectly, this PR also adds support for `cos`, `sin`, `tan`, `cosh`, `sinh`, `tanh`, `log`, `acos`, `asin`, `atan`, `asinh`, and `sqrt` on real `Symmetric`/`Hermitian` matrices. A future PR will handle the complex Hermitian case for these functions, `acosh`/`atanh`, and repeated eigenvalues.