### PR TITLE
adjoints for StatsFuns

### DIFF
--- a/src/lib/statsfuns.jl
+++ b/src/lib/statsfuns.jl
@@ -8,13 +8,11 @@ using Base.Broadcast: broadcasted
     back(δ) = (dx * δ,)
     return result, back
 end
-
 @adjoint function broadcasted(::typeof(xlogx), x::Numeric)
     result, dx = ∇xlogx(x)
     back(δ) = (nothing, unbroadcast(x, δ .* dx))
     return result, back
 end
-
 function ∇xlogx(x::Numeric)
     logx = log.(x)
     xlogx = x .* logx
@@ -32,13 +30,16 @@ end
 
 @adjoint log1psq(x::Real) = log1psq(x), Δ->(Δ * 2x / (1 + abs2(x)),)
 
-@adjoint function log1pexp(x::Float64)
-    return log1pexp(x), Δ->(Δ * (x < 18.0 ? logistic(x) : x < 33.3 ? 1 - exp(-x) : 1),)
+@adjoint function log1pexp(x::Real)
+    dx = ∂log1pexp(x)
+    return log1pexp(x), δ -> (δ * dx,)
 end
-
-@adjoint function log1pexp(x::Float32)
-    return log1pexp(x), Δ->(Δ * (x < 9f0 ? logistic(x) : x < 16f0 ? 1 - exp(-x) : 1),)
+@adjoint function broadcasted(::typeof(log1pexp), x::Numeric)
+    dx = ∂log1pexp.(x)
+    return log1pexp.(x), δ -> (nothing, unbroadcast(x, δ .* dx))
 end
+∂log1pexp(x::Real)    = x < 18.0 ? logistic(x) : x < 33.3 ? one(x) - exp(-x) : oftype(exp(x), 1)
+∂log1pexp(x::Float32) = x < 9f0  ? logistic(x) : x < 16f0 ? one(x) - exp(-x) : oftype(exp(x), 1)
 
 @adjoint function logsumexp(X::AbstractArray{<:Real}; dims=:)
     lse = logsumexp(X; dims=dims)
@@ -50,13 +51,11 @@ end
     back(δ) = (δ * dx, δ * dy)
     return result, back
 end
-
 @adjoint function broadcasted(::typeof(xlogy), x::Numeric, y::Numeric)
     result, dx, dy = ∇xlogy(x, y)
     back(δ) = (nothing, unbroadcast(x, δ .* dx), unbroadcast(y, δ .* dy))
     return result, back
 end
-
 function ∇xlogy(x::Numeric, y::Numeric)
     dx = logy = log.(y)
     dy = x ./ y
@@ -70,13 +69,11 @@ end
     back(δ) = (δ * dx, δ * dy)
     return result, back
 end
-
 @adjoint function broadcasted(::typeof(logaddexp), x::Numeric, y::Numeric)
     result, dx, dy = ∇logaddexp(x, y)
     back(δ) = (nothing, unbroadcast(x, δ .* dx), unbroadcast(y, δ .* dy))
     return result, back
 end
-
 function ∇logaddexp(x::Numeric, y::Numeric)
     result = logaddexp.(x, y)
     t = @. exp(-abs(x - y))
@@ -89,13 +86,11 @@ end
     back(δ) = (δ * dx, δ * dy)
     return result, back
 end
-
 @adjoint function broadcasted(::typeof(logsubexp), x::Numeric, y::Numeric)
     result, dx, dy = ∇logsubexp(x, y)
     back(δ) = (nothing, unbroadcast(x, δ .* dx), unbroadcast(y, δ .* dy))
     return result, back
 end
-
 function ∇logsubexp(x::Numeric, y::Numeric)
     result = logsubexp.(x, y)
     t = @. -inv(expm1(-abs(x - y)))

--- a/src/lib/statsfuns.jl
+++ b/src/lib/statsfuns.jl
@@ -77,7 +77,7 @@ end
 function ∇logaddexp(x::Numeric, y::Numeric)
     result = logaddexp.(x, y)
     t = @. exp(-abs(x - y))
