### PR TITLE
delete Matric Vector multiply rules that are now in ChainRules

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,7 +26,7 @@ ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 [compat]
 AbstractFFTs = "0.5"
 ArrayLayouts = "0.1, 0.2, 0.3, 0.4"
-ChainRules = "0.7.16"
+ChainRules = "0.7.33"
 DiffRules = "1.0"
 FillArrays = "0.8, 0.9, 0.10"
 ForwardDiff = "0.10"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Zygote"
 uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
-version = "0.5.14"
+version = "0.5.15"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -317,21 +317,6 @@ end
 # LinAlg
 # ======
 
-# TODO: remove these once https://github.com/JuliaDiff/ChainRules.jl/pull/305 is merged
-@adjoint function(A::AbstractMatrix * x::AbstractVector)
-  return A * x, Δ::AbstractVector->(Δ * x', A' * Δ)
-end
-
-@adjoint function *(x::Union{Transpose{<:Any, <:AbstractVector},
-                             LinearAlgebra.Adjoint{<:Any, <:AbstractVector}},
-                    y::AbstractVector)
-  return x * y, Δ->(Δ * y', x' * Δ)
-end
-
-@adjoint function(a::AbstractVector * x::AbstractMatrix)
-  return a * x, Δ::AbstractMatrix->(vec(Δ * x'), a' * Δ)
-end
-
 @adjoint function transpose(x)
   back(Δ) = (transpose(Δ),)
   back(Δ::NamedTuple{(:parent,)}) = (Δ.parent,)

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -314,8 +314,8 @@ end
   end
 end
 
-# LinAlg
-# ======
+# LinearAlgebra
+# =============
 
 @adjoint function transpose(x)
   back(Δ) = (transpose(Δ),)


### PR DESCRIPTION
@simeonschaub  want to review?

this needs @gxyd 's PR to ChainRules to be merged first
https://github.com/JuliaDiff/ChainRules.jl/pull/305