### PR TITLE
Fix FFT type promotions

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -836,7 +836,7 @@ end
 @adjoint function \(P::AbstractFFTs.Plan, xs)
   return P \ xs, function(Δ)
     N = prod(size(Δ)[[P.region...]])
-    return (nothing, 1/N * (P * Δ))
+    return (nothing, (P * Δ)/N)
   end
 end
 
@@ -844,7 +844,7 @@ end
 @adjoint function ifft(xs)
   return AbstractFFTs.ifft(xs), function(Δ)
     N = length(xs)
-    return (1/N* AbstractFFTs.fft(Δ),)
+    return (AbstractFFTs.fft(Δ)/N,)
   end
 end
 
@@ -884,7 +884,7 @@ end
 @adjoint function irfft(xs, d)
   return AbstractFFTs.irfft(xs, d), function(Δ)
     total = length(Δ)
-    fullTransform = 1/total * AbstractFFTs.rfft(real.(Δ))
+    fullTransform = AbstractFFTs.rfft(real.(Δ))/total
     return (fullTransform, nothing)
   end
 end
@@ -918,7 +918,7 @@ end
   return AbstractFFTs.ifft(xs, dims), function(Δ)
     dims = collect(dims)
     N = prod(collect(size(xs))[dims])
-    return (1/N * AbstractFFTs.fft(Δ, dims),nothing)
+    return (AbstractFFTs.fft(Δ, dims)/N,nothing)
   end
 end
 
@@ -934,7 +934,7 @@ end
   return AbstractFFTs.ifft(xs, dims), function(Δ)
     dims = collect(dims)
     N = prod(collect(size(xs))[dims])
-    return (1/N * AbstractFFTs.rfft(Δ, dims), nothing, nothing)
+    return (AbstractFFTs.rfft(Δ, dims)/N, nothing, nothing)
   end
 end
 @adjoint function brfft(xs, d, dims)

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -1441,7 +1441,31 @@ end
   @test gradient((x)->sum(abs.(rfft(x))), x)[1] ≈
     gradient( (x) -> sum(abs.(fft(rfft(x,1),2))),  x)[1]
   @test gradient((x, dims)->sum(abs.(rfft(x,dims))), x, (1,2))[1] ≈
-    gradient( (x) -> sum(abs.(rfft(x))), x)[1]
+      gradient( (x) -> sum(abs.(rfft(x))), x)[1]
+
+  # Test type stability of fft
+
+  x = randn(Float64,16)
+  P = plan_fft(x)
+  @test typeof(gradient(x->sum(abs2,ifft(fft(x))),x)[1]) == Array{Complex{Float64},1}
+  @test typeof(gradient(x->sum(abs2,P\(P*x)),x)[1]) == Array{Complex{Float64},1}
+  @test typeof(gradient(x->sum(abs2,irfft(rfft(x),16)),x)[1]) == Array{Float64,1}
+
+  x = randn(Float64,16,16)
+  @test typeof(gradient(x->sum(abs2,ifft(fft(x,1),1)),x)[1]) == Array{Complex{Float64},2}
+  # This errors: something is the wrong size
+  #@test typeof(gradient(x->sum(abs2,irfft(rfft(x,1),16,1)),x)[1]) == Array{Float64,2} 
+
+  x = randn(Float32,16)
+  P = plan_fft(x)
+  @test typeof(gradient(x->sum(abs2,ifft(fft(x))),x)[1]) == Array{Complex{Float32},1}
+  @test typeof(gradient(x->sum(abs2,P\(P*x)),x)[1]) == Array{Complex{Float32},1}
+  @test typeof(gradient(x->sum(abs2,irfft(rfft(x),16)),x)[1]) == Array{Float32,1}
+
+  x = randn(Float32,16,16)
+  @test typeof(gradient(x->sum(abs2,ifft(fft(x,1),1)),x)[1]) == Array{Complex{Float32},2}
+  # This errors: something is the wrong size
+  #@test typeof(gradient(x->sum(abs2,irfft(rfft(x,1),16,1)),x)[1]) == Array{Float32,2}
 end
 
 @testset "FillArrays" begin


### PR DESCRIPTION
I ran into an issue with type promotions while using `Conv` layers in Flux when I tried to run model output through FFTs. I tracked it down to the definitions of the adjoints for the various `fft` variants. The 1/N factors needed in the `irfft` adjoints automatically promoted `Float32` arrays to `Float64` arrays, which then caused the error when propagated back through the chain. A minimal example is included below.

This pull request just changes all those multiplications by 1/N into divisions by N, which prevents the promotion. I also added a few tests that assert that the gradients are the right types. The tests with `irfft(x,dims)` throw an error that is not related to the type promotion, so I commented those out.

