### PR TITLE
Adjoint for sort

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -155,6 +155,11 @@ end
 
 @adjoint iterate(r::UnitRange, i...) = iterate(r, i...), _ -> nothing
 
+@adjoint function sort(x::AbstractArray)
+  p = sortperm(x)
+  return x[p], x̄ -> (x̄[invperm(p)],)
+end
+
 # Reductions
 
 @adjoint function sum(xs::AbstractArray; dims = :)

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -157,7 +157,7 @@ end
 
 @testset "circshift" begin
   L = 5
-  for D ∈ 1:5, reps ∈ 1:5 
+  for D ∈ 1:5, reps ∈ 1:5
     x0 = zeros(ntuple(d->L, D))
     g = gradient(x -> x[1], x0)[1] #Zero shift gradient
     shift = ntuple(_ -> rand(-L:L), D) #Random shift
@@ -187,6 +187,10 @@ end
   end
   @test gradtest(foo, 3)
   @test gradient(v -> sum([x for x in v]), [1.1,2.2,3.3]) == ([1, 1, 1],)
+end
+
+@testset "sort" begin
+  @test gradtest(sort, 5)
 end
 
 @testset "mean" begin


### PR DESCRIPTION
Currently not including the `dims` keyword argument since `sortperm` doesn't accept this. If `dims` is provided we probably have to use `mapslices` or something, but for now this is a strict improvement.