### PR TITLE
Make map 3.5-4.8 times faster

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -158,6 +158,9 @@ function unzip(tuples)
       map(tuple -> tuple[i], tuples)
   end
 end
+function unzip(tuples::AbstractVector{<:Tuple{Any, Any}})
+  map(first, tuples), map(last, tuples)
+end
 function ∇map(cx, f, args...)
   ys_and_backs = map((args...) -> _pullback(cx, f, args...), args...)
   if isempty(ys_and_backs)
@@ -835,11 +838,11 @@ end
 end
 
 
-# to actually use rfft, one needs to insure that everything 
-# that happens in the Fourier domain could've been done in 
-# the space domain with real numbers. This means enforcing 
-# conjugate symmetry along all transformed dimensions besides 
-# the first. Otherwise this is going to result in *very* weird 
+# to actually use rfft, one needs to insure that everything
+# that happens in the Fourier domain could've been done in
+# the space domain with real numbers. This means enforcing
+# conjugate symmetry along all transformed dimensions besides
+# the first. Otherwise this is going to result in *very* weird
 # behavior.
 @adjoint function rfft(xs::AbstractArray{<:Real})
   return AbstractFFTs.rfft(xs), function(Δ)

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -158,6 +158,7 @@ function unzip(tuples)
       map(tuple -> tuple[i], tuples)
   end
 end
+# Special-case for this particularly commonly called varient that has outer loop unrolled 
 function unzip(tuples::AbstractVector{<:Tuple{Any, Any}})
   map(first, tuples), map(last, tuples)
 end


### PR DESCRIPTION
## Julia 1.5 ~4.8x
### Without this PR
```julia
julia> @btime (x->last(map(sin, fill(x,100))))'(0.1)
  15.635 μs (769 allocations: 23.53 KiB)
```

### With this PR
```julia
julia> @btime (x->last(map(sin, fill(x,100))))'(0.1)
  3.182 μs (35 allocations: 8.23 KiB)
```

## Julia 1.4 ~3.5x faster
### Without this PR
```julia
julia> @btime (x->last(map(sin, fill(x,100))))'(0.1)
  16.815 μs (769 allocations: 22.88 KiB)
0.9950041652780258
```

### With this PR
```julia
julia> @btime (x->last(map(sin, fill(x,100))))'(0.1)
  4.751 μs (57 allocations: 8.14 KiB)
````