### PR TITLE
Dispatch on AContext

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Zygote"
 uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
-version = "0.5.14"
+version = "0.5.15"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -125,14 +125,14 @@ end
   val, back
 end
 
-function _pullback(cx::Context, ::typeof(literal_indexed_iterate), xs::Tuple, ::Val{i}) where i
+function _pullback(cx::AContext, ::typeof(literal_indexed_iterate), xs::Tuple, ::Val{i}) where i
   y, b = _pullback(cx, literal_getindex, xs, Val(i))
   back(::Nothing) = nothing
   back(ȳ) = b(ȳ[1])
   (y, i+1), back
 end
 
-function _pullback(cx::Context, ::typeof(literal_indexed_iterate), xs::Tuple, ::Val{i}, st) where i
+function _pullback(cx::AContext, ::typeof(literal_indexed_iterate), xs::Tuple, ::Val{i}, st) where i
   y, b = _pullback(cx, literal_getindex, xs, Val(i))
   back(::Nothing) = nothing
   back(ȳ) = (b(ȳ[1])..., nothing)
@@ -224,16 +224,16 @@ end
   unwrap(val), back
 end
 
-_pullback(cx::Context, ::typeof(getproperty), x, f::Symbol) =
+_pullback(cx::AContext, ::typeof(getproperty), x, f::Symbol) =
   _pullback(cx, literal_getproperty, x, Val(f))
 
-_pullback(cx::Context, ::typeof(getfield), x, f::Symbol) =
+_pullback(cx::AContext, ::typeof(getfield), x, f::Symbol) =
   _pullback(cx, literal_getproperty, x, Val(f))
 
-_pullback(cx::Context, ::typeof(literal_getindex), x::NamedTuple, ::Val{f}) where f =
+_pullback(cx::AContext, ::typeof(literal_getindex), x::NamedTuple, ::Val{f}) where f =
   _pullback(cx, literal_getproperty, x, Val(f))
 
-_pullback(cx::Context, ::typeof(literal_getproperty), x::Tuple, ::Val{f}) where f =
+_pullback(cx::AContext, ::typeof(literal_getproperty), x::Tuple, ::Val{f}) where f =
   _pullback(cx, literal_getindex, x, Val(f))
 
 grad_mut(x) = Ref{Any}(nt_nothing(x))


### PR DESCRIPTION
Some of the rules in lib/lib have concrete type constraints to `Context`, rather than the (abstract) `AContext`. This has caused me some problems while playing around with my own subtype of `AContext`.

@DhairyaLGandhi  do you reckon this is going to be okay? I can't forsee it causing problems, but I'm not sure if I'm missing something important.