### PR TITLE
use matmul rule from ChainRules

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Zygote"
 uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
-version = "0.5.10"
+version = "0.5.11"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -317,10 +317,7 @@ end
 # LinAlg
 # ======
 
-@adjoint function(A::AbstractMatrix * B::AbstractMatrix)
-  return A * B, Δ::AbstractMatrix->(Δ * B', A' * Δ)
-end
-
+# TODO: remove these once https://github.com/JuliaDiff/ChainRules.jl/pull/305 is merged
 @adjoint function(A::AbstractMatrix * x::AbstractVector)
   return A * x, Δ::AbstractVector->(Δ * x', A' * Δ)
 end


### PR DESCRIPTION
Any reason not to use ChainRules for these rules? This bit me, because I defined a custom rrule for multiplication of my custom matrix type and it wasn't hit because it was shadowed by this adjoint defined in Zygote. cc: @oxinabox