### PR TITLE
Relax bound for DiffRules to 0.1 for compat with SpecialFunctions v0.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 
 [compat]
-DiffRules = "0.0"
+DiffRules = "0.0, 0.1"
 FFTW = "1"
 FillArrays = "0"
 ForwardDiff = "0"


### PR DESCRIPTION
Zygote.jl already allows `SpecialFunctions@0.8` but also suffers from the this issue: https://github.com/JuliaMath/SpecialFunctions.jl/issues/186 (though different error message):
```julia
julia> using Zygote, SpecialFunctions

julia> Zygote.gradient(a -> SpecialFunctions.loggamma(a[1]), [1.0])
ERROR: TypeError: in _pullback, in ccall: first argument not a pointer or valid constant expression, expected Ptr, got Tuple{Symbol,String}
Stacktrace:
 [1] logabsgamma at /var/home/tef30/.julia/packages/SpecialFunctions/ne2iw/src/gamma.jl:606 [inlined]
 [2] loggamma at /var/home/tef30/.julia/packages/SpecialFunctions/ne2iw/src/gamma.jl:650 [inlined]
 [3] #9 at ./REPL[9]:1 [inlined]
 [4] _pullback(::Zygote.Context, ::getfield(Main, Symbol("##9#10")), ::Array{Float64,1}) at /var/home/tef30/.julia/packages/Zygote/8dVxG/src/compiler/interface2.jl:0
 [5] _pullback(::Function, ::Array{Float64,1}) at /var/home/tef30/.julia/packages/Zygote/8dVxG/src/compiler/interface.jl:31
 [6] pullback(::Function, ::Array{Float64,1}) at /var/home/tef30/.julia/packages/Zygote/8dVxG/src/compiler/interface.jl:37
 [7] gradient(::Function, ::Array{Float64,1}) at /var/home/tef30/.julia/packages/Zygote/8dVxG/src/compiler/interface.jl:46
 [8] top-level scope at none:0
```

DiffRules recently got their version bumped to support SpecialFunctions v0.8 (https://github.com/JuliaDiff/DiffRules.jl/commit/49129c0c9993a7206965ead8d6564d3afdc011cd) which fixes this issue.

EDIT: Together with `DiffRules@0.1.0`:
```julia
julia> using Zygote, SpecialFunctions

julia> Zygote.gradient(a -> SpecialFunctions.loggamma(a[1]), [1.0])
([-0.577216],)
```