### PR TITLE
Tweaks euclidean distance

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Zygote"
 uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
-version = "0.4.15"
+version = "0.4.16"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/lib/distances.jl
+++ b/src/lib/distances.jl
@@ -65,7 +65,7 @@ end
 end
 
 @adjoint function pairwise(::Euclidean, X::AbstractMatrix, Y::AbstractMatrix; dims=2)
-  D, back = pullback((X, Y) -> pairwise(SqEuclidean(), X, Y; dims = dims), X, Y)
+  D, back = pullback((X, Y) -> pairwise(SqEuclidean(100 * eps()), X, Y; dims = dims), X, Y)
   D .= sqrt.(D)
   return D, Δ -> (nothing, back(Δ ./ (2 .* D))...)
 end

--- a/src/lib/distances.jl
+++ b/src/lib/distances.jl
@@ -65,7 +65,11 @@ end
 end
 
 @adjoint function pairwise(::Euclidean, X::AbstractMatrix, Y::AbstractMatrix; dims=2)
-  D, back = pullback((X, Y) -> pairwise(SqEuclidean(100 * eps()), X, Y; dims = dims), X, Y)
+  D, back = pullback(
+    (X, Y) -> pairwise(SqEuclidean(100 * eps(eltype(X))), X, Y; dims = dims),
+    X,
+    Y,
+  )
   D .= sqrt.(D)
   return D, Δ -> (nothing, back(Δ ./ (2 .* D))...)
 end

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -1040,6 +1040,14 @@ end
       @test gradtest(Y->pairwise(metric, X, Y; dims=2), Y)
     end
 
+    # Check binary pairwise when X and Y are close.
+    let
+      X = randn(rng, D, P)
+      Y = X .+ 1e-10
+      dist = pairwise(metric, X, Y; dims=2)
+      @test first(pullback((X, Y)->pairwise(metric, X, Y; dims=2), X, Y)) ≈ dist
+    end
+
     let
       Xt, Yt = randn(rng, P, D), randn(rng, Q, D)
       @test gradtest(Xt->pairwise(metric, Xt, Yt; dims=1), Xt)


### PR DESCRIPTION
Makes the `SqEuclidean` computation recompute if there are potentially roundoff errors in the forwards pass. This makes it possible to use Zygote to propagate gradient information when inputs are close together. Prior to this change you wind up with negative arguments to `sqrt`.