### PR TITLE
nograd randexp

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -1,6 +1,7 @@
 using Random, FillArrays, AbstractFFTs
 using FillArrays: AbstractFill, getindex_value
 using Base.Broadcast: broadcasted, broadcast_shape
+using Random: default_rng
 
 @adjoint (::Type{T})(::UndefInitializer, args...) where T<:Array = T(undef, args...), Δ -> nothing
 
@@ -8,7 +9,7 @@ using Base.Broadcast: broadcasted, broadcast_shape
 @adjoint Array(xs::Array) = Array(xs), ȳ -> (ȳ,)
 
 @nograd size, length, eachindex, axes, Colon(), findfirst, findlast, findall, ones, zeros, one, zero, any, all
-@nograd randn, randexp, randn!, randexp!, Random.default_rng
+@nograd randn, randexp, randn!, randexp!, default_rng
 
 @adjoint Base.rand(rng::AbstractRNG, ::Type{T}, dims...) where {T<:Number} =
   rand(rng, T, dims...), _ -> nothing

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -1,17 +1,17 @@
-using FillArrays, AbstractFFTs
+using Random, FillArrays, AbstractFFTs
 using FillArrays: AbstractFill, getindex_value
 using Base.Broadcast: broadcasted, broadcast_shape
-import Random.randn!
 
 @adjoint (::Type{T})(::UndefInitializer, args...) where T<:Array = T(undef, args...), Δ -> nothing
 
 @adjoint Array(xs::AbstractArray) = Array(xs), ȳ -> (ȳ,)
 @adjoint Array(xs::Array) = Array(xs), ȳ -> (ȳ,)
 
-@nograd size, length, eachindex, axes, Colon(), findfirst, findlast, findall, randn, randn!, ones, zeros, one, zero,
+@nograd size, length, eachindex, axes, Colon(), findfirst, findlast, findall, randn, randexp, randn!, randexp!, ones, zeros, one, zero,
   any, all
 
-@adjoint rand(dims::Integer...) = rand(dims...), _ -> nothing
+@adjoint Base.rand(rng::AbstractRNG, ::Type{T}, dims::Integer...) where {T<:Number} =
+  rand(rng, T, dims...), _ -> nothing
 
 @adjoint Base.vect(xs...) = Base.vect(xs...), Δ -> (Δ...,)
 

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -12,6 +12,8 @@ using Base.Broadcast: broadcasted, broadcast_shape
 
 @adjoint Base.rand(rng::AbstractRNG, ::Type{T}, dims::Integer...) where {T<:Number} =
   rand(rng, T, dims...), _ -> nothing
+@adjoint Base.rand(rng::AbstractRNG, ::Type{T}, dims::NTuple{N,Int}) where {T<:Number,N} =
+  rand(rng, T, dims...), _ -> nothing
 
 @adjoint Base.vect(xs...) = Base.vect(xs...), Δ -> (Δ...,)
 

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -1,7 +1,6 @@
 using Random, FillArrays, AbstractFFTs
 using FillArrays: AbstractFill, getindex_value
 using Base.Broadcast: broadcasted, broadcast_shape
-using Random: default_rng
 
 @adjoint (::Type{T})(::UndefInitializer, args...) where T<:Array = T(undef, args...), Δ -> nothing
 
@@ -9,7 +8,10 @@ using Random: default_rng
 @adjoint Array(xs::Array) = Array(xs), ȳ -> (ȳ,)
 
 @nograd size, length, eachindex, axes, Colon(), findfirst, findlast, findall, ones, zeros, one, zero, any, all
-@nograd randn, randexp, randn!, randexp!, default_rng
+@nograd randn, randexp, randn!, randexp!
+@static if VERSION > v"1.3"
+  @nograd Random.default_rng
+end
 
 @adjoint Base.rand(rng::AbstractRNG, ::Type{T}, dims...) where {T<:Number} =
   rand(rng, T, dims...), _ -> nothing

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -7,12 +7,10 @@ using Base.Broadcast: broadcasted, broadcast_shape
 @adjoint Array(xs::AbstractArray) = Array(xs), ȳ -> (ȳ,)
 @adjoint Array(xs::Array) = Array(xs), ȳ -> (ȳ,)
 
