### PR TITLE
Adds a nograd function to encapsulate an operation without gradient

### DIFF
--- a/docs/src/utils.md
+++ b/docs/src/utils.md
@@ -11,4 +11,5 @@ Zygote.dropgrad
 Zygote.hessian
 Zygote.Buffer
 Zygote.forwarddiff
+Zygote.nograd
 ```

--- a/src/lib/grad.jl
+++ b/src/lib/grad.jl
@@ -1,5 +1,11 @@
 using MacroTools: @q
 
+"""
+    @nograd(f...)
+
+The output of the argument functions will be considered as constant
+and will not contribute gradients.
+"""
 macro nograd(ex)
   isexpr(ex, :tuple) || (ex = Expr(:tuple, ex))
   blk = @q begin end
@@ -9,6 +15,23 @@ macro nograd(ex)
   end
   return blk
 end
+
+"""
+    nograd(x)
+
+Treats `x` as a constant. For example:
+
+```julia-repl
+julia> f(x) = sum(nograd(x) + x); gradient(f, randn(5))
+([1.0, 1.0, 1.0, 1.0, 1.0],)
+```
+
+In the example above, the gradient is an array of ones even though
+`f(x)` computes `sum(2x)`, because `nograd(x)` uses the value of `x`
+as if it were a constant.
+"""
+nograd(x) = x
+@nograd nograd
 
 macro which(ex)
   @capture(ex, f_(args__)) || error("Zygote.@which f(args...)")

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -1312,6 +1312,11 @@ end
   @test gradient(x -> findall(ismissing, x)[1], [1, missing]) == (nothing,)
 end
 
+@testset "nograd" begin
+  f(x) = sum(Zygote.nograd(x) + x)
+  @test gradient(f, randn(5)) == (ones(5),)
+end
+
 @testset "fastmath" begin
   @test gradient(x -> begin @fastmath sin(x) end, 1) == gradient(x -> sin(x), 1)
   @test gradient(x -> begin @fastmath tanh(x) end, 1) == gradient(x -> tanh(x), 1)


### PR DESCRIPTION
As suggested by @MikeInnes, the idea is to be able to write something like this:

```julia
A = randn(5)
x = randn(5)

function f(x)
      nograd() do
          A .= x
      end
      sum(A + x)
end

f'(x) # returns [1, 1, 1, 1, 1]
```

Even though `f(x)` is computing `sum(2x)`, the gradient is a vector of ones because `A` is treated as a constant. This way we are able to mutate arrays for which we don't need a gradient.