### PR TITLE
improve support for nested array

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -28,6 +28,7 @@ end
 @adjoint (::Type{T})(sz) where {T<:Ones} = Ones(sz), Δ->(nothing,)
 
 _zero(xs::AbstractArray{<:Number}, T=float(eltype(xs))) = fill!(similar(xs, T), false)
+_zero(xs::AbstractArray{<:AbstractArray}, T=eltype(xs)) = eltype(xs)[_zero(x,eltype(T)) for x in xs]
 _zero(xs::AbstractArray, T=Any) = Union{Nothing, T}[nothing for x in xs]
 
 @adjoint getindex(x::AbstractArray, inds...) = x[inds...], ∇getindex(x, inds)

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -27,6 +27,11 @@ end
 @adjoint (::Type{T})(sz) where {T<:Zeros} = Zeros(sz), Δ->(nothing,)
 @adjoint (::Type{T})(sz) where {T<:Ones} = Ones(sz), Δ->(nothing,)
 
+@adjoint reinterpret(::Type{T}, x::T) where T = x, Δ->(nothing, Δ)
+@adjoint reinterpret(::Type{NTuple{N,T}}, xs::AbstractArray{T}) where {N,T} = reinterpret(NTuple{N,T}, xs), Δ->(nothing, reinterpret(T, Δ))
+@adjoint reinterpret(::Type{T}, xs::AbstractArray{NTuple{N,T}}) where {N,T} = reinterpret(T, xs), Δ->(nothing, reinterpret(NTuple{N,T}, Δ))
+@adjoint reinterpret(::Type{T}, x) where T = reinterpret(T, x), _ -> error("Non-trivial reinterpreting is not supported")
+
 _zero(xs::AbstractArray{<:Number}, T=float(eltype(xs))) = fill!(similar(xs, T), false)
 _zero(xs::AbstractArray{<:AbstractArray}, T=eltype(xs)) = eltype(xs)[_zero(x,eltype(T)) for x in xs]
 _zero(xs::AbstractArray, T=Any) = Union{Nothing, T}[nothing for x in xs]

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -90,6 +90,9 @@ Random.seed!(0)
   irep = [1 2; 2 2]
   @test gradtest(x -> x[1,irep], (3,4))
 
+  # nested arrays
+  @test gradient(x -> x[1][1], [[1]]) == ([[1]],)
+
   # https://github.com/invenia/Nabla.jl/issues/139
   x = rand(3)
   z = [1,2,3,3]

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -104,6 +104,15 @@ Random.seed!(0)
   @test back(1.0)[2] == [-im, 0]
 end
 
+@testset "reinterpret" begin
+  let T = Float64, T2 = Float32
+    @test_throws ErrorException gradient(x->reinterpret(T2, x), T[1.])
+    @test gradient(x -> reinterpret(T, x), rand(T)) == (1.,)
+    @test gradient(x -> sum(sum(reinterpret(NTuple{2,T}, x))), rand(T, 2)) == ([1., 1.],)
+    @test gradient(x -> sum(sum(reinterpret(T, x))), [(rand(T), rand(T))]) == ([(1., 1.)],)
+  end
+end
+
 @testset "view" begin
   @test gradtest(x -> view(x,:,2,:), (3,4,5))
   @test gradtest(x -> view(x,1:2,3:4), (3,4))


### PR DESCRIPTION
These definitions are handy when working with `Vector{NTuple{d,T}}` types which can be interpreted as `Vector{T}`.