### PR TITLE
Fixed bcasting issue on GPU

### DIFF
--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -169,7 +169,7 @@ end
 
 @init @require CuArrays="3a865a2d-5b23-5a0f-bc46-62713ec82fae" begin
   @adjoint function broadcasted(::Broadcast.ArrayStyle{CuArrays.CuArray}, f, args...)
-    y, back = broadcast_forward(f, args...)
+    y, back = broadcast_forward(CuArrays.cufunc(f), args...)
     y, ȳ -> (nothing, nothing, back(ȳ)...)
   end
 end

--- a/test/cuda.jl
+++ b/test/cuda.jl
@@ -1,0 +1,10 @@
+using CuArrays
+@testset "basic bcasting" begin
+  a = cu(collect(1:9))
+  v(x, n) = x .^ n
+  pow_grada = cu(Float32[7.0, 448.0, 5103.0, 28672.0, 109375.0, 326592.0, 823543.0, 1.835008e6, 3.720087e6])
+  @test gradient(x -> v(x, 7) |> sum, a) == (pow_grada,)
+  w(x) = broadcast(log, x)
+  log_grada = cu(Float32[1.0, 0.5, 0.33333334, 0.25, 0.2, 0.16666667, 0.14285715, 0.125, 0.11111111])
+  @test gradient(x -> w(x) |> sum, a) == (log_grada,)
+end


### PR DESCRIPTION
Should fix Flux.jl#889 also.

```
julia> using Zygote, CuArrays

julia> v(x, n) = x .^ n;

julia> Zygote.gradient(x -> v(x, 7) |> sum, cu(rand(3,3)))
(Float32[4.804972e-5 0.15564603 7.750634e-6; 0.0015771488 0.6221976 0.32504037; 0.3631478 0.00038040814 0.00063724036],)
```
Also checked this works for `log`.