### PR TITLE
Tracker compat

### DIFF
--- a/src/flux.jl
+++ b/src/flux.jl
@@ -3,3 +3,4 @@ using .Tracker: TrackedArray, TrackedReal
 unwrap(x::Union{TrackedArray,TrackedReal}) = Tracker.data(x)
 
 pullback(f, ps::Tracker.Params) = pullback(f, Params(ps))
+Tracker.forward(f, ps::Params) = Tracker.forward(f, Tracker.Params(ps))

--- a/src/flux.jl
+++ b/src/flux.jl
@@ -4,3 +4,4 @@ unwrap(x::Union{TrackedArray,TrackedReal}) = Tracker.data(x)
 
 pullback(f, ps::Tracker.Params) = pullback(f, Params(ps))
 Tracker.forward(f, ps::Params) = Tracker.forward(f, Tracker.Params(ps))
+Tracker.gradient_(f, ps::Params) = Tracker.gradient_(f, Tracker.Params(ps))


### PR DESCRIPTION
Making `Zygote.Params` work with Tracker's gradient function.