### PR TITLE
Add adjoints for UnitUpperTriangular.

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -369,6 +369,8 @@ end
 
 @adjoint LinearAlgebra.LowerTriangular(A) = LowerTriangular(A), Δ->(LowerTriangular(Δ),)
 @adjoint LinearAlgebra.UpperTriangular(A) = UpperTriangular(A), Δ->(UpperTriangular(Δ),)
+@adjoint LinearAlgebra.UnitLowerTriangular(A) = UnitLowerTriangular(A), Δ->(UnitLowerTriangular(Δ)-I,)
+@adjoint LinearAlgebra.UnitUpperTriangular(A) = UnitUpperTriangular(A), Δ->(UnitUpperTriangular(Δ)-I,)
 
 # This is basically a hack while we don't have a working `ldiv!`.
 @adjoint function \(A::Cholesky, B::AbstractVecOrMat)

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -388,6 +388,18 @@ end
   @test gradtest((U, Y) -> Y' / UpperTriangular(U), U, Y)
   @test gradtest((U, Y) -> Y' / UpperTriangular(U), U, y)
 
+  # / (UnitLowerTriangular)
+  @test gradtest((L, Y) -> Y' / L, L, Y)
+  @test gradtest((L, Y) -> Y' / L, L, y)
+  @test gradtest((L, Y) -> Y' / UnitLowerTriangular(L), L, Y)
+  @test gradtest((L, Y) -> Y' / UnitLowerTriangular(L), L, y)
+
+  # / (UnitUpperTriangular)
+  @test gradtest((U, Y) -> Y' / U, U, Y)
+  @test gradtest((U, Y) -> Y' / U, U, y)
+  @test gradtest((U, Y) -> Y' / UnitUpperTriangular(U), U, Y)
+  @test gradtest((U, Y) -> Y' / UnitUpperTriangular(U), U, y)
+
   @testset "Cholesky" begin
 
     # Check that the forwards pass computes the correct thing.


### PR DESCRIPTION
This adds adjoints for UnitUpperTriangular and UnitLowerTriangular. For these types, adjoints are zero on the diagonal and other half of the matrix.