### PR TITLE
Use dispatch for accum nothing cases

### DIFF
--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -5,10 +5,10 @@ using Base: RefValue
 accum() = nothing
 accum(x) = x
 
-accum(x, y) = x + y
-accum(::Nothing, y) = y
-accum(x, ::Nothing) = y
-accum(::Nothing, ::Nothing) = nothing
+accum(x, y) = 
+  x === nothing ? y :
+  y === nothing ? x :
+  x + y
 
 accum(x, y, zs...) = accum(accum(x, y), zs...)
 

--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -5,7 +5,7 @@ using Base: RefValue
 accum() = nothing
 accum(x) = x
 
-accum(x, y) = 
+accum(x, y) =
   x === nothing ? y :
   y === nothing ? x :
   x + y

--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -5,10 +5,10 @@ using Base: RefValue
 accum() = nothing
 accum(x) = x
 
-accum(x, y) =
-  x == nothing ? y :
-  y == nothing ? x :
-  x + y
+accum(x, y) = x + y
+accum(::Nothing, y) = y
+accum(x, ::Nothing) = y
+accum(::Nothing, ::Nothing) = nothing
 
 accum(x, y, zs...) = accum(accum(x, y), zs...)
 


### PR DESCRIPTION
Very minor change.
It will compile down to the same code.
But I find this easier to read.

* technically there is an edge case, that is someone had defined a non-`Nothing` value to be `==nothing` then this would change things.
But I don't think we want to deal with that case like this.