### PR TITLE
copyto! for Params and Grads

### DIFF
--- a/docs/src/utils.md
+++ b/docs/src/utils.md
@@ -12,4 +12,5 @@ Zygote.hessian
 Zygote.Buffer
 Zygote.forwarddiff
 Zygote.nograd
+copyto!
 ```

--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -91,7 +91,7 @@ end
     copyto!(x::AbstractVector, ps::Params)
     
 Copies the content of array `x` into the parameters `ps` or viceversa.
-The length of `x` has to be equal to the sum of the lenghts
+The length of `x` has to be equal to the sum of the lengths
 of all parameters.
 """
 function Base.copyto!(ps::Params, x::AbstractVector)

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -6,3 +6,27 @@
   @test length(ps.order) == length(ps.params) == 1
   @test first(ps.order) == first(ps.params) == w
 end
+
+@teset "copyto!" begin
+  x = [0,0]
+  ps = Params([x])
+  copyto!(ps, [1, 2])
+  @test x == [1, 2]
+  
+  x = [0,0]
+  y = [0]
+  ps = Params([x, y])
+  copyto!(ps, [1, 2, 3])
+  @test x == [1, 2]
+  @test y == [3]
+
+  ps = Params([[1,2]])
+  x = [0, 0]
+  copyto!(x, ps)
+  @test x == [1, 2]
+  
+  ps = Params([[1,2], [3]])
+  x = [0, 0, 0]
+  copyto!(x, ps)
+  @test x == [1, 2, 3]
+end

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -7,7 +7,7 @@
   @test first(ps.order) == first(ps.params) == w
 end
 
-@teset "copyto!" begin
+@testset "copyto!" begin
   x = [0,0]
   ps = Params([x])
   copyto!(ps, [1, 2])


### PR DESCRIPTION
Implement `copyto!`, copying params and gradients to flat vectors (and viceversa). This can be convenient for interoperability with other libraries in the julia ecosystem, e.g. [see this for Optim.jl](https://github.com/baggepinnen/FluxOptTools.jl/blob/master/src/FluxOptTools.jl)

I had to add an extra field to Grads containing the original params object, since Grads sometimes contain some extra elements. I don't think this is a problem. cc @baggepinnen 