-@nograd size, length, eachindex, axes, Colon(), findfirst, findlast, findall, randn, randexp, randn!, randexp!, ones, zeros, one, zero,
-  any, all
+@nograd size, length, eachindex, axes, Colon(), findfirst, findlast, findall, ones, zeros, one, zero, any, all
+@nograd randn, randexp, randn!, randexp!, Random.default_rng
 
-@adjoint Base.rand(rng::AbstractRNG, ::Type{T}, dims::Integer...) where {T<:Number} =
-  rand(rng, T, dims...), _ -> nothing
-@adjoint Base.rand(rng::AbstractRNG, ::Type{T}, dims::NTuple{N,Int}) where {T<:Number,N} =
+@adjoint Base.rand(rng::AbstractRNG, ::Type{T}, dims...) where {T<:Number} =
   rand(rng, T, dims...), _ -> nothing
 
 @adjoint Base.vect(xs...) = Base.vect(xs...), Δ -> (Δ...,)

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -1485,10 +1485,10 @@ end
   @test gradient(x -> rand(), 1) == (nothing,)
   @test gradient(x -> sum(rand(4)), 1) == (nothing,)
   @test gradient(x -> sum(rand(Random.default_rng(), 4)), 1) == (nothing,)
-  @test gradient(x -> sum(rand(Random.default_rng(), Float32, 1,1)), [1])[1] === nothing
-  @test gradient(x -> sum(rand(Random.default_rng(), Float32, (1,1))), [1])[1] === nothing
-  @test gradient(x -> sum(randn(Random.default_rng(), Float32, 1,1)), [1])[1] === nothing
-  @test gradient(x -> sum(randn(Random.default_rng(), Float32, (1,1))), [1])[1] === nothing
-  @test gradient(x -> sum(randexp(Random.default_rng(), Float32, 1,1)), [1])[1] === nothing
-  @test gradient(x -> sum(randexp(Random.default_rng(), Float32, (1,1))), [1])[1] === nothing
+  @test gradient(x -> sum(rand(Random.default_rng(), Float32, 1,1)), 1) == (nothing,)
+  @test gradient(x -> sum(rand(Random.default_rng(), Float32, (1,1))), 1) == (nothing,)
+  @test gradient(x -> sum(randn(Random.default_rng(), Float32, 1,1)), 1) == (nothing,)
+  @test gradient(x -> sum(randn(Random.default_rng(), Float32, (1,1))), 1) == (nothing,)
+  @test gradient(x -> sum(randexp(Random.default_rng(), Float32, 1,1)), 1) == (nothing,)
+  @test gradient(x -> sum(randexp(Random.default_rng(), Float32, (1,1))), 1) == (nothing,)
 end

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -1480,3 +1480,15 @@ end
   @test gradient(x -> sum(Matrix{Float64}(x[1]*I, 2, 2)), [1.0]) == ([2.0],)
   @test gradient(x -> sum(Matrix{Float64}(x[1]*I, (2, 2))), [1.0]) == ([2.0],)
 end
+
+@testset "random" begin
+  @test gradient(x -> rand(), 1) == (nothing,)
+  @test gradient(x -> sum(rand(4)), 1) == (nothing,)
+  @test gradient(x -> sum(rand(Random.default_rng(), 4)), 1) == (nothing,)
+  @test gradient(x -> sum(rand(Random.default_rng(), Float32, 1,1)), [1])[1] === nothing
+  @test gradient(x -> sum(rand(Random.default_rng(), Float32, (1,1))), [1])[1] === nothing
+  @test gradient(x -> sum(randn(Random.default_rng(), Float32, 1,1)), [1])[1] === nothing
+  @test gradient(x -> sum(randn(Random.default_rng(), Float32, (1,1))), [1])[1] === nothing
+  @test gradient(x -> sum(randexp(Random.default_rng(), Float32, 1,1)), [1])[1] === nothing
+  @test gradient(x -> sum(randexp(Random.default_rng(), Float32, (1,1))), [1])[1] === nothing
+end

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -1484,11 +1484,21 @@ end
 @testset "random" begin
   @test gradient(x -> rand(), 1) == (nothing,)
   @test gradient(x -> sum(rand(4)), 1) == (nothing,)
