### PR TITLE
Restrict some linear algebra adjoints to matrices

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -342,13 +342,13 @@ end
 
 @adjoint diag(A::AbstractMatrix) = diag(A), Δ->(Diagonal(Δ),)
 
-@adjoint det(xs::AbstractMatrix) = det(xs), Δ -> (Δ * det(xs) * inv(xs)',)
+@adjoint det(xs::Union{Number, AbstractMatrix}) = det(xs), Δ -> (Δ * det(xs) * inv(xs)',)
 
-@adjoint logdet(xs::AbstractMatrix) = logdet(xs), Δ -> (Δ * inv(xs)',)
+@adjoint logdet(xs::Union{Number, AbstractMatrix}) = logdet(xs), Δ -> (Δ * inv(xs)',)
 
 @adjoint logabsdet(xs::AbstractMatrix) = logabsdet(xs), Δ -> (Δ[1] * inv(xs)',)
 
-@adjoint function inv(A::AbstractMatrix)
+@adjoint function inv(A::Union{Number, AbstractMatrix})
   Ainv = inv(A)
   return Ainv, function (Δ)
     ∇A = - Ainv' * Δ * Ainv'

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -342,13 +342,13 @@ end
 
 @adjoint diag(A::AbstractMatrix) = diag(A), Δ->(Diagonal(Δ),)
 
-@adjoint det(xs) = det(xs), Δ -> (Δ * det(xs) * inv(xs)',)
+@adjoint det(xs::AbstractMatrix) = det(xs), Δ -> (Δ * det(xs) * inv(xs)',)
 
-@adjoint logdet(xs) = logdet(xs), Δ -> (Δ * inv(xs)',)
+@adjoint logdet(xs::AbstractMatrix) = logdet(xs), Δ -> (Δ * inv(xs)',)
 
-@adjoint logabsdet(xs) = logabsdet(xs), Δ -> (Δ[1] * inv(xs)',)
+@adjoint logabsdet(xs::AbstractMatrix) = logabsdet(xs), Δ -> (Δ[1] * inv(xs)',)
 
-@adjoint function inv(A)
+@adjoint function inv(A::AbstractMatrix)
   Ainv = inv(A)
   return Ainv, function (Δ)
     ∇A = - Ainv' * Δ * Ainv'

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -110,6 +110,8 @@ end
 @test gradtest(det, (4, 4))
 @test gradtest(logdet, map(x -> x*x', (rand(4, 4),))[1])
 @test gradtest(x -> logabsdet(x)[1], (4, 4))
+@test gradient(det, 2.0)[1] == 1
+@test gradient(logdet, 2.0)[1] == 0.5
 
 @testset "getindex" begin
   @test gradtest(x -> x[:,2,:], (3,4,5))
@@ -389,6 +391,7 @@ end
   @test gradtest(pinv, A)
   @test gradtest(inv, B)
   @test gradtest(pinv, C)
+  @test gradient(inv, 2.0)[1] == -0.25
 end
 
 @testset "multiplication" begin


### PR DESCRIPTION
This PR restricts the adjoints that make sense for matrices to matrices. This PR fixes https://github.com/TuringLang/Bijectors.jl/issues/90.