-    dx, dy = swap(x .≥ y, inv.(one.(t) .+ t), t ./ (one.(t) .+ t))
+    dx, dy = select(x .≥ y, inv.(one.(t) .+ t), t ./ (one.(t) .+ t))
     return result, dx, dy
 end
 
@@ -94,16 +94,16 @@ end
 function ∇logsubexp(x::Numeric, y::Numeric)
     result = logsubexp.(x, y)
     t = @. -inv(expm1(-abs(x - y)))
-    dx, dy = swap(x .≥ y, t, one.(t) .- t)
+    dx, dy = select(x .≥ y, t, one.(t) .- t)
     return result, dx, dy
 end
 
 """
-	swap(cond, x, y)
+	select(cond, x, y)
 
-The call `a, b = swap(cond, x, y)` constructs two arrays `a, b`, where
+The call `a, b = select(cond, x, y)` constructs two arrays `a, b`, where
 `a[i], b[i] = x[i], y[i]` if `cond[i]` is `true`, and `a[i], b[i] = y[i], x[i]`
  if `cond[i]` is `false`.
 """
-swap(cond, x, y) = ifelse.(cond, x, y), ifelse.(cond, y, x)
+select(cond, x, y) = ifelse.(cond, x, y), ifelse.(cond, y, x)
 

--- a/src/lib/statsfuns.jl
+++ b/src/lib/statsfuns.jl
@@ -77,7 +77,7 @@ end
 function ∇logaddexp(x::Numeric, y::Numeric)
     result = logaddexp.(x, y)
     t = @. exp(-abs(x - y))
-    dx, dy = select(x .≥ y, inv.(one.(t) .+ t), t ./ (one.(t) .+ t))
+    dx, dy = swap(x .≥ y, inv.(one.(t) .+ t), t ./ (one.(t) .+ t))
     return result, dx, dy
 end
 
@@ -94,16 +94,16 @@ end
 function ∇logsubexp(x::Numeric, y::Numeric)
     result = logsubexp.(x, y)
     t = @. -inv(expm1(-abs(x - y)))
-    dx, dy = select(x .≥ y, t, one.(t) .- t)
+    dx, dy = swap(x .≥ y, t, one.(t) .- t)
     return result, dx, dy
 end
 
 """
-	select(cond, x, y)
+	swap(cond, x, y)
 
-The call `a, b = select(cond, x, y)` constructs two arrays `a, b`, where
+The call `a, b = swap(cond, x, y)` constructs two arrays `a, b`, where
 `a[i], b[i] = x[i], y[i]` if `cond[i]` is `true`, and `a[i], b[i] = y[i], x[i]`
  if `cond[i]` is `false`.
 """
-select(cond, x, y) = ifelse.(cond, x, y), ifelse.(cond, y, x)
+swap(cond, x, y) = ifelse.(cond, x, y), ifelse.(cond, y, x)
 

--- a/src/lib/statsfuns.jl
+++ b/src/lib/statsfuns.jl
@@ -1,5 +1,7 @@
 import .StatsFuns
-using .StatsFuns: xlogx, logistic, logit, log1psq, log1pexp, logsumexp
+using .StatsFuns: xlogx, xlogy, logistic, logit, log1psq, log1pexp,
+    logsumexp, logaddexp, logsubexp
+using Base.Broadcast: broadcasted
 
 @adjoint function xlogx(x::Real)
     y = xlogx(x)
@@ -29,3 +31,70 @@ end
     lse = logsumexp(X; dims=dims)
     return lse, Δ -> (Δ .* exp.(X .- lse),)
 end
