### PR TITLE
Return tuple of nothings while broadcasting

### DIFF
--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -179,7 +179,7 @@ end
 @inline function broadcast_forward(f, args::Vararg{Any,N}) where N
   T = Broadcast.combine_eltypes(f, args)
   out = dual_function(f).(args...)
-  eltype(out) <: Dual || return (out, _ -> nothing)
+  eltype(out) <: Dual || return (out, _ -> (nothing, ntuple(_ -> nothing, N)...)
   y = map(x -> x.value, out)
   _back(ȳ, i) = unbroadcast(args[i], ((a, b) -> a*b.partials[i]).(ȳ, out))
   back(ȳ) = ntuple(i -> _back(ȳ, i), N)

--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -179,7 +179,7 @@ end
 @inline function broadcast_forward(f, args::Vararg{Any,N}) where N
   T = Broadcast.combine_eltypes(f, args)
   out = dual_function(f).(args...)
-  eltype(out) <: Dual || return (out, _ -> (nothing, ntuple(_ -> nothing, N)...)
+  eltype(out) <: Dual || return (out, _ -> (nothing, ntuple(_ -> nothing, N)...))
   y = map(x -> x.value, out)
   _back(ȳ, i) = unbroadcast(args[i], ((a, b) -> a*b.partials[i]).(ȳ, out))
   back(ȳ) = ntuple(i -> _back(ȳ, i), N)


### PR DESCRIPTION
Tentatively fixes #678, and probably others

@MikeInnes would it be alright to return a `Tuple` here? Should we do a manual check for `AbstractArrays` or look into why the numerical rules fail here.

This currently has slightly different behaviour on master as: 

```julia
julia> r = rand(Float32, 3,3);

julia> cr = cu(r);

julia> gradient((x,y) -> sum(x .< y), r, 1)
([nothing nothing nothing; nothing nothing nothing; nothing nothing nothing], nothing)

julia> gradient((x,y) -> sum(x .< y), cr, 1)
(nothing, nothing)
```