### PR TITLE
make docs build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,7 @@ git:
 matrix:
  allow_failures:
  - julia: nightly
-
-jobs:
-  include:
+ include:
     - stage: "Documentation"
       julia: 1.3
       os: linux


### PR DESCRIPTION
I haven't checked if they are not building but TravisCI broke them for most who use both `jobs` and `matrix`

https://github.com/JuliaDocs/Documenter.jl/issues/1228