### PR TITLE
accum_zero

### DIFF
--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -44,9 +44,12 @@ accum_sum(xs::AbstractArray{<:AbstractArray{<:Number}}; dims = :) = sum(xs, dims
 accum_sum(xs::Number; dims = :) = xs
 
 # https://github.com/FluxML/Zygote.jl/issues/594
-function Base.reducedim_init(::typeof(identity), ::typeof(accum), A::AbstractArray, region)
-  Base.reducedim_initarray(A, region, nothing, Union{Nothing,eltype(A)})
-end
+accum_zero(::Type{T}) where {T} = zero(T)
+accum_zero(::Type{<:Nothing}) = nothing
+accum_zero(::Type{S}) where {names,types,S<:NamedTuple{names,types}} =
+  S(accum_zero.(types.types))
+accum_sum(xs::AbstractArray{T}; dims=:) where {T<:NamedTuple} =
+  reduce(accum, xs; dims=dims, init=accum_zero(T))
 
 trim(x, Δ) = reshape(Δ, ntuple(i -> size(Δ, i), Val(ndims(x))))
 

--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -44,8 +44,8 @@ accum_sum(xs::AbstractArray{<:AbstractArray{<:Number}}; dims = :) = sum(xs, dims
 accum_sum(xs::Number; dims = :) = xs
 
 # https://github.com/FluxML/Zygote.jl/issues/594
-accum_zero(::Type{T}) where {T} = zero(T)
-accum_zero(::Type{<:Nothing}) = nothing
+accum_zero(::Type) = nothing
+accum_zero(::Type{T}) where {T<:Number} = zero(T)
 accum_zero(::Type{S}) where {names,types,S<:NamedTuple{names,types}} =
   S(accum_zero.(types.types))
 accum_sum(xs::AbstractArray{T}; dims=:) where {T<:NamedTuple} =

--- a/test/structures.jl
+++ b/test/structures.jl
@@ -45,10 +45,21 @@ end
 @testset "#594" begin
   struct A x::Float64 end
   f(a,v) = a.x + v
-  g(A,V) = sum(f.(A,V))
+  g(X,Y) = sum(f.(X,Y))
   X = A.(randn(2))
   Y = randn(2,2)
   ∇ = gradient(g,X,Y)
   @test ∇[1] == [(x = 2.0,); (x = 2.0,)]
+  @test ∇[2] == [1 1; 1 1]
+end
+
+@testset "#594 2" begin
+  struct B x::Float64; y::Float64 end
+  f(a,v) = a.x + v
+  g(X,Y) = sum(f.(X,Y))
+  X = B.(randn(2),randn(2))
+  Y = randn(2,2)
+  ∇ = gradient(g,X,Y)
+  @test ∇[1] == [(x=2.0, y=nothing); (x=2.0, y=nothing)]
   @test ∇[2] == [1 1; 1 1]
 end


### PR DESCRIPTION
https://github.com/FluxML/Zygote.jl/pull/613 is not type-stable. This version should be type-stable.
See https://github.com/FluxML/Zygote.jl/issues/594.

Currently tests fail, because `accum_zero` is capturing cases it shouldn't.

@CarloLucibello @MikeInnes 