### PR TITLE
vcat vectors + numbers

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -95,9 +95,10 @@ end
   hvcat(rows, xs...), ȳ -> (nothing, permutedims(ȳ)...)
 end
 
+pull_block_vert(sz, Δ, A::Number) = Δ[sz]
 pull_block_vert(sz, Δ, A::AbstractVector) = Δ[sz-length(A)+1:sz]
 pull_block_vert(sz, Δ, A::AbstractMatrix) = Δ[sz-size(A, 1)+1:sz, :]
-@adjoint function vcat(A::Union{AbstractVector, AbstractMatrix}...)
+@adjoint function vcat(A::Union{AbstractVector, AbstractMatrix, Number}...)
   sz = cumsum([size.(A, 1)...])
   return vcat(A...), Δ->(map(n->pull_block_vert(sz[n], Δ, A[n]), eachindex(A))...,)
 end

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -86,7 +86,7 @@ end
 @test gradient((x,y) -> prod(yi -> yi*x, y), 1, [1,1]) == (2, [1, 1])
 
 @test gradient((x,y) -> sum(map(yi -> yi*x, y)), 1, [1,1]) == (2, [1, 1])
-@test gradient((x,y) -> prod(map(yi -> yi*x, y)), 1, [1,1]) == (2, [1, 1]) 
+@test gradient((x,y) -> prod(map(yi -> yi*x, y)), 1, [1,1]) == (2, [1, 1])
 
 @test gradtest(x -> prod(x, dims = (2, 3)), (3,4,5))
 @test gradtest(x -> prod(x), (3,4))
@@ -166,8 +166,8 @@ end
   cdims = DenseConvDims(x, w)
   @test gradtest((x, w) -> conv(x, w, cdims), x, w)
   @test gradtest((x, w) -> sum(conv(x, w, cdims)), x, w)  # https://github.com/FluxML/Flux.jl/issues/1055
-  
-  y = conv(x, w, cdims) 
+
+  y = conv(x, w, cdims)
   @test gradtest((y, w) -> ∇conv_data(y, w, cdims), y, w)
   if spatial_rank == 3
     @test_broken gradtest((y, w) -> sum(∇conv_data(y, w, cdims)), y, w)
@@ -177,7 +177,7 @@ end
 
   dcdims = DepthwiseConvDims(x, w)
   @test gradtest((x, w) -> depthwiseconv(x, w, dcdims), x, w)
-  
+
   y = depthwiseconv(x, w, dcdims)
   @test gradtest((y, w) -> ∇depthwiseconv_data(y, w, dcdims), y, w)
   if spatial_rank == 3
@@ -1006,6 +1006,10 @@ end
   # Scalar
   @test gradient((x,y) -> sum(vcat(x,y)), 1,2) == (1,1)
   @test gradient((x,y) -> sum([x;y]), 1,2) == (1,1)
+
+  # Scalar + Vector
+  @test gradient(x -> sum(vcat(x, 1, x)), rand(3)) == ([2,2,2],)
+  @test gradient((x,y) -> sum(vcat(x, y, y)), rand(3), 4) == ([1,1,1], 2)
 
   # Vector-only.
   cat_test(vcat, randn(1))


### PR DESCRIPTION
Closes #440, and closes #538.

Smaller change than the one proposed here:  https://github.com/FluxML/Zygote.jl/issues/440#issuecomment-581906699