### PR TITLE
lyap adjoint more robust to different inputs

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -447,10 +447,10 @@ end
   end
 end
 
-@adjoint function lyap(A::AbstractMatrix, C::AbstractMatrix)
+Zygote.@adjoint function lyap(A::T, C::T) where {T<:AbstractMatrix}
   X = lyap(A, C)
   return X, function (X̄)
-    C̄ = lyap(collect(A'), X̄)
+    C̄ = lyap(collect(A'), convert(T,X̄))
     Ā = C̄*X' + C̄'*X
     return (Ā, C̄)
   end

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -447,10 +447,10 @@ end
   end
 end
 
-Zygote.@adjoint function lyap(A::T, C::T) where {T<:AbstractMatrix}
+Zygote.@adjoint function lyap(A::StridedArray, C::StridedArray)
   X = lyap(A, C)
-  return X, function (X̄)
-    C̄ = lyap(collect(A'), convert(T,X̄))
+  return X, function (X̄::AbstractArray{T}) where {T}
+    C̄ = lyap(Matrix{T}(A'), Matrix{T}(X̄))
     Ā = C̄*X' + C̄'*X
     return (Ā, C̄)
   end

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -521,6 +521,8 @@ end
 @testset "lyap" begin
   n = 5
   @test gradtest(lyap, (n,n), (n,n))
+  C = rand(n,n)
+  @test gradtest(A->Diagonal(lyap(A,C))[1,1],(n,n)) # pull request 407
   @test gradcheck(x->lyap(x[1],x[2]),[3.1,4.6])
 end
 

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -519,12 +519,8 @@ end
 end
 
 @testset "lyap" begin
-  rng, N = MersenneTwister(6865943), 5
-  for i = 1:5
-    A = randn(rng, N, N)
-    C = randn(rng, N, N)
-    @test gradtest(lyap, A, C)
-  end
+  n = 5
+  @test gradtest(lyap, (n,n), (n,n))
   @test gradcheck(x->lyap(x[1],x[2]),[3.1,4.6])
 end
 


### PR DESCRIPTION
A difference between the adjoint input type and the types to the original lyap can cause issues in computing the adjoint. They are address by converting the adjoint argument to the original type.