### PR TITLE
@nograd randn!

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -1,13 +1,14 @@
 using FillArrays, AbstractFFTs
 using FillArrays: AbstractFill, getindex_value
 using Base.Broadcast: broadcasted, broadcast_shape
+import Random.randn!
 
 @adjoint (::Type{T})(::UndefInitializer, args...) where T<:Array = T(undef, args...), Δ -> nothing
 
 @adjoint Array(xs::AbstractArray) = Array(xs), ȳ -> (ȳ,)
 @adjoint Array(xs::Array) = Array(xs), ȳ -> (ȳ,)
 
-@nograd size, length, eachindex, axes, Colon(), findfirst, findlast, findall, randn, ones, zeros, one, zero,
+@nograd size, length, eachindex, axes, Colon(), findfirst, findlast, findall, randn, randn!, ones, zeros, one, zero,
   any, all
 
 @adjoint rand(dims::Integer...) = rand(dims...), _ -> nothing


### PR DESCRIPTION
It's very commonplace when using Flux with CuArrays to write `x = randn!(similar(y, (16,32)))` rather than `randn(16,32)` because this works equally well whether or not the input `y` is an `Array` or `CuArray`.

This PR adds `@nograd` for `randn!`, whereas right now it is only reserved for `randn`.