### PR TITLE
adjoints for Transpose and Adjoint constructors

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -317,13 +317,27 @@ end
   return transpose(x), back
 end
 
+@adjoint function LinearAlgebra.Transpose(x)
+  back(Δ) = (LinearAlgebra.Transpose(Δ),)
+  back(Δ::NamedTuple{(:parent,)}) = (Δ.parent,)
+  return LinearAlgebra.Transpose(x), back
+end
+
+
 @adjoint function Base.adjoint(x)
   back(Δ) = (Δ',)
   back(Δ::NamedTuple{(:parent,)}) = (Δ.parent,)
   return x', back
 end
 
+@adjoint function LinearAlgebra.Adjoint(x)
+  back(Δ) = (LinearAlgebra.Adjoint(Δ),)
+  back(Δ::NamedTuple{(:parent,)}) = (Δ.parent,)
+  return LinearAlgebra.Adjoint(x), back
+end
+
 @adjoint parent(x::LinearAlgebra.Adjoint) = parent(x), ȳ -> (LinearAlgebra.Adjoint(ȳ),)
+@adjoint parent(x::LinearAlgebra.Transpose) = parent(x), ȳ -> (LinearAlgebra.Transpose(ȳ),)
 
 @adjoint dot(x::AbstractArray, y::AbstractArray) = dot(x, y), Δ->(Δ .* y, Δ .* x)
 

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -96,7 +96,12 @@ end
 @test gradtest((x, W, b) -> logσ.(W*x .+ b), (5,3), (2,5), 2)
 
 @test gradtest((w, x) -> w'*x, randn(10, 2), randn(10))
+@test gradtest((w, x) -> Adjoint(w)*x, randn(10, 2), randn(10))
 @test gradtest((w, x) -> transpose(w)*x, randn(5,5), randn(5,5))
+@test gradtest((w, x) -> Transpose(w)*x, randn(5,5), randn(5,5))
+
+@test gradtest((w, x) -> parent(w)*x, randn(5,5)', randn(5,5))
+@test gradtest((w, x) -> parent(w)*x, transpose(randn(5,5)), randn(5,5))
 
 @test gradtest(x -> sum(x, dims = (2, 3)), (3,4,5))
 @test gradtest(x -> sum(abs2, x), randn(4, 3, 2))
@@ -453,6 +458,7 @@ end
     @test gradtest(*, randn(rng, M, P), randn(rng, P))
     @test gradtest(*, randn(rng, M, 1), randn(rng, 1, Q))
     @test gradtest(*, randn(rng, M), randn(rng, 1, Q))
+    @test gradtest(*, randn(rng, 10)', randn(rng, 10))
     @test gradtest(*, randn(rng, 10)', randn(rng, 10))
 
     let


### PR DESCRIPTION
Add adjoints for the lower level `Transpose` and `Adjoint` constructors. I also added an adjoint for `parent(::Transpose)` while I was at it. These shouldn't get called a lot directly, but I think we might as well have them. This came up in https://discourse.julialang.org/t/zygote-gradient-error/38206.