### PR TITLE
Adds `@nograd <<, >>`

### DIFF
--- a/src/lib/number.jl
+++ b/src/lib/number.jl
@@ -61,7 +61,7 @@ end
 
 @adjoint a // b = (a // b, c̄ -> (c̄ * 1//b, - c̄ * a // b // b))
 
-@nograd floor, ceil, trunc, round, hash
+@nograd floor, ceil, trunc, round, hash, <<, >>
 
 # Complex Numbers
 


### PR DESCRIPTION
Or maybe it's better to restrict it to just `<<(::Integer, ::Integer)`?