### PR TITLE
Point users to release version

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,10 +6,10 @@ At least, that's the idea. We're still in beta so expect some adventures.
 
 ## Setup
 
-Zygote is still moving quickly and it's best to work from the development branches. Run this in a Julia session:
+Zygote can be installed from the package manager in Julia's REPL:
 
 ```julia
-using Pkg; pkg"add Zygote#master"
+] add Zygote
 ```
 
 ## Taking Gradients


### PR DESCRIPTION
The readme needs an update before release as well, but this at least prevents people defaulting to master (which is no longer the best starting point).