### PR TITLE
Fix Flux.flip by providing an adjoint for Base.reverse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.jl.*.cov
 *.jl.mem
 docs/build
+.tags*

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 *.jl.*.cov
 *.jl.mem
 docs/build
-.tags*

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -65,8 +65,7 @@ end
 
 @adjoint function reverse(x::AbstractArray, args...; kwargs...)
   _reverse(t) = reverse(t, args...; kwargs...)
-  _nothings(t) = map(_->nothing, keys(t))
-  _reverse(x), Δ->(_reverse(Δ), _nothings(args)..., _nothings(kwargs)...)
+  _reverse(x), Δ->(_reverse(Δ), map(_->nothing, args)...)
 end
 
 @adjoint permutedims(xs) = permutedims(xs), Δ -> (permutedims(Δ),)

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -63,6 +63,12 @@ end
   circshift(A, shifts), Δ -> (circshift(Δ, map(-, shifts)), nothing)
 end
 
+@adjoint function reverse(x::AbstractArray, args...; kwargs...)
+  _reverse(t) = reverse(t, args...; kwargs...)
+  _nothings(t) = map(_->nothing, keys(t))
+  _reverse(x), Δ->(_reverse(Δ), _nothings(args)..., _nothings(kwargs)...)
+end
+
 @adjoint permutedims(xs) = permutedims(xs), Δ -> (permutedims(Δ),)
 
 @adjoint permutedims(xs::AbstractVector) = permutedims(xs), Δ -> (vec(permutedims(Δ)),)

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -129,6 +129,11 @@ end
   @test gradtest(x -> meanpool(x, pdims), x)
 end
 
+@test gradtest(x -> reverse(x), rand(17))
+@test gradtest(x -> reverse(x, 8), rand(17))
+@test gradtest(x -> reverse(x, 8, 13), rand(17))
+@test gradtest(x -> reverse(x, dims=2), rand(17, 42))
+
 @test gradtest(x -> permutedims(x), rand(2))
 @test gradtest(x -> permutedims(x), rand(2,3))
 @test gradtest(x -> permutedims(x, [3,1,2]), rand(4,5,6))


### PR DESCRIPTION
The main motivation behind this PR is to address various issues concerning `Flux.flip()` (used mainly for bRNNs), e.g.  FluxML/Flux.jl#962, FluxML/Flux.jl#990 and FluxML/model-zoo#179