### PR TITLE
Differentiation of Dual numbers

### DIFF
--- a/src/lib/forward.jl
+++ b/src/lib/forward.jl
@@ -8,6 +8,9 @@ using ForwardDiff: Dual
 @adjoint literal_getproperty(d::Dual{T}, ::Val{:partials}) where T =
   d.partials, ṗ -> (Dual{T}(0, ṗ...),)
 
+@adjoint literal_getproperty(d::Dual{T}, ::Val{:value}) where T =
+  d.value, ẋ -> (Dual{T}(ẋ, zeros(d.partials.values)...),)
+
 # Mixed mode
 
 seed(x::Real, ::Val) = Dual(x, true)

--- a/src/lib/forward.jl
+++ b/src/lib/forward.jl
@@ -1,6 +1,15 @@
 using ForwardDiff
 using ForwardDiff: Dual
 
+# ForwardDiff integration
+
+@adjoint Dual{T}(x, ẋ::Tuple) where T = Dual{T}(x, ẋ), ḋ -> (ForwardDiff.value(ḋ), (ForwardDiff.partials(ḋ)...,))
+
+@adjoint literal_getproperty(d::Dual{T}, ::Val{:partials}) where T =
+  d.partials, ṗ -> (Dual{T}(0, ṗ...),)
+
+# Mixed mode
+
 seed(x::Real, ::Val) = Dual(x, true)
 
 function seed(x, ::Val{N}, offset = 0) where N

--- a/src/lib/forward.jl
+++ b/src/lib/forward.jl
@@ -3,13 +3,16 @@ using ForwardDiff: Dual
 
 # ForwardDiff integration
 
-@adjoint Dual{T}(x, ẋ::Tuple) where T = Dual{T}(x, ẋ), ḋ -> (ForwardDiff.value(ḋ), (ForwardDiff.partials(ḋ)...,))
+@adjoint function Dual{T}(x, ẋ::Tuple) where T
+  @assert length(ẋ) == 1
+  Dual{T}(x, ẋ), ḋ -> (ḋ.partials[1], (ḋ.value,))
+end
 
 @adjoint literal_getproperty(d::Dual{T}, ::Val{:partials}) where T =
-  d.partials, ṗ -> (Dual{T}(0, ṗ...),)
+  d.partials, ṗ -> (Dual{T}(ṗ[1], 0),)
 
 @adjoint literal_getproperty(d::Dual{T}, ::Val{:value}) where T =
-  d.value, ẋ -> (Dual{T}(ẋ, zeros(d.partials.values)...),)
+  d.value, ẋ -> (Dual{T}(0, ẋ),)
 
 # Mixed mode
 


### PR DESCRIPTION
This PR shows how to make `Dual` constructors and `partials` to be differentiable in Zygote. Because `Dual`s are `Number`s, we have to differentiate them naturally rather than structurally (this works already):

```julia
julia> gradient(x -> x*x, Dual(5, 1))
(Dual{Nothing}(10,2),)
```

This is easy to interpret if we're doing forward-over-reverse; we get the second derivative here. It's harder to interpret that if we do something like

```julia
gradient(x -> partials(x*x, 1), Dual(5, 1))
```

In a case like this it makes more sense to take a structural derivative (calculating the derivatives of the partials, not the partials of the derivative). That's what Zygote currently does for `partials`, but this breaks as in #494 when we try to mix structural and natural gradients.

The way to resolve this is to work out how derivatives-of-partials and partials-of-derivatives are related and map between them in the adjoints for `partials` and `Dual`. This PR currently just assumes they are the same, which actually works in some simple cases, but we should be much more careful that this is valid before merging.

```julia
julia> gradient(x -> partials(sin(Dual(5, x)), 1), 1)
(0.28366218546322625,)
```
