### PR TITLE
Accumulate over Params

### DIFF
--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -49,6 +49,13 @@ end
   end
 end
 
+function accum_param(cx::Context, x::Vector{<:AbstractArray}, Δ)
+  for (p,g) in zip(x, Δ)
+    haskey(cache(cx), p) && (cache(cx)[p] = accum(cache(cx)[p],g))
+  end
+  nothing
+end
+
 function accum_global(cx::Context, ref, x̄)
   gs = globals(cx)
   gs[ref] = accum(get(gs, ref, nothing), x̄)


### PR DESCRIPTION
Implicit parameters can be tricky to reason with, since some cases may need to collect the gradients from non bitstype cases (https://github.com/JuliaDiffEq/DiffEqFlux.jl/pull/96), such as how we have in the `Params` object. We should really start deprecating the implicit params soon.

Good to get some eyes on this.