### PR TITLE
fill can't handle nothing as a recieved gradient

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -75,7 +75,11 @@ end
 
 @adjoint collect(x::Array) = collect(x), Δ -> (Δ,)
 
-@adjoint fill(x::Real, dims...) = fill(x, dims...), Δ->(sum(Δ), map(_->nothing, dims)...)
+@adjoint function fill(x::Real, dims...) 
+    back(Δ) =(sum(x->((x==nothing) ? 0 : x), Δ), map(_->nothing, dims)...)
+    back(Δ::NTuple{N, <:Nothing}) where N = (nothing, map(_->nothing, dims)...)
+    return fill(x, dims...), back
+end
 
 @adjoint function circshift(A, shifts)
   circshift(A, shifts), Δ -> (circshift(Δ, map(-, shifts)), nothing)

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -272,6 +272,11 @@ end
   @test gradtest(x->fill(first(x), N), randn(rng, 1))
   @test gradtest(x->fill(first(x), N, M), randn(rng, 1))
   @test gradtest(x->fill(first(x), N, M, P), randn(rng, 1))
+  # checking fill still works if the gradient is nothing
+  let 
+    out, back = pullback(fill, 5, 3)
+    @test back((nothing,)) == (nothing,nothing)
+  end
 end
 
 @testset "circshift" begin


### PR DESCRIPTION
I was using fill as a way of indexing into another matrix, e.g. `x[fill(1,N)...]`, and this causes `(nothing,)` to be handed to the pullback of `fill`. As all the gradient does is sum at the moment, this causes errors trying to sum `nothing`. I address this by checking the type, and passing on any received `nothing`, and if the entries are mixed it ignores any `nothing`s in the sum.