### PR TITLE
Exception handlers (happy path only)

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -23,9 +23,9 @@ version = "0.2.0"
 
 [[DataStructures]]
 deps = ["InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "f784254f428fb8fd7ac15982e5862a38a44523d3"
+git-tree-sha1 = "b7720de347734f4716d1815b00ce5664ed6bbfd4"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.17.7"
+version = "0.17.9"
 
 [[Dates]]
 deps = ["Printf"]
@@ -74,7 +74,9 @@ version = "0.10.8"
 
 [[IRTools]]
 deps = ["InteractiveUtils", "MacroTools", "Test"]
-git-tree-sha1 = "72421971e60917b8cd7737f9577c4f0f87eab306"
+git-tree-sha1 = "233865da5ffbf50b9c5d528106fc962800780555"
+repo-rev = "master"
+repo-url = "https://github.com/MikeInnes/IRTools.jl.git"
 uuid = "7869d1d1-7146-5819-86e3-90919afe41df"
 version = "0.3.0"
 
@@ -89,7 +91,6 @@ deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[LibGit2]]
-deps = ["Printf"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 
 [[Libdl]]
@@ -103,10 +104,10 @@ uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [[MKL_jll]]
-deps = ["Libdl", "Pkg"]
-git-tree-sha1 = "61069ae718b8ab1e325bbfb4e5268902e7ea08e3"
+deps = ["IntelOpenMP_jll", "Libdl", "Pkg"]
+git-tree-sha1 = "720629cc8cbd12c146ca01b661fd1a6cf66e2ff4"
 uuid = "856f044c-d86e-5d09-b602-aeab76dc8ba7"
-version = "2019.0.117+0"
+version = "2019.0.117+2"
 
 [[MacroTools]]
 deps = ["DataStructures", "Markdown", "Random"]
@@ -144,7 +145,7 @@ uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 version = "1.1.0"
 
 [[Pkg]]
-deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Test", "UUIDs"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [[Printf]]


### PR DESCRIPTION
In theory, all we have to do to support exceptions now is to stop complaining about them. Unfortunately the following test case is crashing, so further investigation is needed:

```julia
function foo(f)
  y = 1
  try
    y = f()
  catch
    y
  end
  y
end

gradient(x -> foo(() -> x), 1) # 1
pullback(foo, () -> 0//0) # segfault
```

We could just be violating some `enter`/`leave` invariant in lowered code.

For now, we won't support differentiating through `catch` blocks at all. Full support for exceptions would require us to build some kind of continuation-like object as we unwind the stack; that's heavy machinery that will likely slow everything else down. An obvious compromise is to drop the gradient for the exception itself so that we can ignore all operations further down the stack; unfortunately, while this works for pure programs, in Julia the stack might have carried out mutations that are visible elsewhere. Dropping those gradients might be an acceptable compromise, or it might lead to extremely hard-to-debug incorrect gradients. For now, refusing to go there at all is a safe option.