### PR TITLE
make Params construction differentiable

### DIFF
--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -55,8 +55,20 @@ Base.adjoint(f::Function) = x -> gradient(f, x)[1]
 struct Params
   order::Vector{Any}
   params::IdSet{Any}
-  Params() = new([], IdSet())
+  function Params(xs)
+    order = Buffer([])
+    params = IdSet()
+    for x in xs
+      if !(x in params)
+        push!(order, x)
+        push!(params, x)
+      end
+    end
+    return new(copy(order), params)
+  end
 end
+
+Params() = Params(())
 
 @forward Params.order Base.iterate, Base.length
 
@@ -69,8 +81,6 @@ function Base.push!(ps::Params, x)
 end
 
 Base.push!(ps::Params, x...) = (foreach(x -> push!(ps, x), x); ps)
-
-Params(xs) = push!(Params(), xs...)
 
 function Base.show(io::IO, ps::Params)
   print(io, "Params([")


### PR DESCRIPTION
This is the companion PR to https://github.com/FluxML/Flux.jl/pull/997 (but they can be merged separately). With both PRs the following becomes possible:

```julia
gradient(params(model)) do
  sum(norm, params(model))
end
```

The constructors of `Params` should be exactly the same, with the same output, I only changed which one is the inner constructor.