### PR TITLE
Fix for #717 - grads for dictionaries in closures/struct fields

### DIFF
--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -199,7 +199,7 @@ end
 @adjoint function literal_getproperty(x, ::Val{f}) where f
   val = getproperty(x, f)
   function back(Δ)
-    accum_param(__context__, val, Δ) === nothing && return
+    accum_param(__context__, val, Δ) # === nothing && return
     if isimmutable(x)
       ((;nt_nothing(x)...,pair(Val(f), Δ)...), nothing)
     else

--- a/test/lib/base.jl
+++ b/test/lib/base.jl
@@ -1,0 +1,32 @@
+struct Maz
+    d::Dict
+end
+maz = m -> begin
+    d = getfield(m, :d)
+    z = getindex(d, :x)
+    return z
+end
+
+struct Bar
+    x::Float64
+end
+bar = m -> begin
+    z = getfield(m, :x)
+    return z
+end
+
+fn = m -> begin
+    z = getindex(m, :x)
+    return z
+end
+
+@testset "Grad of closure over dictionary" begin
+    _, back = pullback(maz, Maz(Dict(:x => 5.0)))
+    @test back(1.0) == ((d = Dict{Any, Any}(:x => 1.0), ), )
+    _, back = pullback(bar, Bar(5.0))
+    @test back(1.0) == ((x = 1.0, ), )
+    _, back = pullback(fn, Dict(:x => 5.0))
+    @test back(1.0) == (Dict{Any, Any}(:x => 1.0), )
+
+    @test Zygote.gradient(x -> (() -> x[:y])(), Dict(:y => 0.4)) == (Dict{Any, Any}(:y => 1.0), )
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,10 @@ end
   include("lib/number.jl")
 end
 
+@testset "lib/base" begin
+  include("lib/base.jl")
+end
+
 @testset "Features" begin
   include("features.jl")
 end


### PR DESCRIPTION
Commented out `===` check in lib `@adjoint` for `literal_getproperty`.

This is breaking grads for dicts in closures (and thus, also structs with dictionary fields).

There are a number of small MWEs for this issue:

https://github.com/FluxML/Zygote.jl/issues/717

I have no idea if this breaks other things, because master already has broken tests.