### PR TITLE
Correct primal of Matrix from UniformScaling & handle sum of boolean arrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Zygote"
 uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
-version = "0.5.7"
+version = "0.5.8"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -780,17 +780,17 @@ end
   end
 end
 
-@adjoint function Matrix(::UniformScaling, i::Integer, j::Integer)
-  return Matrix(I, i, j), Δ -> ((λ=tr(Δ),), nothing, nothing)
+@adjoint function Matrix(S::UniformScaling, i::Integer, j::Integer)
+  return Matrix(S, i, j), Δ -> ((λ=tr(Δ),), nothing, nothing)
 end
-@adjoint function Matrix(::UniformScaling, ij::NTuple{2, Integer})
-  return Matrix(I, ij), Δ -> ((λ=tr(Δ),), nothing)
+@adjoint function Matrix(S::UniformScaling, ij::NTuple{2, Integer})
+  return Matrix(S, ij), Δ -> ((λ=tr(Δ),), nothing)
 end
-@adjoint function Matrix{T}(::UniformScaling, i::Integer, j::Integer) where {T}
-  return Matrix{T}(I, i, j), Δ -> ((λ=tr(Δ),), nothing, nothing)
+@adjoint function Matrix{T}(S::UniformScaling, i::Integer, j::Integer) where {T}
+  return Matrix{T}(S, i, j), Δ -> ((λ=tr(Δ),), nothing, nothing)
 end
-@adjoint function Matrix{T}(::UniformScaling, ij::NTuple{2, Integer}) where {T}
-  return Matrix{T}(I, ij), Δ -> ((λ=tr(Δ),), nothing)
+@adjoint function Matrix{T}(S::UniformScaling, ij::NTuple{2, Integer}) where {T}
+  return Matrix{T}(S, ij), Δ -> ((λ=tr(Δ),), nothing)
 end
 @adjoint function +(A::AbstractMatrix, S::UniformScaling)
   return A + S, Δ->(Δ, (λ=tr(Δ),))

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -165,7 +165,7 @@ function unzip(tuples)
 end
 
 # Reverse iteration order when ∇map is applied to vector,
-# needed for stateful functions. 
+# needed for stateful functions.
 # See https://github.com/FluxML/Flux.jl/issues/1209
 # Should be generalized to abstract array, but reverse takes a dims keyword there
 _tryreverse(m, backs, Δ) = backs, Δ
@@ -184,7 +184,7 @@ for (mapfunc,∇mapfunc) in [(:map,:∇map),(:pmap,:∇pmap),(:vmap,:∇vmap)]
       ys, backs = unzip(ys_and_backs)
       ys, function (Δ)
         # Apply pullbacks in reverse order. Needed for correctness if `f` is stateful.
-        Δf_and_args_zipped = $mapfunc((f, δ) -> f(δ), _tryreverse($mapfunc, backs, Δ)...) 
+        Δf_and_args_zipped = $mapfunc((f, δ) -> f(δ), _tryreverse($mapfunc, backs, Δ)...)
         Δf_and_args = unzip(_tryreverse($mapfunc, Δf_and_args_zipped))
         Δf = reduce(accum, Δf_and_args[1])
         (Δf, Δf_and_args[2:end]...)
@@ -222,13 +222,16 @@ end
 end
 
 # Reductions
-
 @adjoint function sum(xs::AbstractArray; dims = :)
   if dims === (:)
     sum(xs), Δ -> (Fill(Δ, size(xs)),)
   else
     sum(xs, dims = dims), Δ -> (similar(xs) .= Δ,)
   end
+end
+
+@adjoint function sum(xs::AbstractArray{Bool}; dims = :)
+  sum(xs, dims = dims), Δ -> (nothing,)
 end
 
 _normalize_kws(kws::NamedTuple) = kws

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -141,6 +141,10 @@ end
   @test gradtest(X -> sum(x -> x^2, X), randn(10))
   @test gradtest(X -> sum(sum(x -> x^2, X; dims=1)), randn(10)) # issue #681
 
+  # Non-differentiable sum of booleans
+  @test gradient(sum, [true, false, true]) == (nothing,)
+  @test gradient(x->sum(x .== 0.0), [1.2, 0.2, 0.0, -1.1, 100.0]) == (nothing,)
+
   # https://github.com/FluxML/Zygote.jl/issues/314
   @test gradient((x,y) -> sum(yi -> yi*x, y), 1, [1,1]) == (2, [1, 1])
   @test gradient((x,y) -> prod(yi -> yi*x, y), 1, [1,1]) == (2, [1, 1])
@@ -1107,7 +1111,7 @@ end
 
         # This is impressively inaccurate, but at least it doesn't produce a NaN.
         @test first(Δ_fd) ≈ first(pb(Δ)) atol=1e-3 rtol=1e-3
-      end 
+      end
     end
 
     @testset "binary pairwise - X and Y close" begin
@@ -1565,11 +1569,11 @@ end
 @testset "@nograd" begin
   @test gradient(x->eachindex([10,20,30])[1], 11) == (nothing,)
 
-  #These are defined in ChainRules, we test them here to check we are handling them right 
+  #These are defined in ChainRules, we test them here to check we are handling them right
   @test gradient(x -> findfirst(ismissing, x), [1, missing]) == (nothing,)
   @test gradient(x -> findlast(ismissing, x), [1, missing]) == (nothing,)
   @test gradient(x -> findall(ismissing, x)[1], [1, missing]) == (nothing,)
-  
+
 
   @test gradient(x -> Zygote.ignore(() -> x*x), 1) == (nothing,)
   @test gradient(x -> Zygote.@ignore(x*x), 1) == (nothing,)

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -1600,6 +1600,9 @@ end
   @test gradient(x -> sum(Matrix(x[1]*I, (2, 2))), [1.0]) == ([2.0],)
   @test gradient(x -> sum(Matrix{Float64}(x[1]*I, 2, 2)), [1.0]) == ([2.0],)
   @test gradient(x -> sum(Matrix{Float64}(x[1]*I, (2, 2))), [1.0]) == ([2.0],)
+
+  # Check we haven't broken the forward pass:
+  @test first(Zygote.pullback(x->Matrix(x*I, 2,2), 8.0)) == Matrix(8.0*I, 2,2)
 end
 
 @testset "random" begin


### PR DESCRIPTION
Can't do AD on bools.

This was breaking code like:
```
using Distances, Zygote
function o(x)
           d = pairwise(Euclidean(), x, dims=2)
           return sum(iszero, d)
 end

gradient(o, rand(5,3))
````

since the sum was returning an `Array{Nothing}`.
Possibly we should post process those and normalize them into `nothing` more generally.
but to fix this particular case, just making sum of arrays of bools seems like a good start.

I would fix this in ChainRules but because Zygote defines `sum(::AbstractArray)` with a better definition than what ChainRules has right now, that will always take precidence.