### PR TITLE
Add adjoints for get and get! for dicts

### DIFF
--- a/src/lib/base.jl
+++ b/src/lib/base.jl
@@ -49,6 +49,45 @@ end
 
 @nograd haskey
 
+# Just for reuse between get and get!
+function ∇getdictkey(d::AbstractDict, k, ctx, Δ)
+    grad = grad_mut(ctx, d)
+    grad[k] = accum(get(grad, k, nothing), Δ)
+    return (nothing, grad, nothing)
+end
+
+@adjoint! function get!(f::Function, d::AbstractDict, k)
+    # Will be replaced if ∇f is called
+    back = Δ -> ∇getdictkey(d, k, __context__, Δ)
+
+    function ∇f()
+        res,fback = pullback(__context__,f)
+        back = function(Δ)
+                Δd = get(grad_mut(__context__, d), k, nothing)
+                delete!(grad_mut(__context__, d), k)
+                fback(Δ) # Always return empty tuple due to no arg?
+                return (nothing, Δd, nothing)
+            end
+        return res
+    end
+    return get!(∇f, d, k), back
+end
+
+@adjoint! function get(f::Function, d::AbstractDict, k)
+    # Will be replaced if ∇f is called
+    back = Δ -> ∇getdictkey(d, k, __context__, Δ)
+
+    function ∇f()
+        res,fback = pullback(__context__,f)
+        back = function(Δ)
+                fback(Δ) # Always return empty tuple due to no arg?
+                return (nothing, nothing, nothing)
+            end
+        return res
+    end
+    return get(∇f, d, k), back
+end
+
 # Channels
 
 @nograd Channel, schedule


### PR DESCRIPTION
Fixes #408 

Not 100% sure if this is a good idea or if it just opens up for a never ending set of corner cases to catch. Just close with prejudice if it is the wrong way to go about things.

Prior to this attempt, I tried adding adjoints for the lower level functions used by get and get! but a couple of methods in I got stuck with array mutation iirc.

I skipped implementing gradients for the fields `age` and `count`. I can't tell if this will create subtle bugs or if it doesn't matter.