### PR TITLE
Include rank in conv and pooling gradcheck testset names

### DIFF
--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -112,23 +112,21 @@ end
 end
 
 @testset "conv: spatial_rank=$spatial_rank" for spatial_rank in (1, 2, 3)
-    x = rand(repeat([10], spatial_rank)..., 3, 2)
-    w = rand(repeat([3], spatial_rank)..., 3, 3)
-    cdims = DenseConvDims(x, w)
-    @test gradtest((x, w) -> conv(x, w, cdims), x, w)
-    y = conv(x, w, cdims)
-    @test gradtest((y, w) -> ∇conv_data(y, w, cdims), y, w)
-    dcdims = DepthwiseConvDims(x, w)
-    @test gradtest((x, w) -> depthwiseconv(x, w, dcdims), x, w)
-  end
+  x = rand(repeat([10], spatial_rank)..., 3, 2)
+  w = rand(repeat([3], spatial_rank)..., 3, 3)
+  cdims = DenseConvDims(x, w)
+  @test gradtest((x, w) -> conv(x, w, cdims), x, w)
+  y = conv(x, w, cdims)
+  @test gradtest((y, w) -> ∇conv_data(y, w, cdims), y, w)
+  dcdims = DepthwiseConvDims(x, w)
+  @test gradtest((x, w) -> depthwiseconv(x, w, dcdims), x, w)
 end
 
 @testset "pooling: spatial_rank=$spatial_rank" for spatial_rank in (1, 2)
-    x = rand(repeat([10], spatial_rank)..., 3, 2)
-    pdims = PoolDims(x, 2)
-    @test gradtest(x -> maxpool(x, pdims), x)
-    @test gradtest(x -> meanpool(x, pdims), x)
-  end
+  x = rand(repeat([10], spatial_rank)..., 3, 2)
+  pdims = PoolDims(x, 2)
+  @test gradtest(x -> maxpool(x, pdims), x)
+  @test gradtest(x -> meanpool(x, pdims), x)
 end
 
 @test gradtest(x -> permutedims(x), rand(2))

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -111,8 +111,7 @@ end
   @test gradient(g, ones(3)) == ([1,0,0],)
 end
 
-@testset "conv" begin
-  for spatial_rank in (1, 2, 3)
+@testset "conv: spatial_rank=$spatial_rank" for spatial_rank in (1, 2, 3)
     x = rand(repeat([10], spatial_rank)..., 3, 2)
     w = rand(repeat([3], spatial_rank)..., 3, 3)
     cdims = DenseConvDims(x, w)
@@ -124,8 +123,7 @@ end
   end
 end
 
-@testset "pooling" begin
-  for spatial_rank in (1, 2)
+@testset "pooling: spatial_rank=$spatial_rank" for spatial_rank in (1, 2)
     x = rand(repeat([10], spatial_rank)..., 3, 2)
     pdims = PoolDims(x, 2)
     @test gradtest(x -> maxpool(x, pdims), x)


### PR DESCRIPTION
When these tests fail, it is useful to know what rank was being tested when it failed