-  @test gradient(x -> sum(rand(Random.default_rng(), 4)), 1) == (nothing,)
-  @test gradient(x -> sum(rand(Random.default_rng(), Float32, 1,1)), 1) == (nothing,)
-  @test gradient(x -> sum(rand(Random.default_rng(), Float32, (1,1))), 1) == (nothing,)
-  @test gradient(x -> sum(randn(Random.default_rng(), Float32, 1,1)), 1) == (nothing,)
-  @test gradient(x -> sum(randn(Random.default_rng(), Float32, (1,1))), 1) == (nothing,)
-  @test gradient(x -> sum(randexp(Random.default_rng(), Float32, 1,1)), 1) == (nothing,)
-  @test gradient(x -> sum(randexp(Random.default_rng(), Float32, (1,1))), 1) == (nothing,)
+  @test gradient(x -> sum(rand(4)), 1) == (nothing,)
+  @test gradient(x -> sum(rand(Float32, 1,1)), 1) == (nothing,)
+  @test gradient(x -> sum(rand(Float32, (1,1))), 1) == (nothing,)
+  @test gradient(x -> sum(randn(Float32, 1,1)), 1) == (nothing,)
+  @test gradient(x -> sum(randn(Float32, (1,1))), 1) == (nothing,)
+  @test gradient(x -> sum(randexp(Float32, 1,1)), 1) == (nothing,)
+  @test gradient(x -> sum(randexp(Float32, (1,1))), 1) == (nothing,)
+
+  @static if VERSION > v"1.3"
+    @test gradient(x -> sum(rand(Random.default_rng(), 4)), 1) == (nothing,)
+    @test gradient(x -> sum(rand(Random.default_rng(), Float32, 1,1)), 1) == (nothing,)
+    @test gradient(x -> sum(rand(Random.default_rng(), Float32, (1,1))), 1) == (nothing,)
+    @test gradient(x -> sum(randn(Random.default_rng(), Float32, 1,1)), 1) == (nothing,)
+    @test gradient(x -> sum(randn(Random.default_rng(), Float32, (1,1))), 1) == (nothing,)
+    @test gradient(x -> sum(randexp(Random.default_rng(), Float32, 1,1)), 1) == (nothing,)
+    @test gradient(x -> sum(randexp(Random.default_rng(), Float32, (1,1))), 1) == (nothing,)
+  end
 end

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -1492,6 +1492,16 @@ end
   @test gradient(x -> sum(randexp(Float32, 1,1)), 1) == (nothing,)
   @test gradient(x -> sum(randexp(Float32, (1,1))), 1) == (nothing,)
 
+  @test gradient(x -> rand(), 1) == (nothing,)
+  @test gradient(x -> sum(rand(Random.GLOBAL_RNG, 4)), 1) == (nothing,)
+  @test gradient(x -> sum(rand(Random.GLOBAL_RNG, 4)), 1) == (nothing,)
+  @test gradient(x -> sum(rand(Random.GLOBAL_RNG, Float32, 1,1)), 1) == (nothing,)
+  @test gradient(x -> sum(rand(Random.GLOBAL_RNG, Float32, (1,1))), 1) == (nothing,)
+  @test gradient(x -> sum(randn(Random.GLOBAL_RNG, Float32, 1,1)), 1) == (nothing,)
+  @test gradient(x -> sum(randn(Random.GLOBAL_RNG, Float32, (1,1))), 1) == (nothing,)
+  @test gradient(x -> sum(randexp(Random.GLOBAL_RNG, Float32, 1,1)), 1) == (nothing,)
+  @test gradient(x -> sum(randexp(Random.GLOBAL_RNG, Float32, (1,1))), 1) == (nothing,)
+
   @static if VERSION > v"1.3"
     @test gradient(x -> sum(rand(Random.default_rng(), 4)), 1) == (nothing,)
     @test gradient(x -> sum(rand(Random.default_rng(), Float32, 1,1)), 1) == (nothing,)


### PR DESCRIPTION
Just like `randn`, we should have a nograd rule for `randexp`.

We should also extend the rule for `rand` to cover different number types and / or random generators.