### PR TITLE
Fix Fill ctor

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -18,7 +18,12 @@ using Base.Broadcast: broadcasted, broadcast_shape
 
 # Array Constructors
 @adjoint (::Type{T})(x::T) where T<:Array = T(x), ȳ -> (ȳ,)
-@adjoint (::Type{T})(x::Number, sz) where {T <: Fill} = Fill(x, sz), Δ -> (sum(Δ), nothing)
+@adjoint function (::Type{T})(x::Number, sz) where {T <: Fill}
+    back(Δ::AbstractArray) = (sum(Δ), nothing)
+    back(Δ::NamedTuple) = (Δ.value, nothing)
+    return Fill(x, sz), back
+end
+
 @adjoint (::Type{T})(sz) where {T<:Zeros} = Zeros(sz), Δ->(nothing,)
 @adjoint (::Type{T})(sz) where {T<:Ones} = Ones(sz), Δ->(nothing,)
 

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -1116,6 +1116,8 @@ end
   @test gradcheck(x->sum(Fill(x[], (2, 2))), [0.1])
   @test first(Zygote.gradient(sz->sum(Ones(sz)), 6)) === nothing
   @test first(Zygote.gradient(sz->sum(Zeros(sz)), 6)) === nothing
+  @test gradcheck(x->Fill(x[], 5).value, [0.1])
+  @test gradcheck(x->FillArrays.getindex_value(Fill(x[], 5)), [0.1])
 end
 
 @testset "AbstractArray Addition / Subtraction / Negation" begin


### PR DESCRIPTION
The Fill constructor adjoint fell over if you used any indexing operations on a given `Fill`. This is annoying as there are legitimate reasons for wanting to do this.