### PR TITLE
add back julia 1.3 compatibility

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -39,7 +39,7 @@ NaNMath = "0.3"
 Requires = "0.5, 1.0"
 SpecialFunctions = "0.10"
 ZygoteRules = "0.2"
-julia = "1.4"
+julia = "1.3"
 
 [extras]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/Project.toml
+++ b/Project.toml
@@ -40,13 +40,3 @@ Requires = "0.5, 1.0"
 SpecialFunctions = "0.10"
 ZygoteRules = "0.2"
 julia = "1.3"
-
-[extras]
-CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
-Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
-FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
-StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[targets]
-test = ["Test", "Distances", "StatsFuns", "CUDA", "FFTW"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Zygote"
 uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
-version = "0.5.2"
+version = "0.5.3"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Zygote.jl
+++ b/src/Zygote.jl
@@ -11,7 +11,7 @@ using IRTools
 using MacroTools, Requires
 using MacroTools: @forward
 
-using LoopVectorization # for vmap
+using LoopVectorization: vmap
 
 export Params, gradient, pullback, pushforward, @code_grad
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,10 @@
+[deps]
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
+FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+NNlib = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
+StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+CUDA = "1"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,10 +1,12 @@
 [deps]
+AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
 ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+Future = "9fa8497b-333b-5362-9e8d-4d0656e87820"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
 NNlib = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,8 +1,12 @@
 [deps]
+ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
+Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
 NNlib = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,7 +2,11 @@
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NNlib = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -3,7 +3,8 @@ using Zygote, NNlib, Test, Random, LinearAlgebra, Statistics, FillArrays,
 using Zygote: gradient
 using NNlib: conv, ∇conv_data, depthwiseconv, batched_mul
 using Base.Broadcast: broadcast_shape
-using LoopVectorization, Distributed
+using LoopVectorization: vmap
+using Distributed: pmap
 
 function ngradient(f, xs::AbstractArray...)
   grads = zero.(xs)


### PR DESCRIPTION
unnecessarily dropped in #728 

Having a separate test/Project.toml as specified in the [Pkg docs](https://julialang.github.io/Pkg.jl/v1/creating-packages/#Test-specific-dependencies-in-Julia-1.2-and-above-1) solves the problem of forcing the same Manifest.toml created from the root Project.toml on each testing environment, which may lead to incompatibilities with some extra packages required in the test phase. In this case in fact, LLVM,jl 2.0 was installed on julia 1.3, but then no CUDA.jl version could be resolved