```julia
x = randn(Float32,16,1,1)
m = Conv((5,),1=>1,relu,pad=SamePad())
loss(x) = sum(abs2,irfft(rfft(m(x)),16))
gradient(()->loss(x),Flux.params(m))

┌ Warning: Slow fallback implementation invoked for ∇conv_data!  You probably don't want this; check your datatypes.
│   yT = AbstractFloat
│   T1 = AbstractFloat
│   T2 = Float32
└ @ NNlib C:\Users\wkearney\.julia\packages\NNlib\sSn9M\src\conv.jl:206
ERROR: UndefRefError: access to undefined reference
Stacktrace:
 [1] getindex at .\array.jl:745 [inlined]
 [2] #conv_direct!#149(::Float64, ::Bool, ::typeof(NNlib.conv_direct!), ::Array{AbstractFloat,5}, ::Array{AbstractFloat,5}, ::Array{Float32,5}, ::DenseConvDims{3,(5, 1, 1),1,1,(1, 1, 1),(2, 2, 0, 0, 0, 0),(1, 1, 1),false}) at C:\Users\wkearney\.julia\packages\NNlib\sSn9M\src\impl\conv_direct.jl:98
 [3] (::NNlib.var"#kw##conv_direct!")(::NamedTuple{(:alpha, :beta),Tuple{Float64,Bool}}, ::typeof(NNlib.conv_direct!), ::Array{AbstractFloat,5}, ::Array{AbstractFloat,5}, ::Array{Float32,5}, ::DenseConvDims{3,(5, 1, 1),1,1,(1, 1, 1),(2, 2, 0, 0, 0, 0),(1, 1, 1),false}) at .\none:0
 [4] #∇conv_data_direct!#152(::Float64, ::Bool, ::typeof(NNlib.∇conv_data_direct!), ::Array{AbstractFloat,5}, ::Array{AbstractFloat,5}, ::Array{Float32,5}, ::DenseConvDims{3,(5, 1, 1),1,1,(1, 1, 1),(2, 2, 0, 0, 0, 0),(1, 1, 1),false}) at C:\Users\wkearney\.julia\packages\NNlib\sSn9M\src\impl\conv_direct.jl:163
 [5] ∇conv_data_direct! at C:\Users\wkearney\.julia\packages\NNlib\sSn9M\src\impl\conv_direct.jl:158 [inlined]
 [6] #∇conv_data!#106(::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}, ::typeof(∇conv_data!), ::Array{AbstractFloat,5}, ::Array{AbstractFloat,5}, ::Array{Float32,5}, ::DenseConvDims{3,(5, 1, 1),1,1,(1, 1, 1),(2, 2, 0, 0, 0, 0),(1, 1, 1),false}) at C:\Users\wkearney\.julia\packages\NNlib\sSn9M\src\conv.jl:208
 [7] ∇conv_data!(::Array{AbstractFloat,5}, ::Array{AbstractFloat,5}, ::Array{Float32,5}, ::DenseConvDims{3,(5, 1, 1),1,1,(1, 1, 1),(2, 2, 0, 0, 0, 0),(1, 1, 1),false}) at C:\Users\wkearney\.julia\packages\NNlib\sSn9M\src\conv.jl:206
 [8] #∇conv_data!#67(::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}, ::typeof(∇conv_data!), ::Array{AbstractFloat,3}, ::Array{AbstractFloat,3}, ::Array{Float32,3}, ::DenseConvDims{1,(5,),1,1,(1,),(2, 2),(1,),false}) at C:\Users\wkearney\.julia\packages\NNlib\sSn9M\src\conv.jl:148
 [9] ∇conv_data! at C:\Users\wkearney\.julia\packages\NNlib\sSn9M\src\conv.jl:148 [inlined]
 [10] #∇conv_data#39 at C:\Users\wkearney\.julia\packages\NNlib\sSn9M\src\conv.jl:103 [inlined]
 [11] ∇conv_data at C:\Users\wkearney\.julia\packages\NNlib\sSn9M\src\conv.jl:101 [inlined]
 [12] #1241 at C:\Users\wkearney\.julia\dev\Zygote\src\lib\nnlib.jl:42 [inlined]
 [13] (::Zygote.var"#4101#back#1243"{Zygote.var"#1241#1242"{Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}},Array{Float32,3},Array{Float32,3},DenseConvDims{1,(5,),1,1,(1,),(2, 2),(1,),false}}})(::Array{AbstractFloat,3}) at C:\Users\wkearney\.julia\packages\ZygoteRules\6nssF\src\adjoint.jl:49
 [14] Conv at C:\Users\wkearney\.julia\packages\Flux\IjMZL\src\layers\conv.jl:147 [inlined]
 [15] (::typeof(∂(λ)))(::Array{Float64,3}) at C:\Users\wkearney\.julia\dev\Zygote\src\compiler\interface2.jl:0
 [16] loss at .\REPL[6]:1 [inlined]
 [17] (::typeof(∂(loss)))(::Float32) at C:\Users\wkearney\.julia\dev\Zygote\src\compiler\interface2.jl:0
 [18] #7 at .\REPL[8]:1 [inlined]
 [19] (::typeof(∂(#7)))(::Float32) at C:\Users\wkearney\.julia\dev\Zygote\src\compiler\interface2.jl:0
 [20] (::Zygote.var"#56#57"{Params,Zygote.Context,typeof(∂(#7))})(::Float32) at C:\Users\wkearney\.julia\dev\Zygote\src\compiler\interface.jl:177
 [21] gradient(::Function, ::Params) at C:\Users\wkearney\.julia\dev\Zygote\src\compiler\interface.jl:54
```