### PR TITLE
fix for rrules with kwargs and multiple zero partials

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Zygote"
 uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
-version = "0.5.7"
+version = "0.5.8"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -99,6 +99,14 @@ As per [`chain_rrule`](@ref) but with support for kwargs.
 """
 @inline function chain_rrule_kw(kwf, kwargs, f, args...)
   y, back = rrule(f, args...; kwargs...)
-  kw_zpullback(dy) = (nothing, nothing, ZBack(back)(dy)...)  # first two nothings are for kwfunc and kwargs
+  function kw_zpullback(dy)
+    dxs = ZBack(back)(dy)
+    if dxs === nothing  # if dxs is nothing, then all partiaols are nothing
+      # Zygote convention is a single nothing no mather how partials, if all are nothing
+      return nothing
+    else
+      return (nothing, nothing, dxs...)  # first two nothings are for kwfunc and kwargs
+    end
+  end
   return y, kw_zpullback
 end

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -159,13 +159,13 @@ using Zygote, Test, ChainRules
         end
 
         @test (1,) == h(1)
-        
+
         if VERSION >= v"1.3"
             # broken on Julia 1.0 because of https://github.com/FluxML/Zygote.jl/issues/638
             a3, pb3 = Zygote.pullback(h, 1)
             @test ((1,),) == pb3(1)
         end
-    end 
+    end
 
     @testset "kwargs" begin
         kwfoo_rrule_hitcount = Ref(0)
@@ -190,6 +190,23 @@ using Zygote, Test, ChainRules
             @test kwfoo_rrule_hitcount[] == 1
             @test kwfoo_pullback_hitcount[] == 1
         end
+    end
+
+
+    @testset "kwarg, with all AbstractZero partials" begin
+        # while ChainRules always has a partial for every input, Zygote combined them all
+        # to a single `nothing` if they are all zero-like.
+
+        not_diff_kw_eg(x, i; kw=1.0) = [10, 20][i]
+        function ChainRules.rrule(::typeof(not_diff_kw_eg), x, i; kwargs...)
+            function not_diff_kw_eg_pullback(Δ)
+                return ChainRules.NO_FIELDS, ChainRules.Zero(), ChainRules.DoesNotExist()
+            end
+            return not_diff_kw_eg(x, i; kwargs...), not_diff_kw_eg_pullback
+        end
+
+        @test (nothing,) == Zygote.gradient(x->not_diff_kw_eg(x, 2), 10.4)
+        @test (nothing,) == Zygote.gradient(x->not_diff_kw_eg(x, 2; kw=2.0), 10.4)
     end
 end
 


### PR DESCRIPTION
This fixes https://github.com/JuliaDiff/ChainRulesCore.jl/issues/216
correcting a bug I introduced in #780 

cc @devmotion 


(I have confirmed that the second test that uses the kwargs fails on Zygore#master