### PR TITLE
add broadcasting for subtraction

### DIFF
--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -68,6 +68,9 @@ Numeric{T<:Number} = Union{T,AbstractArray{<:T}}
 @adjoint broadcasted(::typeof(+), xs::Numeric...) =
   broadcast(+, xs...), ȳ -> (nothing, map(x -> unbroadcast(x, ȳ), xs)...)
 
+@adjoint broadcasted(::typeof(-), x::Numeric, y::Numeric) = x .- y,
+  Δ -> (nothing, unbroadcast(x, Δ), -unbroadcast(y, Δ))
+
 @adjoint broadcasted(::typeof(*), x::Numeric, y::Numeric) = x.*y,
   z̄ -> (nothing, unbroadcast(x, z̄ .* conj.(y)), unbroadcast(y, z̄ .* conj.(x)))
 


### PR DESCRIPTION
This pull request adds a `@adjoint broadcasted(::typeof(-), x, y)` such that expressions like
`gradient(x -> sum(x .- 1), x)` and `gradient(x -> sum(x .+ (-1)), x)` become equally performant. (Before, the performance of the former was significantly inferior to the latter, both for `Array`s and `CuArray`s.)