### PR TITLE
define copy! instead of copyto!

### DIFF
--- a/docs/src/utils.md
+++ b/docs/src/utils.md
@@ -13,3 +13,5 @@ Zygote.Buffer
 Zygote.forwarddiff
 Zygote.ignore
 ```
+
+`Params` and `Grads` can be copied to and from arrays using the `copy!` function.

--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -1,3 +1,13 @@
+using InteractiveUtils
+using InteractiveUtils: typesof
+using Core: Typeof
+
+@static if VERSION >= v"1.1"
+  import Base: copy!
+else
+  import Future: copy!
+end
+
 mutable struct Context <: AContext
   cache::Union{IdDict{Any,Any},Nothing}
 end
@@ -91,14 +101,14 @@ end
 
 
 """
-    copyto!(ps::Params, x::AbstractVector)
-    copyto!(x::AbstractVector, ps::Params)
+    copy!(ps::Params, x::AbstractVector)
+    copy!(x::AbstractVector, ps::Params)
     
 Copies the content of array `x` into the parameters `ps` or viceversa.
 The length of `x` has to be equal to the sum of the lengths
 of all parameters.
 """
-function Base.copyto!(ps::Params, x::AbstractVector)
+function copy!(ps::Params, x::AbstractVector)
   @assert length(x) == sum(length(p) for p in ps)
   i = 0
   for p in ps
@@ -108,7 +118,7 @@ function Base.copyto!(ps::Params, x::AbstractVector)
   ps
 end
 
-function Base.copyto!(x::AbstractVector, ps::Params)
+function copy!(x::AbstractVector, ps::Params)
   @assert length(x) == sum(length(p) for p in ps)
   i = 0
   for p in ps
@@ -134,14 +144,14 @@ function Base.getindex(gs::Grads, x)
 end
 
 """
-    copyto!(gs::Grads, x::AbstractVector)
-    copyto!(x::AbstractVector, gs::Grads)
+    copy!(gs::Grads, x::AbstractVector)
+    copy!(x::AbstractVector, gs::Grads)
 
 Copies the content of array `x` into the gradient object `gs` or viceversa.
 The length of `x` has to be equal to the sum of the lenghts
 of all gradients.
 """
-function Base.copyto!(gs::Grads, x::AbstractVector)
+function copy!(gs::Grads, x::AbstractVector)
   i = 0
   for p in gs.params
       gs[p] .= reshape(x[i+1:i+length(p)], size(p))
@@ -150,7 +160,7 @@ function Base.copyto!(gs::Grads, x::AbstractVector)
   x
 end
 
-function Base.copyto!(x::AbstractVector,  gs::Grads)
+function copy!(x::AbstractVector,  gs::Grads)
   i = 0
   for p in gs.params
       x[i+1:i+length(p)] .= vec(gs[p]) 
@@ -172,10 +182,6 @@ function pullback(f, ps::Params)
 end
 
 # Code Reflection
-
-using InteractiveUtils
-using InteractiveUtils: typesof
-using Core: Typeof
 
 function code_ir(f, T)
   m = meta(Tuple{Typeof(f),T.parameters...})

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -8,27 +8,27 @@
     @test first(ps.order) == first(ps.params) == w
   end
 
-  @testset "copyto!" begin
+  @testset "copy!" begin
     x = [0,0]
     ps = Params([x])
-    copyto!(ps, [1, 2])
+    copy!(ps, [1, 2])
     @test x == [1, 2]
     
     x = [0,0]
     y = [0]
     ps = Params([x, y])
-    copyto!(ps, [1, 2, 3])
+    copy!(ps, [1, 2, 3])
     @test x == [1, 2]
     @test y == [3]
 
     ps = Params([[1,2]])
     x = [0, 0]
-    copyto!(x, ps)
+    copy!(x, ps)
     @test x == [1, 2]
     
     ps = Params([[1,2], [3]])
     x = [0, 0, 0]
-    copyto!(x, ps)
+    copy!(x, ps)
     @test x == [1, 2, 3]
   end
 
@@ -36,6 +36,7 @@
     x, y = [1,2], [1]
     ps = Params([x, y])
     @test length.(ps) == length.([x, y]) # 617
+    @test all(Params([[1,1]]) .== Params([[1,1]]))
   end
 
   @testset "indexing" begin


### PR DESCRIPTION
fix #617 . `copyto!` has been around for so little that we can consider this non-breaking