+
+@adjoint function xlogy(x::Real, y::Real)
+    result, dx, dy = ∇xlogy(x, y)
+    back(δ) = (δ * dx, δ * dy)
+    return result, back
+end
+
+@adjoint function broadcasted(::typeof(xlogy), x::Numeric, y::Numeric)
+    result, dx, dy = ∇xlogy(x, y)
+    back(δ) = (nothing, unbroadcast(x, δ .* dx), unbroadcast(y, δ .* dy))
+    return result, back
+end
+
+function ∇xlogy(x::Numeric, y::Numeric)
+    dx = logy = log.(y)
+    dy = x ./ y
+    xlogy = x .* logy
+    result = @. ifelse(iszero(x) & !isnan(y), zero(xlogy), xlogy)
+    return result, dx, dy
+end
+
+@adjoint function logaddexp(x::Real, y::Real)
+    result, dx, dy = ∇logaddexp(x, y)
+    back(δ) = (δ * dx, δ * dy)
+    return result, back
+end
+
+@adjoint function broadcasted(::typeof(logaddexp), x::Numeric, y::Numeric)
+    result, dx, dy = ∇logaddexp(x, y)
+    back(δ) = (nothing, unbroadcast(x, δ .* dx), unbroadcast(y, δ .* dy))
+    return result, back
+end
+
+function ∇logaddexp(x::Numeric, y::Numeric)
+    result = logaddexp.(x, y)
+    t = @. exp(-abs(x - y))
+    dx, dy = select(x .≥ y, inv.(one.(t) .+ t), t ./ (one.(t) .+ t))
+    return result, dx, dy
+end
+
+@adjoint function logsubexp(x::Real, y::Real)
+    result, dx, dy = ∇logsubexp(x, y)
+    back(δ) = (δ * dx, δ * dy)
+    return result, back
+end
+
+@adjoint function broadcasted(::typeof(logsubexp), x::Numeric, y::Numeric)
+    result, dx, dy = ∇logsubexp.(x, y)
+    back(δ) = (nothing, unbroadcast(x, δ .* dx), unbroadcast(y, δ .* dy))
+    return result, back
+end
+
+function ∇logsubexp(x::Numeric, y::Numeric)
+    result = logsubexp.(x, y)
+    t = @. exp(-abs(x - y))
+    dx, dy = select(x .≥ y, inv.(one.(t) .+ t), t ./ (one.(t) .+ t))
+    return result, dx, dy
+end
+
+"""
+	select(cond, x, y)
+
+Given a Boolean array `cond`, construct two arrays, where items from `x` or `y`
+are selected according to whether the corresponding item from `cond` is `true` or `false`.
+"""
+select(cond, x, y) = ifelse.(cond, x, y), ifelse.(cond, y, x)
+

--- a/src/lib/statsfuns.jl
+++ b/src/lib/statsfuns.jl
@@ -106,8 +106,9 @@ end
 """
 	select(cond, x, y)
 
-Given a Boolean array `cond`, construct two arrays, where items from `x` or `y`
-are selected according to whether the corresponding item from `cond` is `true` or `false`.
+The call `a, b = select(cond, x, y)` constructs two arrays `a, b`, where
+`a[i], b[i] = x[i], y[i]` if `cond[i]` is `true`, and `a[i], b[i] = y[i], x[i]`
+ if `cond[i]` is `false`.
 """
 select(cond, x, y) = ifelse.(cond, x, y), ifelse.(cond, y, x)
 

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -1170,6 +1170,7 @@ Zygote.refresh()
 @testset "xlogx" begin
   @test gradcheck(x->2.5 * StatsFuns.xlogx(x[1]), [1.0])
   @test gradcheck(x->2.5 * StatsFuns.xlogx(x[1]), [2.45])
+  @test gradtest(x -> StatsFuns.xlogx.(x), (3,3))
 end
 
 @testset "xlogy" begin
@@ -1230,7 +1231,15 @@ end
   @test gradcheck(x -> StatsFuns.logaddexp(x[1], x[2]), [1.0, 2.0])
   @test gradcheck(x -> StatsFuns.logaddexp(x[1], x[2]), [1.0, -1.0])
   @test gradcheck(x -> StatsFuns.logaddexp(x[1], x[2]), [-2.0, -3.0])
+  @test gradcheck(x -> StatsFuns.logaddexp(x[1], x[2]), [5.0, 5.0])
   @test gradtest((x,y) -> StatsFuns.logaddexp.(x,y), (3,3), (3,3))
