### PR TITLE
use IdDict in grad_mut fallback for IdDict

### DIFF
--- a/src/lib/base.jl
+++ b/src/lib/base.jl
@@ -24,6 +24,7 @@ end
 # Dictionaries
 
 grad_mut(d::AbstractDict) = Dict()
+grad_mut(d::IdDict) = IdDict()
 
 # TODO perhaps look up mutable gradients in `pullback`
 function accum(a::AbstractDict, b::AbstractDict)


### PR DESCRIPTION
Fixes hashing issues with CuArrays, i.e. https://github.com/FluxML/Flux.jl/issues/989