### PR TITLE
Remove Base.parameter_upper_bound given removal from Base

### DIFF
--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -29,7 +29,7 @@ end
 
 @nograd Core.apply_type, Core.typeof, nfields, fieldtype, Core.TypeVar, Core.UnionAll,
   (==), (===), (<=), (>=), (<), (>), isempty, supertype, Base.typename,
-  Base.parameter_upper_bound, eps, Meta.parse, Base.eval, sleep, isassigned
+  eps, Meta.parse, Base.eval, sleep, isassigned
 
 @adjoint deepcopy(x) = deepcopy(x), ȳ -> (ȳ,)
 


### PR DESCRIPTION
`Base.parameter_upper_bound` has been removed on julia master, so was breaking Flux on julia master.
It doesn't seem to be mentioned anywhere other than this in Zygote

I couldn't find where it left base, but perhaps it wasn't intended to be used anyway given https://github.com/JuliaLang/julia/pull/36769#issuecomment-662719375

I can't vouch for just deleting this being a good idea, other than I couldn't find any other mention in the Zygote source, but either way it needs fixing