+end
+
+@testset "logsubexp" begin
+  @test gradcheck(x -> StatsFuns.logsubexp(x[1], x[2]), [1.0, 2.0])
+  @test gradcheck(x -> StatsFuns.logsubexp(x[1], x[2]), [1.0, -1.0])
+  @test gradcheck(x -> StatsFuns.logsubexp(x[1], x[2]), [-2.0, -3.0])
+  @test gradtest((x,y) -> StatsFuns.logsubexp.(x,y), (3,3), (3,3))
 end
 
 @testset "logsumexp" begin

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -1216,6 +1216,9 @@ end
       test_log1pexp(Float64, [33.3, 33.3 + eps(), 100.0])
     end
   end
+  @test gradcheck(x->2.5 * StatsFuns.log1pexp(x[1]), [1.0])
+  @test gradcheck(x->2.5 * StatsFuns.log1pexp(x[1]), [2.45])
+  @test gradtest(x -> StatsFuns.log1pexp.(x), (3,3))
 end
 
 @testset "log1psq" begin

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -1172,6 +1172,12 @@ Zygote.refresh()
   @test gradcheck(x->2.5 * StatsFuns.xlogx(x[1]), [2.45])
 end
 
+@testset "xlogy" begin
+  @test gradcheck(x -> StatsFuns.xlogy(x[1], x[2]), [1.0, 2.0])
+  @test gradcheck(x -> StatsFuns.xlogy(x[1], x[2]), [0.0, 2.0])
+  @test gradtest((x,y) -> StatsFuns.xlogy.(x,y), (3,3), (3,3))
+end
+
 @testset "logistic" begin
   @test gradcheck(x->3.0 * StatsFuns.logistic(x[1]), [-5.0])
   @test gradcheck(x->3.0 * StatsFuns.logistic(x[1]), [-1.0])
@@ -1218,6 +1224,13 @@ end
       @test gradcheck(x->5.1 * StatsFuns.log1psq(x[1]), [x])
     end
   end
+end
+
+@testset "logaddexp" begin
+  @test gradcheck(x -> StatsFuns.logaddexp(x[1], x[2]), [1.0, 2.0])
+  @test gradcheck(x -> StatsFuns.logaddexp(x[1], x[2]), [1.0, -1.0])
+  @test gradcheck(x -> StatsFuns.logaddexp(x[1], x[2]), [-2.0, -3.0])
+  @test gradtest((x,y) -> StatsFuns.logaddexp.(x,y), (3,3), (3,3))
 end
 
 @testset "logsumexp" begin


### PR DESCRIPTION
Add some adjoints for functions from [StatsFuns.jl](https://github.com/JuliaStats/StatsFuns.jl). We need these rules because some of these functions use `ifelse` or `max/min` statements which make sense mathematically but confuse Zygote.

For example, this line:

https://github.com/JuliaStats/StatsFuns.jl/blob/069cbb0924640c466a58a331d4513a5f6bdb5a8b/src/basicfuns.jl#L211

results in a wrong gradient computed by Zygote:

```
julia> gradient(logaddexp, 5, 5)  # should be (0.5, 0.5)
(0.0, 1.0)
```

This and similar issues are fixed in this PR for the functions addressed here.

I also added rules for broadcasting of these functions, since Zygote is slow differentiating broadcasts (until something like https://github.com/FluxML/Zygote.jl/pull/338 gets merged). In the meantime we need these broadcasting rules for the functions we want to broadcast and differentiate fast. For example, take:

```julia
julia> using StatsFuns, Zygote, BenchmarkTools
julia> f(x) = sum(xlogx.(x))
julia> x = rand(100);
```

Before this PR:

```julia
julia> @btime gradient(f, $x);
  17.104 μs (342 allocations: 12.33 KiB)
```

After this PR:

```julia
julia> @btime gradient(f, $x)
  1.029 μs (7 allocations: 4.42 KiB)
```

is **17x faster**.

The functions addressed in this PR are: `xlogx`, `xlogy`, `logaddexp`, `logsubexp`, `log1pexp`.