### PR TITLE
Remove get! macro

### DIFF
--- a/src/compiler/reverse.jl
+++ b/src/compiler/reverse.jl
@@ -2,7 +2,6 @@ using IRTools: IR, Variable, Pipe, xcall, var, prewalk, postwalk,
   blocks, predecessors, successors, argument!, arguments, branches,
   insertafter!, finish, expand!, prune!, substitute!, substitute,
   block, block!, branch!, return!, stmt, meta
-using Base: @get!
 
 @inline tuple_va(N, xs) = xs
 @inline tuple_va(N, x, xs...) = (x, tuple_va(N, xs...)...)

--- a/src/lib/base.jl
+++ b/src/lib/base.jl
@@ -1,5 +1,3 @@
-using Base: @get!
-
 @nograd readline, Base.gc_num, Base.time_ns
 
 # Gradient of AD stacks


### PR DESCRIPTION
The get! macro is imported but unused. It was deprecated by https://github.com/JuliaLang/julia/pull/34611, https://github.com/JuliaLang/julia/pull/34646