### PR TITLE
Bug Fix: norm of complex array

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -437,7 +437,7 @@ end
 end
 
 function _pullback(cx::AContext, ::typeof(norm), x::AbstractArray, p::Real = 2)
-  fallback = (x, p) -> sum(abs.(x).^p .+ eps(0f0)) ^ (one(eltype(x)) / p) # avoid d(sqrt(x))/dx == Inf at 0
+  fallback = (x, p) -> sum(abs.(x).^p .+ eps(0f0)) ^ (real(one(eltype(x))) / p) # avoid d(sqrt(x))/dx == Inf at 0
   _pullback(cx, fallback, x, p)
 end
 

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -1642,4 +1642,11 @@ end
   end
 end
 
-@test gradient(x -> norm(x), rand(Float32, 2, 2))[1] isa Matrix{Float32}
+@testset "norm" begin
+    for T in (Float64, Float32, ComplexF64, ComplexF32)
+        x = randn(T, 2, 2)
+        y = x / norm(x)
+        z = gradient(norm, x)[1]
+        @test z ≈ y && typeof(z) == typeof(y)
+    end
+end


### PR DESCRIPTION
#826 made it impossible to take gradient of norm of complex array.
```julia
julia> gradient(x -> norm(x), randn(ComplexF64,2,2))
ERROR: Output is complex, so the gradient is not defined.
Stacktrace:
 [1] error(::String) at ./error.jl:33
 [2] sensitivity(::Complex{Float64}) at /home/hnakano/.julia/packages/Zygote/JXGyI/src/compiler/interface.jl:49
 [3] gradient(::Function, ::Array{Complex{Float64},2}) at /home/hnakano/.julia/packages/Zygote/JXGyI/src/compiler/interface.jl:54
 [4] top-level scope at REPL[9]:1
```
This patch fixes it.