### PR TITLE
Add nograd for nthreads and threadid

### DIFF
--- a/src/lib/base.jl
+++ b/src/lib/base.jl
@@ -1,5 +1,5 @@
 @nograd readline, Base.gc_num, Base.time_ns, Base.print, Base.println, Base.show,
-  Core.show, Core.print, Core.println, string, repr
+  Core.show, Core.print, Core.println, string, repr, Threads.nthreads, Threads.threadid
 
 # Gradient of AD stacks
 


### PR DESCRIPTION
This PR adds `Threads.nthreads` and `Threads.threadid` to the nograd list.