### PR TITLE
Fix Euclidean and SqEuclidean distances

### DIFF
--- a/src/lib/distances.jl
+++ b/src/lib/distances.jl
@@ -1,11 +1,12 @@
 using .Distances
 
-@adjoint function sqeuclidean(x::AbstractVector, y::AbstractVector)
+@adjoint function (::SqEuclidean)(x::AbstractVector, y::AbstractVector)
   δ = x .- y
-  return sum(abs2, δ), function(Δ::Real)
+  function sqeuclidean(Δ::Real)
     x̄ = (2 * Δ) .* δ
     return x̄, -x̄
   end
+  return sum(abs2, δ), sqeuclidean
 end
 
 @adjoint function colwise(s::SqEuclidean, x::AbstractMatrix, y::AbstractMatrix)

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -1,4 +1,4 @@
-using Zygote, NNlib, Test, Random, LinearAlgebra, Statistics, FillArrays, FFTW
+using Zygote, NNlib, Test, Random, LinearAlgebra, Statistics, FillArrays, FFTW, Distances
 using Zygote: gradient
 using NNlib: conv, ∇conv_data, depthwiseconv
 using Base.Broadcast: broadcast_shape
@@ -851,57 +851,49 @@ end
   end
 end
 
-using Distances
-
-Zygote.refresh()
-
 @testset "distances" begin
   rng, P, Q, D = MersenneTwister(123456), 10, 9, 8
 
-   # Check sqeuclidean.
-  let
-    x, y = randn(rng, D), randn(rng, D)
-    @test gradtest(x->sqeuclidean(x, y), x)
-    @test gradtest(y->sqeuclidean(x, y), y)
-  end
+  for (f, metric) in ((euclidean, Euclidean()), (sqeuclidean, SqEuclidean()))
+    let
+      x, y = randn(rng), randn(rng)
+      @test gradtest(x -> f(x[1], y), [x])
+      @test gradtest(x -> evaluate(metric, x[1], y), [x])
+      @test gradtest(y -> f(x, y[1]), [y])
+      @test gradtest(y -> evaluate(metric, x, y[1]), [y])
+    end
 
-   # Check binary colwise.
-  let
-    X, Y = randn(rng, D, P), randn(rng, D, P)
-    @test gradtest(X->colwise(SqEuclidean(), X, Y), X)
-    @test gradtest(Y->colwise(SqEuclidean(), X, Y), Y)
-  end
+    let
+      x, y = randn(rng, D), randn(rng, D)
+      @test gradtest(x -> f(x, y), x)
+      @test gradtest(x -> evaluate(metric, x, y), x)
+      @test gradtest(y -> f(x, y), y)
+      @test gradtest(y -> evaluate(metric, x, y), y)
+    end
 
-   # Check binary pairwise.
-  let
-    X, Y = randn(rng, D, P), randn(rng, D, Q)
-    @test gradtest(X->pairwise(SqEuclidean(), X, Y; dims=2), X)
-    @test gradtest(Y->pairwise(SqEuclidean(), X, Y; dims=2), Y)
-  end
-  let
-    Xt, Yt = randn(rng, P, D), randn(rng, Q, D)
-    @test gradtest(Xt->pairwise(SqEuclidean(), Xt, Yt; dims=1), Xt)
-    @test gradtest(Yt->pairwise(SqEuclidean(), Xt, Yt; dims=1), Yt)
-  end
+    # Check binary colwise.
+    let
+      X, Y = randn(rng, D, P), randn(rng, D, P)
+      @test gradtest(X->colwise(metric, X, Y), X)
+      @test gradtest(Y->colwise(metric, X, Y), Y)
+    end
 
-   # Check unary pairwise.
-  @test gradtest(X->pairwise(SqEuclidean(), X; dims=2), randn(rng, D, P))
-  @test gradtest(Xt->pairwise(SqEuclidean(), Xt; dims=1), randn(rng, P, D))
+    # Check binary pairwise.
+    let
+      X, Y = randn(rng, D, P), randn(rng, D, Q)
+      @test gradtest(X->pairwise(metric, X, Y; dims=2), X)
+      @test gradtest(Y->pairwise(metric, X, Y; dims=2), Y)
+    end
 
-  @testset "colwise(::Euclidean, X, Y; dims=2)" begin
-    rng, D, P = MersenneTwister(123456), 2, 3
-    X, Y, D̄ = randn(rng, D, P), randn(rng, D, P), randn(rng, P)
-    gradtest((X, Y)->colwise(Euclidean(), X, Y), X, Y)
-  end
-  @testset "pairwise(::Euclidean, X, Y; dims=2)" begin
-    rng, D, P, Q = MersenneTwister(123456), 2, 3, 5
-    X, Y, D̄ = randn(rng, D, P), randn(rng, D, Q), randn(rng, P, Q)
-    gradtest((X, Y)->pairwise(Euclidean(), X, Y; dims=2), X, Y)
-  end
-  @testset "pairwise(::Euclidean, X; dims=2)" begin
-    rng, D, P = MersenneTwister(123456), 2, 3
-    X, D̄ = randn(rng, D, P), randn(rng, P, P)
-    gradtest(X->pairwise(Euclidean(), X; dims=2), X)
+    let
+      Xt, Yt = randn(rng, P, D), randn(rng, Q, D)
+      @test gradtest(Xt->pairwise(metric, Xt, Yt; dims=1), Xt)
+      @test gradtest(Yt->pairwise(metric, Xt, Yt; dims=1), Yt)
+    end
+
+    # Check unary pairwise.
+    @test gradtest(X->pairwise(metric, X; dims=2), randn(rng, D, P))
+    @test gradtest(Xt->pairwise(metric, Xt; dims=1), randn(rng, P, D))
   end
 end
 


### PR DESCRIPTION
This PR fixes https://github.com/FluxML/Zygote.jl/issues/429 by replacing the adjoint for `sqeuclidean(x::AbstractVector, y::AbstractVector)` with an adjoint for `(::SqEuclidean)(x::AbstractVector, y::AbstractVector)` which is called by both [`evaluate(SqEuclidean(), x::AbstractVector, y::AbstractVector)`](https://github.com/JuliaStats/Distances.jl/blob/7f3a28c0d1372e3b3edbcbc28f00ba5645e1bbdb/src/generic.jl#L24) and [`sqeuclidean(x::AbstractVector, y::AbstractVector)`](https://github.com/JuliaStats/Distances.jl/blob/7f3a28c0d1372e3b3edbcbc28f00ba5645e1bbdb/src/metrics.jl#L274). Moreover, I added the missing adjoint for `(::Euclidean)(x::AbstractVector, y::AbstractVector)` and added support for the `dims` keyword in `pairwise(::Euclidean, ...)` and `colwise(::Euclidean, ...)`. Tests are updated accordingly.