### PR TITLE
support for mutable globals

### DIFF
--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -68,6 +68,20 @@ unwrap(ref, x) = x
   accum_param(__context__, x, x̄)
 end
 
+function global_set(ref, val)
+  ccall(:jl_set_global, Cvoid, (Any, Any, Any),
+        ref.mod, ref.name, val)
+end
+
+@adjoint! function global_set(ref, x)
+  global_set(ref, x), function (x̄)
+    gs = globals(__context__)
+    x̄ = accum(get(gs, ref, nothing), x̄)
+    gs[ref] = nothing
+    return (nothing, x̄)
+  end
+end
+
 # Tuples
 
 using Base: tail

--- a/test/features.jl
+++ b/test/features.jl
@@ -65,6 +65,18 @@ end
 
 @test gradient(pow_mut, 2, 3) == (12,nothing)
 
+r = 1
+function pow_global(x, n)
+  global r
+  while n > 0
+    r *= x
+    n -= 1
+  end
+  return r
+end
+
+@test gradient(pow_global, 2, 3) == (12,nothing)
+
 @test gradient(x -> 1, 2) == (nothing,)
 
 @test gradient(t -> t[1]*t[2], (2, 3)) == ((3, 2),)


### PR DESCRIPTION
Supporting things like

```julia
r = 1
function pow_global(x, n)
  global r
  while n > 0
    r *= x
    n -= 1
  end
  return r
end
```

We were already tracking gradients for globals anyway, we just didn't support modifying them; adding that support just follows the usual rules for resetting the gradient.

This revealed a small bug in how we track globals as well: since branches can contain `GlobalRef`s, but we don't instrument branches (assuming they will only contain trivial expressions). So we now handle `GlobalRef`s found in branches.