### PR TITLE
Fix a bug in ∇getindex

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -40,10 +40,15 @@ _zero(xs::AbstractArray, T=Any) = Union{Nothing, T}[nothing for x in xs]
     dx[inds...] = dy
   else
     dx = _zero(x, eltype(dy))
-    @views dx[inds...] .+= dy
+    dxv = view(dx, inds...)
+    dxv .+= _droplike(dy, dxv)
   end
   (dx, map(_->nothing, inds)...)
 end
+
+_droplike(dy, dxv) = dy
+_droplike(dy::Union{LinearAlgebra.Adjoint, LinearAlgebra.Transpose}, dxv::AbstractVector) =
+  dropdims(dy; dims=2)
 
 @adjoint! setindex!(xs::AbstractArray, x...) = setindex!(xs, x...),
   _ -> error("Mutating arrays is not supported")

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -99,6 +99,11 @@ Random.seed!(0)
   # https://github.com/FluxML/Zygote.jl/issues/376
   _, back = Zygote._pullback(x->x[1]*im, randn(2))
   @test back(1.0)[2] == [-im, 0]
+
+  # _droplike
+  @test gradient(x -> sum(inv, x[1,:]'), ones(2,2)) == ([-1 -1; 0 0],)
+  @test gradient(x -> sum(inv, x[1:1,:]'), ones(2,2)) == ([-1 -1; 0 0],)
+  @test gradient(x -> sum(inv, transpose(view(x,1,:))), ones(2,2)) == ([-1 -1; 0 0],)
 end
 
 @testset "view" begin


### PR DESCRIPTION
This is a slightly crude way to fix a bug in the following gradient:
```
gradient(x -> sum(inv, x[1,:]'), ones(2,2))
# ERROR: DimensionMismatch("cannot broadcast array to have fewer dimensions")
```
which is from `@views dx[inds...] .+= dy` with these inputs:
```
typeof(dy) = Adjoint{Float64,Array{Float64,2}}
size(dy) = (2, 1)
typeof(dx) = Array{Float64,2}
size(dx[inds...]) = (2,)
```