### PR TITLE
Update ArrayLayouts and FillArrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,10 +26,10 @@ ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 
 [compat]
 AbstractFFTs = "0.5"
-ArrayLayouts = "0.1, 0.2, 0.3"
+ArrayLayouts = "0.1, 0.2, 0.3, 0.4"
 ChainRules = "0.7.0"
 DiffRules = "1.0"
-FillArrays = "0.8"
+FillArrays = "0.8, 0.9"
 ForwardDiff = "0"
 IRTools = "0.4"
 LoopVectorization = "0.8.15"


### PR DESCRIPTION
Supersedes https://github.com/FluxML/Zygote.jl/pull/763, https://github.com/FluxML/Zygote.jl/pull/759, and https://github.com/FluxML/Zygote.jl/pull/764. All these PRs didn't actually test ArrayLayouts 0.4 and FillArrays 0.9 (or even failed to install them) since FillArrays 0.9 requires ArrayLayouts 0.4 and hence both compatibilities have to be updated together.

Locally tests fail in the same way as on the master branch with Julia 1.5 and nightly.