### PR TITLE
RFC: specialize some varargs

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -53,6 +53,11 @@ version = "1.0.1"
 deps = ["Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
+[[ExprTools]]
+git-tree-sha1 = "6f0517056812fd6aa3af23d4b70d5325a2ae4e95"
+uuid = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
+version = "0.1.1"
+
 [[FillArrays]]
 deps = ["LinearAlgebra", "Random", "SparseArrays"]
 git-tree-sha1 = "51cc2f9bc4eb9c6c0e81ec2f779d1085583cc956"
@@ -156,6 +161,12 @@ deps = ["OpenSpecFun_jll"]
 git-tree-sha1 = "e19b98acb182567bcb7b75bb5d9eedf3a3b5ec6c"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
 version = "0.10.0"
+
+[[SpecializeVarargs]]
+deps = ["ExprTools"]
+git-tree-sha1 = "198d9939074e645b816c3c7c857946b258e7cc43"
+uuid = "24973c7f-061f-47f0-b8d1-653b711ffc2d"
+version = "0.1.1"
 
 [[StaticArrays]]
 deps = ["LinearAlgebra", "Random", "Statistics"]

--- a/Project.toml
+++ b/Project.toml
@@ -17,6 +17,7 @@ NaNMath = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
+SpecializeVarargs = "24973c7f-061f-47f0-b8d1-653b711ffc2d"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 

--- a/src/Zygote.jl
+++ b/src/Zygote.jl
@@ -10,6 +10,8 @@ using IRTools
 using MacroTools, Requires
 using MacroTools: @forward
 
+using SpecializeVarargs
+
 export Params, gradient, pullback, @code_grad
 
 include("tools/idset.jl")

--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -26,12 +26,12 @@ end
 
 # Wrappers
 
-_pullback(f, args...) = _pullback(Context(), f, args...)
+@specialize_vararg 5 _pullback(f, args...) = _pullback(Context(), f, args...)
 
 tailmemaybe(::Nothing) = nothing
 tailmemaybe(x::Tuple) = Base.tail(x)
 
-function pullback(f, args...)
+@specialize_vararg 5 function pullback(f, args...)
   y, back = _pullback(f, args...)
   y, Δ -> tailmemaybe(back(Δ))
 end
@@ -40,7 +40,7 @@ sensitivity(y::Number) = one(y)
 sensitivity(y::Complex) = error("Output is complex, so the gradient is not defined.")
 sensitivity(y) = error("Output should be scalar; gradients are not defined for output $(repr(y))")
 
-function gradient(f, args...)
+@specialize_vararg 5 function gradient(f, args...)
   y, back = pullback(f, args...)
   return back(sensitivity(y))
 end


### PR DESCRIPTION
@masonprotter

benchmark script
```
@btime (x->last(map(sin, fill(x,100))))'(0.1);
@btime (x->last(map(atan, fill(x,100), fill(2x, 100))))'(0.1);
@btime sin'(0.5);
@btime sin''(0.5);
@btime sin'''(0.5);
```

## Julia 1.4
### Without this PR
```julia
julia> @btime (x->last(map(sin, fill(x,100))))'(0.1);
  17.075 μs (769 allocations: 22.88 KiB)

julia> @btime (x->last(map(atan, fill(x,100), fill(2x, 100))))'(0.1);
  23.213 μs (988 allocations: 37.02 KiB)

julia> @btime sin'(0.5);
  1.346 ns (0 allocations: 0 bytes)

julia> @btime sin''(0.5);
  12.902 ns (0 allocations: 0 bytes)

julia> @btime sin'''(0.5);
  703.346 μs (2664 allocations: 68.30 KiB)
```

### Only with interface.jl changes
```julia
julia> @btime (x->last(map(sin, fill(x,100))))'(0.1);
  15.689 μs (770 allocations: 22.89 KiB)

julia> @btime (x->last(map(atan, fill(x,100), fill(2x, 100))))'(0.1);
  21.278 μs (988 allocations: 37.02 KiB)

julia> @btime sin'(0.5);
  1.247 ns (0 allocations: 0 bytes)

julia> @btime sin''(0.5);
  10.701 ns (0 allocations: 0 bytes)

julia> @btime sin'''(0.5);
  679.070 μs (2626 allocations: 67.69 KiB)
```

### With interface.jl and interface2.jl changes
```julia
julia> @btime (x->last(map(sin, fill(x,100))))'(0.1);
  17.219 μs (770 allocations: 22.89 KiB)

julia> @btime (x->last(map(atan, fill(x,100), fill(2x, 100))))'(0.1);
  22.907 μs (988 allocations: 37.02 KiB)

julia> @btime sin'(0.5);
  1.247 ns (0 allocations: 0 bytes)

julia> @btime sin''(0.5);
  11.414 ns (0 allocations: 0 bytes)

julia> @btime sin'''(0.5);
  674.351 μs (2617 allocations: 67.55 KiB)
```


## Julia 1.5

### Without this PR
```julia
julia> @btime (x->last(map(sin, fill(x,100))))'(0.1);
  14.080 μs (770 allocations: 23.55 KiB)

julia> @btime (x->last(map(atan, fill(x,100), fill(2x, 100))))'(0.1);
  19.151 μs (989 allocations: 37.94 KiB)

julia> @btime sin'(0.5);
  1.246 ns (0 allocations: 0 bytes)

julia> @btime sin''(0.5);
  11.812 ns (0 allocations: 0 bytes)

julia> @btime sin'''(0.5);
  531.809 μs (2410 allocations: 86.27 KiB)
```

### With interface.jl and interface2.jl changes
```julia
julia> @btime (x->last(map(sin, fill(x,100))))'(0.1);
  14.947 μs (770 allocations: 23.55 KiB)

julia> @btime (x->last(map(atan, fill(x,100), fill(2x, 100))))'(0.1);
  19.142 μs (989 allocations: 37.94 KiB)

julia> @btime sin'(0.5);
  1.279 ns (0 allocations: 0 bytes)

julia> @btime sin''(0.5);
  10.987 ns (0 allocations: 0 bytes)

julia> @btime sin'''(0.5);
  509.693 μs (2310 allocations: 83.59 KiB)
```