### PR TITLE
Only directly block mutation on Arrays

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -54,15 +54,15 @@ _droplike(dy::Union{LinearAlgebra.Adjoint, LinearAlgebra.Transpose}, dxv::Abstra
 
 @adjoint getindex(::Type{T}, xs...) where {T} = T[xs...], dy -> (nothing, dy...)
 
-@adjoint! setindex!(xs::AbstractArray, x...) = setindex!(xs, x...),
-  _ -> error("Mutating arrays is not supported")
+@adjoint! setindex!(xs::Array, x...) = setindex!(xs, x...),
+  _ -> error("Mutating Arrays is not supported")
 
-@adjoint! copyto!(args...) = copyto!(args...),
-  _ -> error("Mutating arrays is not supported")
+@adjoint! copyto!(dest::Array, args...) = copyto!(dest, args...),
+  _ -> error("Mutating Arrays is not supported")
 
 for f in [push!, pop!, pushfirst!, popfirst!]
-  @eval @adjoint! $f(xs::Vector, x...) =
-    push!(xs, x...), _ -> error("Mutating arrays is not supported")
+  @eval @adjoint! $f(xs::Vector, x...) = $f(xs, x...),
+    _ -> error("Mutating Arrays is not supported")
 end
 
 # General


### PR DESCRIPTION
Any other arrray is going to be implemented in terms of an `Array`.
So if it is mutated then it  will eventually mutate an an internal `Array` typed field and thow this error (if we have to AD that far).
But if we don't endup having to AD that far some how, then we should not error.

Also fixes the primal for `popfirst!` etc.
Though that doesn't matter since it will error anyway.


I was going to block it for `BitArray` also but then I realized that we should be treating BitArrays are nondifferentiable anyway
https://github.com/JuliaDiff/ChainRules.jl/issues/293
