### PR TITLE
Fix GPU broadcasting tests

### DIFF
--- a/test/cuda.jl
+++ b/test/cuda.jl
@@ -7,7 +7,7 @@ using CuArrays
 end
 
 @testset "basic bcasting" begin
-  a = cu(collect(1:9))
+  a = cu(Float32.(1:9))
   v(x, n) = x .^ n
   pow_grada = cu(Float32[7.0, 448.0, 5103.0, 28672.0, 109375.0, 326592.0, 823543.0, 1.835008e6, 3.720087e6])
   @test gradient(x -> v(x, 7) |> sum, a) == (pow_grada,)


### PR DESCRIPTION
Tests for the correctness of gradients when doing basic broadcasting over arrays on the GPU were added in #373. However, that was before GPU-enabled CI was set up on the repository, so the tests as written were not put through CI.

The issue with the tests as written are just that they use integers. This PR changes them to `Float32`, which should fix the `MethodError`s that occur when running these tests.

Can somebody with the appropriate permissions bors try this?