### PR TITLE
Fix the docs build

### DIFF
--- a/docs/src/utils.md
+++ b/docs/src/utils.md
@@ -11,6 +11,5 @@ Zygote.dropgrad
 Zygote.hessian
 Zygote.Buffer
 Zygote.forwarddiff
-Zygote.nograd
-copyto!
+Zygote.ignore
 ```


### PR DESCRIPTION
Unfortunately it looks like we can't document `copyto!` without breaking Documenter on travis.