### PR TITLE
Test that keyword arguments are correct

### DIFF
--- a/test/features.jl
+++ b/test/features.jl
@@ -360,3 +360,32 @@ end
     @test (x->10*(x => 2)[1])'(100) === 10
     @test (x->10*(x => 2)[2])'(100) === 0
 end
+
+# https://github.com/JuliaDiff/ChainRules.jl/issues/257
+@testset "Keyword Argument Passing" begin
+  struct Type1{VJP}
+    x::VJP
+  end
+
+  struct Type2{compile}
+    Type2(compile=false) = new{compile}()
+  end
+
+  function loss_adjoint(θ)
+    sum(f(sensealg=Type1(Type2(true))))
+  end
+
+  i = 1
+  global x = Any[nothing,nothing]
+
+  Zygote.@nograd g(x,i,sensealg) = Main.x[i] = sensealg
+  function f(;sensealg=nothing)
+    g(x,i,sensealg)
+    return rand(100)
+  end
+
+  loss_adjoint([1.0])
+  i = 2
+  Zygote.gradient(loss_adjoint,[1.0])
+  @test x[1] == x[2]
+end


### PR DESCRIPTION
Because https://github.com/JuliaDiff/ChainRules.jl/issues/257 shows that there are rules that can make it not correct.