### PR TITLE
Make differentiation work with at-time macros (ignore gc_num and time_ns)

### DIFF
--- a/src/lib/base.jl
+++ b/src/lib/base.jl
@@ -1,6 +1,6 @@
 using Base: @get!
 
-@nograd readline
+@nograd readline, Base.gc_num, Base.time_ns
 
 # Gradient of AD stacks
 

--- a/test/features.jl
+++ b/test/features.jl
@@ -304,3 +304,7 @@ end
   @test gradient((x,y,z) -> sum((x,y,z)[1:2]), 7, 8.8, 9.9) == (1.0, 1.0, nothing)
   @test gradient((x,y,z) -> sum((x,y,z)[[1,2,1]]), 1,2,3) == (2, 1, nothing)
 end
+
+@testset "@timed" begin
+  @test gradient(x -> (@timed x)[1], 0) == (1,)
+end


### PR DESCRIPTION
Using `@time` macros produce `Can't differentiate foreigncall expression` error (see below). This PR fixes it by `@nograd`ing `Base.gc_num` and `Base.time_ns`.

```
  Can't differentiate foreigncall expression
  Stacktrace:
   [1] error(::String) at ./error.jl:33
   [2] gc_num at ./util.jl:22 [inlined]
   [3] (::typeof(∂(gc_num)))(::Nothing) at /home/takafumi/.julia/dev/Zygote/src/compiler/interface2.jl:0
   [4] #5 at ./util.jl:299 [inlined]
   [5] (::typeof(∂(#5)))(::Int64) at /home/takafumi/.julia/dev/Zygote/src/compiler/interface2.jl:0
   [6] (::Zygote.var"##32#33"{typeof(∂(#5))})(::Int64) at /home/takafumi/.julia/dev/Zygote/src/compiler/interface.jl:38
   [7] gradient(::Function, ::Int64, ::Vararg{Int64,N} where N) at /home/takafumi/.julia/dev/Zygote/src/compiler/interface.jl:47
   [8] top-level scope at REPL[2]:2
   [9] top-level scope at /home/takafumi/repos/watch/julia/usr/share/julia/stdlib/v1.4/Test/src/Test.jl:1108
   [10] top-level scope at REPL[2]:2
```