### PR TITLE
more interface utils for Params

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -8,18 +8,18 @@ version = "0.5.0"
 
 [[ArrayLayouts]]
 deps = ["FillArrays", "LinearAlgebra"]
-git-tree-sha1 = "f8904599065b57f51715faf6278126f853aef6fc"
+git-tree-sha1 = "5a57a6158c1d340635a89d19beb34b0f325a4431"
 uuid = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
-version = "0.2.4"
+version = "0.2.5"
 
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[BinaryProvider]]
-deps = ["Libdl", "SHA"]
-git-tree-sha1 = "5b08ed6036d9d3f0ee6369410b830f8873d4024c"
+deps = ["Libdl", "Logging", "SHA"]
+git-tree-sha1 = "428e9106b1ff27593cbd979afac9b45b82372b8c"
 uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
-version = "0.5.8"
+version = "0.5.9"
 
 [[CommonSubexpressions]]
 deps = ["Test"]

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -67,9 +67,9 @@ version = "0.10.10"
 
 [[IRTools]]
 deps = ["InteractiveUtils", "MacroTools", "Test"]
-git-tree-sha1 = "1a4355e4b5b50be2311ebb644f34f3306dbd0410"
+git-tree-sha1 = "8845400bd2d9815d37720251f1b53d27a335e1f4"
 uuid = "7869d1d1-7146-5819-86e3-90919afe41df"
-version = "0.3.1"
+version = "0.3.2"
 
 [[InteractiveUtils]]
 deps = ["Markdown"]
@@ -159,9 +159,9 @@ version = "0.10.0"
 
 [[StaticArrays]]
 deps = ["LinearAlgebra", "Random", "Statistics"]
-git-tree-sha1 = "5a3bcb6233adabde68ebc97be66e95dcb787424c"
+git-tree-sha1 = "4118cba3529e99af61aea9a83f7bfd3cff5ffb28"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "0.12.1"
+version = "0.12.2"
 
 [[Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Zygote"
 uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
-version = "0.4.17"
+version = "0.4.18"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -19,9 +19,9 @@ version = "0.8.1"
 
 [[Documenter]]
 deps = ["Base64", "Dates", "DocStringExtensions", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Test", "Unicode"]
-git-tree-sha1 = "646ebc3db49889ffeb4c36f89e5d82c6a26295ff"
+git-tree-sha1 = "dcdea9bcd4126be143b4367b32affaff12bd4d08"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "0.24.7"
+version = "0.24.10"
 
 [[InteractiveUtils]]
 deps = ["Markdown"]
@@ -52,9 +52,9 @@ uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
 [[Parsers]]
 deps = ["Dates", "Test"]
-git-tree-sha1 = "75d07cb840c300084634b4991761886d0d762724"
+git-tree-sha1 = "f8f5d2d4b4b07342e5811d2b6428e45524e241df"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "1.0.1"
+version = "1.0.2"
 
 [[Pkg]]
 deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]

--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -56,7 +56,7 @@ struct Params
   Params() = new(Buffer([], false), IdSet())
 end
 
-@forward Params.order Base.iterate, Base.length
+@forward Params.order Base.iterate, Base.length, Base.getindex
 
 function Base.push!(ps::Params, x)
   if !(x in ps.params)
@@ -78,6 +78,10 @@ function Base.delete!(ps::Params, x)
 end
 
 Params(xs) = push!(Params(), xs...)
+
+Base.broadcasted(f, ps::Params) = broadcasted(f, ps.order)
+
+Base.:(==)(x::Params, y::Params) = x.order.data == y.order.data
 
 function Base.show(io::IO, ps::Params)
   print(io, "Params([")
@@ -115,7 +119,6 @@ function Base.copyto!(x::AbstractVector, ps::Params)
 end
 
 
-
 struct Grads
   grads::IdDict{Any,Any}
   params::Params
@@ -129,7 +132,6 @@ function Base.getindex(gs::Grads, x)
   isbits(x) && error("Only reference types can be differentiated with `Params`.")
   return gs.grads[x]
 end
-
 
 """
     copyto!(gs::Grads, x::AbstractVector)

--- a/test/features.jl
+++ b/test/features.jl
@@ -309,7 +309,7 @@ end
 end
 
 @testset "@timed" begin
-  @test gradient(x -> (@timed x)[1], 0) == (1,)
+  @test gradient(x -> first(@timed x), 0) == (1,)
 end
 
 mutable struct MyMutable

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -1,32 +1,57 @@
-@testset "Params delete!" begin
-  w = rand(2,3)
-  b = rand(2)
-  ps = Params([w,b])
-  delete!(ps, b)
-  @test length(ps.order) == length(ps.params) == 1
-  @test first(ps.order) == first(ps.params) == w
-end
+@testset "Parmas" begin
+  @testset "delete!" begin
+    w = rand(2,3)
+    b = rand(2)
+    ps = Params([w,b])
+    delete!(ps, b)
+    @test length(ps.order) == length(ps.params) == 1
+    @test first(ps.order) == first(ps.params) == w
+  end
 
-@testset "copyto!" begin
-  x = [0,0]
-  ps = Params([x])
-  copyto!(ps, [1, 2])
-  @test x == [1, 2]
-  
-  x = [0,0]
-  y = [0]
-  ps = Params([x, y])
-  copyto!(ps, [1, 2, 3])
-  @test x == [1, 2]
-  @test y == [3]
+  @testset "copyto!" begin
+    x = [0,0]
+    ps = Params([x])
+    copyto!(ps, [1, 2])
+    @test x == [1, 2]
+    
+    x = [0,0]
+    y = [0]
+    ps = Params([x, y])
+    copyto!(ps, [1, 2, 3])
+    @test x == [1, 2]
+    @test y == [3]
 
-  ps = Params([[1,2]])
-  x = [0, 0]
-  copyto!(x, ps)
-  @test x == [1, 2]
-  
-  ps = Params([[1,2], [3]])
-  x = [0, 0, 0]
-  copyto!(x, ps)
-  @test x == [1, 2, 3]
+    ps = Params([[1,2]])
+    x = [0, 0]
+    copyto!(x, ps)
+    @test x == [1, 2]
+    
+    ps = Params([[1,2], [3]])
+    x = [0, 0, 0]
+    copyto!(x, ps)
+    @test x == [1, 2, 3]
+  end
+
+  @testset "broadcast" begin
+    x, y = [1,2], [1]
+    ps = Params([x, y])
+    @test length.(ps) == length.([x, y]) # 617
+  end
+
+  @testset "indexing" begin
+    x, y = [1,2], [1]
+    ps = Params([x, y])
+    @test ps[1] === x
+    @test ps[2] === y
+    @test ps[1:2] == [x, y]
+  end
+
+  @testset "comparison" begin
+    x, y = [1,2], [1]
+    ps1 = Params([x, y])
+    ps2 = Params([x, y])
+    ps3 = Params([y, x])
+    @test ps1 == ps2 
+    @test ps1 != ps3  # comparison is order dependent
+  end
 end


### PR DESCRIPTION
- Add broadcast, fixing #617 
- add getindex, so that we have an array-like interface for convenience
- add comparison, partially fixing https://github.com/FluxML/Flux.jl/issues/1012. Comparison is order based, but we can make it order-independent if we want to.  