### PR TITLE
Added adjoint for sum for CuArrays

### DIFF
--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -172,4 +172,15 @@ end
     y, back = broadcast_forward(f, args...)
     y, ȳ -> (nothing, nothing, back(ȳ)...)
   end
+
+  @adjoint CuArrays.cu(xs) =
+    CuArrays.cu(xs), Δ -> (CuArrays.cu(Δ), )
+
+  @adjoint CuArrays.CuArray{N,T}(xs) where {N,T} =
+    CuArrays.CuArray{N,T}(xs), Δ -> (CuArrays.CuArray{N,T}(Δ), )
+
+  @adjoint function sum(xs::CuArrays.CuArray; dims = :)
+    sum(xs, dims = dims), Δ -> (similar(xs) .= Δ,)
+  end
+
 end

--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -180,7 +180,8 @@ end
     CuArrays.CuArray{N,T}(xs), Δ -> (CuArrays.CuArray{N,T}(Δ), )
 
   @adjoint function sum(xs::CuArrays.CuArray; dims = :)
-    sum(xs, dims = dims), Δ -> (similar(xs) .= Δ,)
+    placeholder = similar(xs)
+    sum(xs, dims = dims), Δ -> (placeholder .= Δ,)
   end
 
 end


### PR DESCRIPTION
The current adjoint for `sum` returns a `FillArray` which ends up playing weirdly with `CuArrays`. The `CuArray{N,T}` adjoint may not be necessary in its current form, as also the allocation for the array can probably be done in a smarter way.

MWE:

```Julia
julia> gradient(x -> sum(x .* 7), cu(rand(3,3))) |> typeof
Tuple{Array{Float32,2}} # should be a CuArray
```