### PR TITLE
utils for Optim.jl

### DIFF
--- a/src/Zygote.jl
+++ b/src/Zygote.jl
@@ -31,6 +31,7 @@ include("lib/nnlib.jl")
 include("lib/forward.jl")
 include("lib/utils.jl")
 include("lib/range.jl")
+include("lib/optim.jl")
 @init @require Distances="b4f34e82-e78d-54a5-968a-f98e89d6e8f7" include("lib/distances.jl")
 @init @require StatsFuns="4c63d2b9-4356-54db-8cca-17b64c39e42c" include("lib/statsfuns.jl")
 

--- a/src/lib/optim.jl
+++ b/src/lib/optim.jl
@@ -1,0 +1,28 @@
+# Interoperability with Optim.jl
+
+function optim_funs(loss, ps::Params)
+    function f(w)
+        copyto!(ps, w)
+        loss()
+    end
+    
+    function g!(G, w)
+        copyto!(ps, w)
+        gs = gradient(loss, ps)
+        copyto!(G, gs)
+    end
+    
+    function fg!(F, G, w)
+        copyto!(ps, w)
+        l, back = pullback(loss, ps)        
+        if G !== nothing
+            gs = back(1)
+            copyto!(G, gs)
+        end
+        return l
+    end
+
+    x0 = vcat((vec(p) for p in ps)...)
+    
+    f, g!, fg!, x0
+end


### PR DESCRIPTION
a convenience function for interoperability with Optim.jl, essentially taken from https://github.com/baggepinnen/FluxOptTools.jl. cc @baggepinnen  
It would be nice to have this here since it is just a few lines of code carrying no extra dependencies. 
Needs #611 to be merged first