### PR TITLE
Fix I - A

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -715,6 +715,9 @@ end
 @adjoint function +(A::AbstractMatrix, S::UniformScaling)
   return A + S, Δ->(Δ, (λ=sum(view(Δ, diagind(Δ))),))
 end
+@adjoint function -(S::UniformScaling, A::AbstractMatrix)
+  return S - A, Δ->((λ=sum(view(Δ, diagind(Δ))),), -Δ)
+end
 
 @adjoint +(A::AbstractArray, B::AbstractArray) = A + B, Δ->(Δ, Δ)
 @adjoint -(A::AbstractArray, B::AbstractArray) = A - B, Δ->(Δ, -Δ)

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -713,10 +713,10 @@ end
   return Matrix{T}(I, ij), Δ -> ((λ=tr(Δ),), nothing)
 end
 @adjoint function +(A::AbstractMatrix, S::UniformScaling)
-  return A + S, Δ->(Δ, (λ=sum(view(Δ, diagind(Δ))),))
+  return A + S, Δ->(Δ, (λ=tr(Δ),))
 end
 @adjoint function -(S::UniformScaling, A::AbstractMatrix)
-  return S - A, Δ->((λ=sum(view(Δ, diagind(Δ))),), -Δ)
+  return S - A, Δ->((λ=tr(Δ),), -Δ)
 end
 
 @adjoint +(A::AbstractArray, B::AbstractArray) = A + B, Δ->(Δ, Δ)

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -533,6 +533,7 @@ end
   rng = MersenneTwister(123456)
   A, λ = randn(rng, 10, 10), randn(rng)
   @test gradtest(A->A + 5I, A)
+  @test gradtest(A->5I - A, A)
   @test gradtest(λ->A + λ[1] * I, [λ])
 end
 


### PR DESCRIPTION
This PR fixes the following error on master:
```julia
using Zygote, LinearAlgebra
gradient(x -> sum(I - x), rand(2, 2))
```
```julia
ERROR: Mutating arrays is not supported
Stacktrace:
 [1] error(::String) at .\error.jl:33
 [2] (::getfield(Zygote, Symbol("##1007#1008")))(::Nothing) at C:\Users\user\.julia\dev\Zygote\src\lib\array.jl:49
 [3] (::getfield(Zygote, Symbol("##2682#back#1009")){getfield(Zygote, Symbol("##1007#1008"))})(::Nothing) at C:\Users\user\.julia\packages\ZygoteRules\6nssF\src\adjoint.jl:49
 [4] - at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.2\LinearAlgebra\src\uniformscaling.jl:176 [inlined]
 [5] (::typeof(∂(-)))(::FillArrays.Fill{Float64,2,Tuple{Base.OneTo{Int64},Base.OneTo{Int64}}}) at C:\Users\user\.julia\dev\Zygote\src\compiler\interface2.jl:0
 [6] #5 at .\REPL[3]:1 [inlined]
 [7] (::typeof(∂(#5)))(::Float64) at C:\Users\user\.julia\dev\Zygote\src\compiler\interface2.jl:0
 [8] (::getfield(Zygote, Symbol("##36#37")){typeof(∂(#5))})(::Float64) at C:\Users\user\.julia\dev\Zygote\src\compiler\interface.jl:38
 [9] gradient(::Function, ::Array{Float64,2}) at C:\Users\user\.julia\dev\Zygote\src\compiler\interface.jl:47
 [10] top-level scope at REPL[3]:1
```