### PR TITLE
ignore macro

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Zygote"
 uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
-version = "0.4.20"
+version = "0.4.21"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Zygote"
 uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
-version = "0.4.21"
+version = "0.4.20"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/lib/utils.jl
+++ b/src/lib/utils.jl
@@ -26,6 +26,17 @@ ignore(f) = f()
 @adjoint ignore(f) = ignore(f), _ -> nothing
 
 """
+    @ignore (...)
+
+Tell Zygote to ignore an expression. Equivalent to `ignore() do (...) end`.
+"""
+macro ignore(ex)
+    return :(ignore() do
+        $ex
+    end)
+end
+
+"""
     hook(x̄ -> ..., x) -> x
 
 Gradient hooks. Allows you to apply an arbitrary function to the gradient for

--- a/src/lib/utils.jl
+++ b/src/lib/utils.jl
@@ -29,10 +29,16 @@ ignore(f) = f()
     @ignore (...)
 
 Tell Zygote to ignore an expression. Equivalent to `ignore() do (...) end`.
+Example:
+
+```julia-repl	
+julia> f(x) = (y = Zygote.@ignore x; x * y); f'(1)
+1
+```	
 """
 macro ignore(ex)
-    return :(ignore() do
-        $ex
+    return :(Zygote.ignore() do
+        $(esc(ex))
     end)
 end
 

--- a/src/lib/utils.jl
+++ b/src/lib/utils.jl
@@ -32,7 +32,8 @@ Tell Zygote to ignore an expression. Equivalent to `ignore() do (...) end`.
 Example:
 
 ```julia-repl	
-julia> f(x) = (y = Zygote.@ignore x; x * y); f'(1)
+julia> f(x) = (y = Zygote.@ignore x; x * y); 
+julia> f'(1)
 1
 ```	
 """

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -1481,7 +1481,11 @@ end
   @test gradient(x -> findlast(ismissing, x), [1, missing]) == (nothing,)
   @test gradient(x -> findall(ismissing, x)[1], [1, missing]) == (nothing,)
   @test gradient(x -> Zygote.ignore(() -> x*x), 1) == (nothing,)
-  @test gradient(x -> Zygote.@ignore x*x, 1) == (nothing,)
+  @test gradient(x -> Zygote.@ignore(x*x), 1) == (nothing,)
+  @test gradient(1) do x
+    y = Zygote.@ignore x
+    x * y
+  end == (1,)
 end
 
 @testset "fastmath" begin

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -1481,6 +1481,7 @@ end
   @test gradient(x -> findlast(ismissing, x), [1, missing]) == (nothing,)
   @test gradient(x -> findall(ismissing, x)[1], [1, missing]) == (nothing,)
   @test gradient(x -> Zygote.ignore(() -> x*x), 1) == (nothing,)
+  @test gradient(x -> Zygote.@ignore x*x, 1) == (nothing,)
 end
 
 @testset "fastmath" begin


### PR DESCRIPTION
A macro version of https://github.com/FluxML/Zygote.jl/pull/623. With this PR,

```julia
ignore() do
    ...
end
```

can also be written as:

```julia
@ignore ...
```

fix https://github.com/FluxML/Zygote.jl/issues/537

CC: @MikeInnes @CarloLucibello 

I bumped the version here so if we merge we can tag a release.