### PR TITLE
Respect linearity when accumulating implicit params

### DIFF
--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -41,10 +41,6 @@ end
 
 @adjoint Base.typeassert(x, T) = Base.typeassert(x, T), Δ -> (Δ, nothing)
 
-# TODO: check correctness. Gradients should be linear types. Right now it's
-# likely possible for gradients to be accumulated as params or globals and
-# backpropagated as values; these should be mutually exclusive options.
-
 @generated function accum_param(cx::Context, x, Δ)
   isbitstype(x) && return :(Δ)
   quote

--- a/test/features.jl
+++ b/test/features.jl
@@ -196,6 +196,16 @@ y, back = pullback(() -> layer(x), Params([W]))
 
 @test gradient(() -> sum(W * x), Params([W]))[W] == [1 2; 1 2]
 
+let
+  p = [1]
+  θ = Zygote.Params([p])
+  θ̄ = gradient(θ) do
+    p′ = (p,)[1]
+    p′[1]
+  end
+  @test θ̄[p][1] == 1
+end
+
 @test gradient(2) do x
   H = [1 x; 3 4]
   sum(H)


### PR DESCRIPTION
All gradients need to be linear, i.e. consumed only once. Previously we allowed gradients to be consumed by the `accum_param` (tracking gradients of parameters given to the `Params` object) _and then_ continue backpropagating. Backpropagated gradients were always correct, but `accum_param` might be triggered more than once on the same object, leading to multiplied gradients. We now backpropagate `nothing` for a value instead.