### PR TITLE
SnoopCompile bot

### DIFF
--- a/.github/workflows/SnoopCompile.yml
+++ b/.github/workflows/SnoopCompile.yml
@@ -73,7 +73,7 @@ jobs:
           # committer: YOUR NAME <yourEmail@something.com> # Change `committer` to your name and your email.
           title: "[AUTO] Update precompiles'"
           labels: SnoopCompile
-          branch: "SnoopCompile"
+          branch: "SnoopCompile_AutoPR"
 
 
   Skip:

--- a/.github/workflows/SnoopCompile.yml
+++ b/.github/workflows/SnoopCompile.yml
@@ -1,0 +1,84 @@
+name: SnoopCompile
+
+# Only runs on pushes. Edit based on your taste.
+on:
+  push:
+    branches:
+      # - 'master'
+  pull_request:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  SnoopCompile:
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # Uncomment other versions if you want multi-version signatures (should exactly match BotConfig.version):
+        version:
+          - '1.4.1'
+          # - '1.2.0'
+          # - '1.0.5'
+        # Uncomment other options if you want multi-os signatures (currently only these are supported by Github):
+        os:
+          - ubuntu-latest
+          # - windows-latest
+          # - macos-latest
+        arch:
+          - x64
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: ${{ matrix.julia-version }}
+      - name: Install dependencies
+        run: |
+          julia --project -e 'using Pkg; Pkg.instantiate();'
+          julia -e 'using Pkg; Pkg.add(PackageSpec(url = "https://github.com/aminya/SnoopCompile.jl", rev = "multios")); Pkg.develop(PackageSpec(; path=pwd())); Pkg.add("JuliaFormatter"); using SnoopCompile; SnoopCompile.addtestdep();'
+      - name: Generating precompile files
+        run: julia --project -e 'include("deps/SnoopCompile/snoopi_bot.jl")'
+      - name: Running Benchmark
+        run: julia --project -e 'include("deps/SnoopCompile/snoopi_bench.jl")'
+      - name: Format precompile_includer.jl
+        run: julia --project -e 'using JuliaFormatter; format_file("src/precompile_includer.jl")'
+      - name: Upload all
+        uses: actions/upload-artifact@v2-preview
+        with:
+          path: ./
+
+  Create_PR:
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    needs: SnoopCompile
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all
+        uses: actions/download-artifact@v2-preview
+      - name: Move the content of the directory to the root
+        run: |
+          mv -v artifact/* ./
+          mv -v artifact/.[^.]* ./
+      - name: Discard unrelated changes
+        run: |
+          git checkout -- Project.toml
+          git diff -w --no-color | git apply --cached --ignore-whitespace && git checkout -- . && git reset && git add -p
+      - name: Create Pull Request
+        # https://github.com/marketplace/actions/create-pull-request
+        uses: peter-evans/create-pull-request@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: Update precompile_*.jl file
+          # committer: YOUR NAME <yourEmail@something.com> # Change `committer` to your name and your email.
+          title: "[AUTO] Update precompiles'"
+          labels: SnoopCompile
+          branch: "SnoopCompile"
+
+
+  Skip:
+    if: "contains(github.event.head_commit.message, '[skip ci]')"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip CI 🚫
+        run: echo skip ci

--- a/.github/workflows/SnoopCompile.yml
+++ b/.github/workflows/SnoopCompile.yml
@@ -1,11 +1,11 @@
 name: SnoopCompile
 
-# Only runs on pushes. Edit based on your taste.
+# Edit based on your repository.
 on:
   push:
     branches:
-      # - 'master'
-  pull_request:
+      # - 'master' # Uncomment for big repositories
+  pull_request:  # Comment for big repositories
 
 defaults:
   run:
@@ -21,12 +21,12 @@ jobs:
         version:
           - '1.4.1'
           # - '1.2.0'
-          # - '1.0.5'
+          - '1.0.5'
         # Uncomment other options if you want multi-os signatures (currently only these are supported by Github):
         os:
           - ubuntu-latest
-          # - windows-latest
-          # - macos-latest
+          - windows-latest
+          - macos-latest
         arch:
           - x64
     steps:

--- a/.github/workflows/SnoopCompile.yml
+++ b/.github/workflows/SnoopCompile.yml
@@ -22,7 +22,7 @@ jobs:
         version:
           - '1.4.1'
           - '1.3.1'
-          - '1.2.0' # min
+          # - '1.2.0' # min
         # Uncomment other options if you want multi-os signatures (currently only these are supported by Github):
         os:
           - ubuntu-latest

--- a/.github/workflows/SnoopCompile.yml
+++ b/.github/workflows/SnoopCompile.yml
@@ -5,8 +5,8 @@ name: SnoopCompile
 on:
   push:
     branches:
-      - 'master' # use for big repositories
-  # pull_request:
+      # - 'master'
+  # pull_request:  # comment for big repositories
 
 defaults:
   run:
@@ -21,8 +21,8 @@ jobs:
         # Uncomment other versions if you want multi-version signatures (should exactly match BotConfig.version):
         version:
           - '1.4.1'
-          # - '1.2.0'
-          - '1.0.5'
+          - '1.3.1'
+          - '1.2.0' # min
         # Uncomment other options if you want multi-os signatures (currently only these are supported by Github):
         os:
           - ubuntu-latest
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest
         with:
-          version: ${{ matrix.julia-version }}
+          version: ${{ matrix.version }}
       - name: Install dependencies
         run: |
           julia --project -e 'using Pkg; Pkg.instantiate();'

--- a/.github/workflows/SnoopCompile.yml
+++ b/.github/workflows/SnoopCompile.yml
@@ -1,11 +1,12 @@
 name: SnoopCompile
 
+
 # Edit based on your repository.
 on:
   push:
     branches:
-      # - 'master' # Uncomment for big repositories
-  pull_request:  # Comment for big repositories
+      - 'master' # use for big repositories
+  # pull_request:
 
 defaults:
   run:
@@ -71,7 +72,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: Update precompile_*.jl file
           # committer: YOUR NAME <yourEmail@something.com> # Change `committer` to your name and your email.
-          title: "[AUTO] Update precompiles'"
+          title: "[AUTO] Update precompiles"
           labels: SnoopCompile
           branch: "SnoopCompile_AutoPR"
 

--- a/.github/workflows/SnoopCompile.yml
+++ b/.github/workflows/SnoopCompile.yml
@@ -38,15 +38,13 @@ jobs:
       - name: Install dependencies
         run: |
           julia --project -e 'using Pkg; Pkg.instantiate();'
-          julia -e 'using Pkg; Pkg.add(PackageSpec(url = "https://github.com/aminya/SnoopCompile.jl", rev = "multios")); Pkg.develop(PackageSpec(; path=pwd())); Pkg.add("JuliaFormatter"); using SnoopCompile; SnoopCompile.addtestdep();'
+          julia -e 'using Pkg; Pkg.add(PackageSpec(url = "https://github.com/aminya/SnoopCompile.jl", rev = "multios")); Pkg.develop(PackageSpec(; path=pwd())); using SnoopCompile; SnoopCompile.addtestdep();'
       - name: Generating precompile files
         run: julia --project -e 'include("deps/SnoopCompile/snoopi_bot.jl")'
       - name: Running Benchmark
         run: julia --project -e 'include("deps/SnoopCompile/snoopi_bench.jl")'
-      - name: Format precompile_includer.jl
-        run: julia --project -e 'using JuliaFormatter; format_file("src/precompile_includer.jl")'
       - name: Upload all
-        uses: actions/upload-artifact@v2-preview
+        uses: actions/upload-artifact@v2
         with:
           path: ./
 
@@ -55,16 +53,20 @@ jobs:
     needs: SnoopCompile
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - name: Download all
-        uses: actions/download-artifact@v2-preview
+        uses: actions/download-artifact@v2
       - name: Move the content of the directory to the root
         run: |
-          mv -v artifact/* ./
-          mv -v artifact/.[^.]* ./
+          rsync -a artifact/* ./
+          rm -d -r artifact
       - name: Discard unrelated changes
         run: |
-          git checkout -- Project.toml
-          git diff -w --no-color | git apply --cached --ignore-whitespace && git checkout -- . && git reset && git add -p
+          test -f 'Project.toml' && git checkout -- 'Project.toml'
+          git ls-files 'Manifest.toml' | grep . && git checkout -- 'Manifest.toml'
+          (git diff -w --no-color || git apply --cached --ignore-whitespace && git checkout -- . && git reset && git add -p) || echo done
+      - name: Format precompile_includer.jl
+        run: julia -e 'using Pkg; Pkg.add("JuliaFormatter"); using JuliaFormatter; format_file("src/precompile_includer.jl")'
       - name: Create Pull Request
         # https://github.com/marketplace/actions/create-pull-request
         uses: peter-evans/create-pull-request@v2

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
 <img width="400px" src="https://raw.githubusercontent.com/FluxML/fluxml.github.io/master/zygote.png"/>
-</p>
+</p> 
 
 [![Build Status](https://travis-ci.org/FluxML/Zygote.jl.svg?branch=master)](https://travis-ci.org/FluxML/Zygote.jl) [![Dev Docs](https://img.shields.io/badge/docs-dev-blue.svg)](https://fluxml.ai/Zygote.jl/dev)
 

--- a/deps/SnoopCompile/example_script.jl
+++ b/deps/SnoopCompile/example_script.jl
@@ -1,3 +1,4 @@
+using Zygote
 using InteractiveUtils
 
 function pow(x, n)
@@ -12,11 +13,11 @@ end
 # Invoking the compiler outside of the genfuncs appears
 # to make the specialised versions visible inside them,
 # leading to a significant first-compile speedup.
-@code_adjoint pow(2, 3)
+Zygote.@code_adjoint pow(2, 3)
 
-@code_adjoint ((x, y) -> sum(x.*y))([1,2,3],[4,5,6])
+Zygote.@code_adjoint ((x, y) -> sum(x.*y))([1,2,3],[4,5,6])
 
-gradient(pow, 2, 3)
-gradient((x, y) -> sum(x.*y), [1, 2, 3], [4, 5, 6])
+Zygote.gradient(pow, 2, 3)
+Zygote.gradient((x, y) -> sum(x.*y), [1, 2, 3], [4, 5, 6])
 
-gradient(x -> sum(Float32.(x)), [1.0])
+Zygote.gradient(x -> sum(Float32.(x)), [1.0])

--- a/deps/SnoopCompile/example_script.jl
+++ b/deps/SnoopCompile/example_script.jl
@@ -21,3 +21,8 @@ Zygote.gradient(pow, 2, 3)
 Zygote.gradient((x, y) -> sum(x.*y), [1, 2, 3], [4, 5, 6])
 
 Zygote.gradient(x -> sum(Float32.(x)), [1.0])
+
+
+# Run the tests
+testdir = joinpath(dirname(dirname(@__DIR__)), "test")
+include("$testdir/runtests.jl")

--- a/deps/SnoopCompile/snoopi_bench.jl
+++ b/deps/SnoopCompile/snoopi_bench.jl
@@ -7,5 +7,7 @@ end
 
 println("Benchmarking the inference time of `using Zygote` & basic function test")
 @snoopi_bench BotConfig("Zygote") begin
-    include("example_script.jl")
+    using Zygote
+    zygote_rootpath = dirname(dirname(pathof(Zygote)))
+    include("$zygote_rootpath/deps/SnoopCompile/example_script.jl")
 end

--- a/deps/SnoopCompile/snoopi_bench.jl
+++ b/deps/SnoopCompile/snoopi_bench.jl
@@ -1,13 +1,14 @@
 using SnoopCompile
 
 println("Benchmarking the inference time of `using Zygote`")
-@snoopi_bench BotConfig("Zygote") begin
-    using Zygote
-end
+snoopi_bench(
+  BotConfig("Zygote"; os = ["linux", "windows", "macos"], version = [v"1.4.1", v"1.0.5"]),
+  :(using Zygote)
+)
+
 
 println("Benchmarking the inference time of `using Zygote` & basic function test")
-@snoopi_bench BotConfig("Zygote") begin
-    using Zygote
-    zygote_rootpath = dirname(dirname(pathof(Zygote)))
-    include("$zygote_rootpath/deps/SnoopCompile/example_script.jl")
-end
+snoopi_bench(
+  BotConfig("Zygote"; os = ["linux", "windows", "macos"], version = [v"1.4.1", v"1.0.5"]),
+  "$(@__DIR__)/example_script.jl",
+)

--- a/deps/SnoopCompile/snoopi_bench.jl
+++ b/deps/SnoopCompile/snoopi_bench.jl
@@ -1,0 +1,11 @@
+using SnoopCompile
+
+println("Benchmarking the inference time of `using Zygote`")
+@snoopi_bench BotConfig("Zygote") begin
+    using Zygote
+end
+
+println("Benchmarking the inference time of `using Zygote` & basic function test")
+@snoopi_bench BotConfig("Zygote") begin
+    include("example_script.jl")
+end

--- a/deps/SnoopCompile/snoopi_bench.jl
+++ b/deps/SnoopCompile/snoopi_bench.jl
@@ -2,7 +2,7 @@ using SnoopCompile
 
 println("Benchmarking the inference time of `using Zygote`")
 snoopi_bench(
-  BotConfig("Zygote"; os = ["linux", "windows", "macos"], version = [v"1.4.1", v"1.3.1", v"1.2.0"]),
+  BotConfig("Zygote"; os = ["linux", "windows", "macos"], version = [v"1.4.1", v"1.3.1"]),
   :(using Zygote)
 )
 

--- a/deps/SnoopCompile/snoopi_bench.jl
+++ b/deps/SnoopCompile/snoopi_bench.jl
@@ -1,14 +1,23 @@
 using SnoopCompile
 
+botconfig = BotConfig(
+  "Zygote";
+  os = ["linux", "windows", "macos"],
+  version = [v"1.4.1", v"1.3.1"],
+  blacklist = ["SqEuclidean"],
+  exhaustive = false,
+)
+
+
 println("Benchmarking the inference time of `using Zygote`")
 snoopi_bench(
-  BotConfig("Zygote"; os = ["linux", "windows", "macos"], version = [v"1.4.1", v"1.3.1"]),
-  :(using Zygote)
+  botconfig,
+  :(using Zygote),
 )
 
 
 println("Benchmarking the inference time of `using Zygote` & basic function test")
 snoopi_bench(
-  BotConfig("Zygote"; os = ["linux", "windows", "macos"], version = [v"1.4.1", v"1.3.1", v"1.2.0"]),
+  botconfig,
   "$(@__DIR__)/example_script.jl",
 )

--- a/deps/SnoopCompile/snoopi_bench.jl
+++ b/deps/SnoopCompile/snoopi_bench.jl
@@ -2,13 +2,13 @@ using SnoopCompile
 
 println("Benchmarking the inference time of `using Zygote`")
 snoopi_bench(
-  BotConfig("Zygote"; os = ["linux", "windows", "macos"], version = [v"1.4.1", v"1.0.5"]),
+  BotConfig("Zygote"; os = ["linux", "windows", "macos"], version = [v"1.4.1", v"1.3.1", v"1.2.0"]),
   :(using Zygote)
 )
 
 
 println("Benchmarking the inference time of `using Zygote` & basic function test")
 snoopi_bench(
-  BotConfig("Zygote"; os = ["linux", "windows", "macos"], version = [v"1.4.1", v"1.0.5"]),
+  BotConfig("Zygote"; os = ["linux", "windows", "macos"], version = [v"1.4.1", v"1.3.1", v"1.2.0"]),
   "$(@__DIR__)/example_script.jl",
 )

--- a/deps/SnoopCompile/snoopi_bot.jl
+++ b/deps/SnoopCompile/snoopi_bot.jl
@@ -1,0 +1,6 @@
+using SnoopCompile
+
+@snoopi_bot BotConfig("Zygote") begin
+  # we should hide them in a file, so Julia doesn't exapnd the macros before executing `using Zygote`
+  include("example_script.jl")
+end

--- a/deps/SnoopCompile/snoopi_bot.jl
+++ b/deps/SnoopCompile/snoopi_bot.jl
@@ -2,5 +2,7 @@ using SnoopCompile
 
 @snoopi_bot BotConfig("Zygote") begin
   # we should hide them in a file, so Julia doesn't exapnd the macros before executing `using Zygote`
-  include("example_script.jl")
+  using Zygote
+  zygote_rootpath = dirname(dirname(pathof(Zygote)))
+  include("$zygote_rootpath/deps/SnoopCompile/example_script.jl")
 end

--- a/deps/SnoopCompile/snoopi_bot.jl
+++ b/deps/SnoopCompile/snoopi_bot.jl
@@ -1,8 +1,6 @@
 using SnoopCompile
 
-@snoopi_bot BotConfig("Zygote") begin
-  # we should hide them in a file, so Julia doesn't exapnd the macros before executing `using Zygote`
-  using Zygote
-  zygote_rootpath = dirname(dirname(pathof(Zygote)))
-  include("$zygote_rootpath/deps/SnoopCompile/example_script.jl")
-end
+snoopi_bot(
+  BotConfig("Zygote"; os = ["linux", "windows", "macos"], version = [v"1.4.1", v"1.0.5"]),
+  "$(@__DIR__)/example_script.jl",
+)

--- a/deps/SnoopCompile/snoopi_bot.jl
+++ b/deps/SnoopCompile/snoopi_bot.jl
@@ -1,6 +1,14 @@
 using SnoopCompile
 
+botconfig = BotConfig(
+  "Zygote";
+  os = ["linux", "windows", "macos"],
+  version = [v"1.4.1", v"1.3.1"],
+  blacklist = ["SqEuclidean"],
+  exhaustive = false,
+)
+
 snoopi_bot(
-  BotConfig("Zygote"; os = ["linux", "windows", "macos"], version = [v"1.4.1", v"1.3.1"]),
+  botconfig,
   "$(@__DIR__)/example_script.jl",
 )

--- a/deps/SnoopCompile/snoopi_bot.jl
+++ b/deps/SnoopCompile/snoopi_bot.jl
@@ -1,6 +1,6 @@
 using SnoopCompile
 
 snoopi_bot(
-  BotConfig("Zygote"; os = ["linux", "windows", "macos"], version = [v"1.4.1", v"1.3.1", v"1.2.0"]),
+  BotConfig("Zygote"; os = ["linux", "windows", "macos"], version = [v"1.4.1", v"1.3.1"]),
   "$(@__DIR__)/example_script.jl",
 )

--- a/deps/SnoopCompile/snoopi_bot.jl
+++ b/deps/SnoopCompile/snoopi_bot.jl
@@ -1,6 +1,6 @@
 using SnoopCompile
 
 snoopi_bot(
-  BotConfig("Zygote"; os = ["linux", "windows", "macos"], version = [v"1.4.1", v"1.0.5"]),
+  BotConfig("Zygote"; os = ["linux", "windows", "macos"], version = [v"1.4.1", v"1.3.1", v"1.2.0"]),
   "$(@__DIR__)/example_script.jl",
 )

--- a/src/Zygote.jl
+++ b/src/Zygote.jl
@@ -43,12 +43,9 @@ include("profiler/Profile.jl")
   include("flux.jl")
 end
 
-precompile() = include(joinpath(@__DIR__, "precompile.jl"))
-
 # helps to work around 265-y issues
 function refresh()
   include(joinpath(@__DIR__, "compiler/interface2.jl"))
-  precompile()
   return
 end
 

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -1308,64 +1308,68 @@ end
   @test gradtest(-, A)
 end
 
-@testset "AbstractFFTs" begin
-  findicateMat(i,j,n1,n2) = [(k==i) && (l==j) ? 1.0 : 0.0 for k=1:n1,
-                             l=1:n2]
-  mirrorIndex(i,N) = i - 2*max(0,i - (N>>1+1))
-  for sizeX in [(2,3), (10,10), (13,15)]
-    X = randn(sizeX)
-    X̂r = rfft(X)
-    X̂ = fft(X)
-    N = prod(sizeX)
-    for i=1:size(X,1), j=1:size(X,2)
-      indicateMat = [(k==i) && (l==j) ? 1.0 : 0.0 for k=1:size(X, 1),
-                     l=1:size(X,2)]
-      # gradient of ifft(fft) must be (approximately) 1 (for various cases)
-      @test gradient((X)->real.(ifft(fft(X))[i, j]), X)[1] ≈ indicateMat
-      # same for the inverse
-      @test gradient((X̂)->real.(fft(ifft(X̂))[i, j]), X̂)[1] ≈ indicateMat
-      # same for rfft(irfft)
-      @test gradient((X)->real.(irfft(rfft(X), size(X,1)))[i, j], X)[1] ≈ real.(indicateMat)
-      # rfft isn't actually surjective, so rffft(irfft) can't really be tested this way.
+if !isdefined(Main, :SnoopCompile_ENV) || SnoopCompile_ENV == false # some of these fail when they run inside SnoopCompile environment
 
-      # the gradients are actually just evaluating the inverse transform on the
-      # indicator matrix
-      mirrorI = mirrorIndex(i,sizeX[1])
-      FreqIndMat = findicateMat(mirrorI, j, size(X̂r,1), sizeX[2])
-      listOfSols = [(fft, bfft(indicateMat), bfft(indicateMat*im),
-                     plan_fft(X), i, X),
-                    (ifft, 1/N*fft(indicateMat), 1/N*fft(indicateMat*im),
-                     plan_fft(X), i, X),
-                    (bfft, fft(indicateMat), fft(indicateMat*im), nothing, i,
-                     X),
-                    (rfft, real.(brfft(FreqIndMat, sizeX[1])),
-                     real.(brfft(FreqIndMat*im, sizeX[1])), plan_rfft(X),
-                     mirrorI, X),
-                    ((K)->(irfft(K,sizeX[1])), 1/N * rfft(indicateMat),
-                     zeros(size(X̂r)), plan_rfft(X), i, X̂r)]
-      for (trans, solRe, solIm, P, mI, evalX) in listOfSols
-        @test gradient((X)->real.(trans(X))[mI, j], evalX)[1] ≈
-          solRe
-        @test gradient((X)->imag.(trans(X))[mI, j], evalX)[1] ≈
-          solIm
-        if typeof(P) <:AbstractFFTs.Plan && maximum(trans .== [fft,rfft])
-          @test gradient((X)->real.(P * X)[mI, j], evalX)[1] ≈
+  @testset "AbstractFFTs" begin
+    findicateMat(i,j,n1,n2) = [(k==i) && (l==j) ? 1.0 : 0.0 for k=1:n1,
+                               l=1:n2]
+    mirrorIndex(i,N) = i - 2*max(0,i - (N>>1+1))
+    for sizeX in [(2,3), (10,10), (13,15)]
+      X = randn(sizeX)
+      X̂r = rfft(X)
+      X̂ = fft(X)
+      N = prod(sizeX)
+      for i=1:size(X,1), j=1:size(X,2)
+        indicateMat = [(k==i) && (l==j) ? 1.0 : 0.0 for k=1:size(X, 1),
+                       l=1:size(X,2)]
+        # gradient of ifft(fft) must be (approximately) 1 (for various cases)
+        @test gradient((X)->real.(ifft(fft(X))[i, j]), X)[1] ≈ indicateMat
+        # same for the inverse
+        @test gradient((X̂)->real.(fft(ifft(X̂))[i, j]), X̂)[1] ≈ indicateMat
+        # same for rfft(irfft)
+        @test gradient((X)->real.(irfft(rfft(X), size(X,1)))[i, j], X)[1] ≈ real.(indicateMat)
+        # rfft isn't actually surjective, so rffft(irfft) can't really be tested this way.
+
+        # the gradients are actually just evaluating the inverse transform on the
+        # indicator matrix
+        mirrorI = mirrorIndex(i,sizeX[1])
+        FreqIndMat = findicateMat(mirrorI, j, size(X̂r,1), sizeX[2])
+        listOfSols = [(fft, bfft(indicateMat), bfft(indicateMat*im),
+                       plan_fft(X), i, X),
+                      (ifft, 1/N*fft(indicateMat), 1/N*fft(indicateMat*im),
+                       plan_fft(X), i, X),
+                      (bfft, fft(indicateMat), fft(indicateMat*im), nothing, i,
+                       X),
+                      (rfft, real.(brfft(FreqIndMat, sizeX[1])),
+                       real.(brfft(FreqIndMat*im, sizeX[1])), plan_rfft(X),
+                       mirrorI, X),
+                      ((K)->(irfft(K,sizeX[1])), 1/N * rfft(indicateMat),
+                       zeros(size(X̂r)), plan_rfft(X), i, X̂r)]
+        for (trans, solRe, solIm, P, mI, evalX) in listOfSols
+          @test gradient((X)->real.(trans(X))[mI, j], evalX)[1] ≈
             solRe
-          @test gradient((X)->imag.(P * X)[mI, j], evalX)[1] ≈
+          @test gradient((X)->imag.(trans(X))[mI, j], evalX)[1] ≈
             solIm
-        elseif typeof(P) <: AbstractFFTs.Plan
-          @test gradient((X)->real.(P \ X)[mI, j], evalX)[1] ≈
-            solRe
-          # for whatever reason the rfft_plan doesn't handle this case well,
-          # even though irfft does
-          if eltype(evalX) <: Real
-            @test gradient((X)->imag.(P \ X)[mI, j], evalX)[1] ≈
+          if typeof(P) <:AbstractFFTs.Plan && maximum(trans .== [fft,rfft])
+            @test gradient((X)->real.(P * X)[mI, j], evalX)[1] ≈
+              solRe
+            @test gradient((X)->imag.(P * X)[mI, j], evalX)[1] ≈
               solIm
+          elseif typeof(P) <: AbstractFFTs.Plan
+            @test gradient((X)->real.(P \ X)[mI, j], evalX)[1] ≈
+              solRe
+            # for whatever reason the rfft_plan doesn't handle this case well,
+            # even though irfft does
+            if eltype(evalX) <: Real
+              @test gradient((X)->imag.(P \ X)[mI, j], evalX)[1] ≈
+                solIm
+            end
           end
         end
       end
     end
-  end
+
+end
 
   x = [-0.353213 -0.789656 -0.270151; -0.95719 -1.27933 0.223982]
   # check ffts for individual dimensions
@@ -1424,7 +1428,7 @@ end
   @testset "broadcast +, -, *, /" begin
     for sx in [(M, N), (M, 1), (1, N), (1, 1)]
       for sy in [(M, N), (M, 1), (1, N), (1, 1)]
-        
+
         #addition, subtraction, multiplication
         for f ∈ (+, -, *)
           @test gradtest((x, y) -> f.(Fill(first(x), sx...), Fill(first(y), sy...)), [x], [y])


### PR DESCRIPTION
It uses the whole test suit of Zygote (except Cuda and Abstract FFT tests) for generating OS-Version specific precompilation sentences.

In running the tests shows that we get:
 - `10s` raw improvement  
 - `23 M` less memory usage
 - `1.16GiB` less memory allocation.

Tests:
- A successful run: https://github.com/aminya/Zygote.jl/actions/runs/95945010
- A successful PR created by the bot: https://github.com/aminya/Zygote.jl/pull/4/files which has precompilation sentences for Windows, Linux, macOS for Julia 1.4 and Julia 1.3.
The CI also passes for that generated PR: https://travis-ci.com/github/aminya/Zygote.jl/builds/162029060

cc: @ianshmean

related: https://github.com/FluxML/Zygote.jl/pull/607

The changes made in the tests are just adding two simple checks for existance of the `SnoopCompile_ENV`. GitHub diff isn't working properly here.

# Ready for review