### PR TITLE
fix a few adjoints for complex arrays

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -301,11 +301,11 @@ end
 
 @adjoint diag(A::AbstractMatrix) = diag(A), Δ->(Diagonal(Δ),)
 
-@adjoint det(xs) = det(xs), Δ -> (Δ * det(xs) * transpose(inv(xs)),)
+@adjoint det(xs) = det(xs), Δ -> (Δ * det(xs) * inv(xs)',)
 
-@adjoint logdet(xs) = logdet(xs), Δ -> (Δ * transpose(inv(xs)),)
+@adjoint logdet(xs) = logdet(xs), Δ -> (Δ * inv(xs)',)
 
-@adjoint logabsdet(xs) = logabsdet(xs), Δ -> (Δ[1] * transpose(inv(xs)),)
+@adjoint logabsdet(xs) = logabsdet(xs), Δ -> (Δ[1] * inv(xs)',)
 
 @adjoint function inv(A)
   Ainv = inv(A)

--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -73,7 +73,7 @@ Numeric{T<:Number} = Union{T,AbstractArray{<:T}}
 
 @adjoint function broadcasted(::typeof(/), x::Numeric, y::Numeric)
   res = x ./ y
-  res, Δ -> (nothing, unbroadcast(x, Δ ./ y), unbroadcast(y, -Δ .* res ./ y))
+  res, Δ -> (nothing, unbroadcast(x, Δ ./ conj.(y)), unbroadcast(y, -Δ .* conj.(res ./ y)))
 end
 
 @adjoint broadcasted(::typeof(identity), x::Numeric) = x, Δ -> (nothing, Δ)

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -1,4 +1,4 @@
-using Zygote, Test
+using Zygote, Test, LinearAlgebra
 
 @test gradient(x -> real(abs(x)*exp(im*angle(x))), 10+20im)[1] ≈ 1
 @test gradient(x -> imag(real(x)+0.3im), 0.3)[1] ≈ 0
@@ -10,6 +10,9 @@ using Zygote, Test
 @test gradient(a -> real(([a].*conj([a])))[], 0.3im)[1] == 0.6im
 @test gradient(a -> real(([a].*conj.([a])))[], 0.3im)[1] == 0.6im
 @test gradient(a -> real.(([a].*conj.([a])))[], 0.3im)[1] == 0.6im
+
+@test gradient(x -> norm((im*x) ./ (im)), 2)[1] == 1
+@test gradient(x -> norm((im) ./ (im*x)), 2)[1] == -1/4
 
 fs_C_to_R = (real,
              imag,

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -13,6 +13,9 @@ using Zygote, Test, LinearAlgebra
 
 @test gradient(x -> norm((im*x) ./ (im)), 2)[1] == 1
 @test gradient(x -> norm((im) ./ (im*x)), 2)[1] == -1/4
+@test gradient(x -> real(det(x)), [1 2im; 3im 4])[1] ≈ [4 3im; 2im 1]
+@test gradient(x -> real(logdet(x)), [1 2im; 3im 4])[1] ≈ [4 3im; 2im 1]/10
+@test gradient(x -> real(logabsdet(x)[1]), [1 2im; 3im 4])[1] ≈ [4 3im; 2im 1]/10
 
 fs_C_to_R = (real,
              imag,


### PR DESCRIPTION
These were giving wrong answers before. 

I didn't write tests for the `det` fixes mostly because I couldn't figure out how to use `gradtest` for complex matrices, although I welcome any help, but perhaps its ok since these are correct in [ChainsRules](https://github.com/JuliaDiff/ChainRules.jl/blob/d3464c2c86b59ee766b10c9e496fb3cde9053b93/src/rulesets/LinearAlgebra/dense.jl#L53) and, as I understand, this will switch to using that soon. 