### PR TITLE
 Fix 'MethodError: no method matching ∇maxpool' error for NNlib.maxpool

### DIFF
--- a/src/lib/nnlib.jl
+++ b/src/lib/nnlib.jl
@@ -67,12 +67,12 @@ colmajor(::AbstractColumnMajor, x) = x
        )
    end
 
-@adjoint function maxpool(x, pdims; kw...)
+@adjoint function maxpool(x, pdims::NNlib.PoolDims; kw...)
   y = maxpool(x, pdims; kw...)
   y, Δ -> (NNlib.∇maxpool(Δ, y, x, pdims; kw...), nothing)
 end
 
-@adjoint function meanpool(x, pdims; kw...)
+@adjoint function meanpool(x, pdims::NNlib.PoolDims; kw...)
   y = meanpool(x, pdims; kw...)
   y, Δ -> (NNlib.∇meanpool(Δ, y, x, pdims; kw...), nothing)
 end

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -220,6 +220,13 @@ end
   @test gradtest(x -> meanpool(x, pdims), x)
   @test gradtest(x -> sum(maxpool(x, pdims)), x)
   @test gradtest(x -> sum(meanpool(x, pdims)), x)
+
+  #https://github.com/FluxML/NNlib.jl/issues/188
+  k = ntuple(_ -> 2, spatial_rank)  # Kernel size of pool in ntuple format
+  @test gradtest(x -> maxpool(x, k), x)
+  @test gradtest(x -> meanpool(x, k), x)
+  @test gradtest(x -> sum(maxpool(x, k)), x)
+  @test gradtest(x -> sum(meanpool(x, k)), x)
 end
 
 @test gradtest(x -> reverse(x), rand(17))


### PR DESCRIPTION
Fix [FluxML/NNlib.jl/issues/188](https://github.com/FluxML/NNlib.jl/issues/188)

- Added type-assertion to `pdims` which caused error while computing gradient for NNlib.maxpool and NNlib.meanpool
- Added test for maxpool and meanpool which inputs `k::NTuple{N, Integer}` instead of `pdims::PoolDims`