### PR TITLE
Fix #368

### DIFF
--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -27,7 +27,7 @@ end
 
 # Core functions
 
-@nograd Core.apply_type, Core.typeof, nfields, fieldtype,
+@nograd Core.apply_type, Core.typeof, nfields, fieldtype, Core.TypeVar, Core.UnionAll,
   (==), (===), (>=), (<), (>), isempty, supertype, Base.typename,
   Base.parameter_upper_bound, eps, Meta.parse, Base.eval, sleep
 

--- a/test/features.jl
+++ b/test/features.jl
@@ -319,8 +319,8 @@ let
   @test back(1.) == ((1.0,),)
 end
 
-function foo()
+function type_test()
    Complex{<:Real}
 end
 
-@test pullback(foo)[1] == Complex{<:Real}
+@test pullback(type_test)[1] == Complex{<:Real}

--- a/test/features.jl
+++ b/test/features.jl
@@ -318,3 +318,9 @@ let
   value, back = Zygote.pullback(baz, (1.0,))
   @test back(1.) == ((1.0,),)
 end
+
+function foo()
+   Complex{<:Real}
+end
+
+@test pullback(foo)[1] == Complex{<:Real}


### PR DESCRIPTION
The rough story here is that when a type like `Complex{<:Real}` gets written down in Julia code, it gets constructed dynamically by:

```julia
tv = Core.TypeVar(:s, Real)
body = Core.apply_type(Complex, tv)
Core.UnionAll(tv, body)
```

`body` is an intermediate state `Complex{s<:Real}` (notice no `where s`); it looks like a type but it isn't actually valid. However, generated functions, `Core.Typeof` etc still treat it as if it were a regular type, so it ends up inside the `Pullback` type, and this eventually breaks down.

```julia
julia> Core.Typeof(body)
Type{Complex{s<:Real}}

julia> Zygote.Pullback{Tuple{Core.Typeof(body)}}
Error showing value of type UnionAll:
ERROR: UndefVarError: S not defined
```

I'm not sure there's anything we can do about this in general; just `@nograd`ing some type functions is enough for now.