### PR TITLE
Fix UnionAll stackoverflow

### DIFF
--- a/src/Zygote.jl
+++ b/src/Zygote.jl
@@ -51,6 +51,10 @@ include("profiler/Profile.jl")
   include("flux.jl")
 end
 
+@init @require Colors="5ae59095-9a9b-59fe-a467-6f913c188581" begin
+  @nograd Colors.ColorTypes._parameter_upper_bound
+end
+
 precompile() = include(joinpath(@__DIR__, "precompile.jl"))
 
 # helps to work around 265-y issues

--- a/src/lib/base.jl
+++ b/src/lib/base.jl
@@ -138,3 +138,7 @@ end
     end
     return getfield(p, i), pair_getfield
 end
+
+@adjoint Base.nameof(x::UnionAll) = nameof(x), _ -> (nothing,)
+
+@nograd typeintersect

--- a/test/structures.jl
+++ b/test/structures.jl
@@ -55,3 +55,13 @@ struct A594 x::Float64 end
   @test ∇[1] == [(x = 2.0,); (x = 2.0,)]
   @test ∇[2] == [1 1; 1 1]
 end
+
+@testset "UnionAll Stackoverflow" begin
+  struct M{T,B}
+    a::T
+    b::B
+  end
+
+  m, b = Zygote._pullback(Zygote.Context(), nameof, M)
+  @test b(m) == (nothing, nothing)
+end


### PR DESCRIPTION
MWE:

```Julia
c = RGB(0,1,1)
t = RGB(1,1,1)

gradient(colordiff, c, t)
ERROR: StackOverflowError:
Stacktrace:
 [1] unwrap_unionall at ./essentials.jl:234 [inlined]
 [2] _pullback(::Zygote.Context, ::typeof(Base.unwrap_unionall), ::Type{M}) at /Users/dhairyagandhi/Downloads/new_clones/Zygote.jl/src/compiler/interface2.jl:0
 [3] nameof at ./reflection.jl:211 [inlined]
 ... (the last 2 lines are repeated 43620 more times)
 [87244] _pullback(::Zygote.Context, ::typeof(nameof), ::Type{M}) at /Users/dhairyagandhi/Downloads/new_clones/Zygote.jl/src/
```

This pointed me to check why there was a stackoverflow, which really shouldn't happen. In some cases, it crashes Julia entirely.

Turns out `nameof` which `UnionAll` structs can cause this but rewriting the complete function like so differentiates as expected.

```Julia
function mynameof(x::UnionAll)
  while isa(x, UnionAll)
    x = x.body
  end
  x.name.name
end
```

Since `nameof` would not produce gradients anyway, I went ahead and gave it a consistent gradient and added the couple other annotations needed to get the Colors.jl examples functional again.