### PR TITLE
Adjust reference to ChainRules

### DIFF
--- a/docs/src/adjoints.md
+++ b/docs/src/adjoints.md
@@ -4,7 +4,7 @@
     Zygote supports the use of [ChainRulesCore](http://www.juliadiff.org/ChainRulesCore.jl/stable/) to define custom sensitivities.
     It is prefered to define the custom sensitivities using `ChainRulesCore.rrule` as they will work for many AD systems, not just Zygote.
     These sensitivities can be added in your own package, or for Base/StdLib functions they can be added to [ChainRules.jl](https://github.com/JuliaDiff/ChainRules.jl/).
-    To use define custom sensitivities using ChainRulesCore, define a `ChainRulesCore.rrule(f, args...; kwargs...)` [ChainRules project's documentation for more information](https://www.juliadiff.org/ChainRulesCore.jl/stable/).
+    To define custom sensitivities using ChainRulesCore, define a `ChainRulesCore.rrule(f, args...; kwargs...)` [ChainRules project's documentation for more information](https://www.juliadiff.org/ChainRulesCore.jl/stable/).
     **If you are defining your custom adjoints using ChainRulesCore then you do not need to read this page**, and can consider it as documenting a legacy feature.
     
     This page exists to descibe how Zygote works, and how adjoints can be directly defined for Zygote.

--- a/docs/src/adjoints.md
+++ b/docs/src/adjoints.md
@@ -1,11 +1,13 @@
 # Custom Adjoints
 
-!!! note "Prefer to use ChainRules to define custom adjoints"
+!!! note "Prefer to use ChainRulesCore to define custom adjoints"
     Zygote supports the use of [ChainRulesCore](http://www.juliadiff.org/ChainRulesCore.jl/stable/) to define custom sensitivities.
     It is prefered to define the custom sensitivities using `ChainRulesCore.rrule` as they will work for many AD systems, not just Zygote.
-    These sensitivities can be added in your own package, or for Base functions they can be added to ChainRules.jl.
-
-    This documentation exists to descibe how Zygote works, and how adjoints can be directly defined for Zygote.
+    These sensitivities can be added in your own package, or for Base/StdLib functions they can be added to [ChainRules.jl](https://github.com/JuliaDiff/ChainRules.jl/).
+    To use define custom sensitivities using ChainRulesCore, define a `ChainRulesCore.rrule(f, args...; kwargs...)` [ChainRules project's documentation for more information](https://www.juliadiff.org/ChainRulesCore.jl/stable/).
+    **If using ChainRulesCore you do not need to read this page**, and can consider it as documenting a legacy feature.
+    
+    This page exists to descibe how Zygote works, and how adjoints can be directly defined for Zygote.
     Defining adjoints this way does not make them accessible to other AD systems, but does let you do things that directly depend on how Zygote works.
     It allows for specific definitions of adjoints that are only defined for Zgyote (which might work differently to more generic definitions defined for all AD).
 

--- a/docs/src/adjoints.md
+++ b/docs/src/adjoints.md
@@ -5,7 +5,7 @@
     It is prefered to define the custom sensitivities using `ChainRulesCore.rrule` as they will work for many AD systems, not just Zygote.
     These sensitivities can be added in your own package, or for Base/StdLib functions they can be added to [ChainRules.jl](https://github.com/JuliaDiff/ChainRules.jl/).
     To use define custom sensitivities using ChainRulesCore, define a `ChainRulesCore.rrule(f, args...; kwargs...)` [ChainRules project's documentation for more information](https://www.juliadiff.org/ChainRulesCore.jl/stable/).
-    **If using ChainRulesCore you do not need to read this page**, and can consider it as documenting a legacy feature.
+    **If you are defining your custom adjoints using ChainRulesCore then you do not need to read this page**, and can consider it as documenting a legacy feature.
     
     This page exists to descibe how Zygote works, and how adjoints can be directly defined for Zygote.
     Defining adjoints this way does not make them accessible to other AD systems, but does let you do things that directly depend on how Zygote works.


### PR DESCRIPTION
Some of the language was confusing people on what they needed to read
From slack:

> True, while the ChainRulesCore  link goes to ChainRules  -- confusion 1; 
> "prefer to use", sure, but how? an example? -- confusion 2; 
> should I read the rest of the Zygote custom adjoint documentation? -- confusion 3.