### PR TITLE
Simplify global variable handling

### DIFF
--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -1,12 +1,10 @@
 mutable struct Context <: AContext
   cache::Union{IdDict{Any,Any},Nothing}
-  globals::Union{Dict{GlobalRef,Any},Nothing}
 end
 
-Context() = Context(nothing, nothing)
+Context() = Context(nothing)
 
 cache(cx::Context) = cx.cache === nothing ? (cx.cache = IdDict()) : cx.cache
-globals(cx::Context) = cx.globals === nothing ? (cx.globals = Dict{GlobalRef,Any}()) : cx.globals
 
 struct Pullback{S,T}
   t::T

--- a/test/features.jl
+++ b/test/features.jl
@@ -275,7 +275,7 @@ global_param = 3
   y, back = Zygote._pullback(cx, x -> x*global_param, 2)
   @test y == 6
   @test back(1) == (nothing, 3)
-  Zygote.globals(cx)[GlobalRef(Main, :global_param)] == 2
+  Zygote.cache(cx)[GlobalRef(Main, :global_param)] == 2
 end
 
 function pow_try(x)


### PR DESCRIPTION
slightly. We need to track gradients for mutable globals anyway, but we were tracking gradients for _all_ globals; the idea was to expose global derivatives as part of the API, but I no longer think this is the right thing to do, so it's back to being an implementation detail.

bors r+