### PR TITLE
stop running functions in init

### DIFF
--- a/src/Zygote.jl
+++ b/src/Zygote.jl
@@ -45,9 +45,6 @@ end
 
 precompile() = include(joinpath(@__DIR__, "precompile.jl"))
 
-# precompile()
-@init Requires.isprecompiling() || precompile()
-
 # helps to work around 265-y issues
 function refresh()
   include(joinpath(@__DIR__, "compiler/interface2.jl"))


### PR DESCRIPTION
Zygote currently does the same thing as CSV used to do (https://github.com/JuliaData/CSV.jl/issues/324) which is to run some representative functions in `__init__` to make the first call look faster. In reality, this just shifts the latency in the first call to package load time. The problem is that Zygote can be loaded in a Julia session without necessarily getting called. In those scenarios, users have to pay the compilation cost anyway which makes it more costly to have Zygote as a dependency. 

