### PR TITLE
WIP: cache-less contexts

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Zygote"
 uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
-version = "0.6.0"
+version = "0.6.1"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
@@ -17,6 +17,7 @@ NaNMath = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 

--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -11,6 +11,27 @@ Context() = Context(nothing)
 
 cache(cx::Context) = cx.cache === nothing ? (cx.cache = IdDict()) : cx.cache
 
+"""
+  NoContext <: Zygote.AContext
+
+The `NoContext` context assumes that there is no global context, and errors if any part of a
+function that is being differentiated interacts with either globals or tasks.
+
+The benefit of using such a construct is the elimination of overhead associated with the
+`cache` `IdDict` in a standard `Context`, which can be prohibitively large in certain
+settings.
+"""
+struct NoContext <: Zygote.AContext end
+
+# There is no cache, so there are never any fields.
+cache(cx::NoContext) = (cache_fields=nothing)
+
+# The is no cache, so this context never has any fields.
+Base.haskey(cx::NoContext, x) = false
+
+accum_param(::NoContext, x, Δ) = Δ
+
+
 struct Pullback{S,T}
   t::T
 end

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -28,9 +28,13 @@ end
 @adjoint (::Type{T})(sz) where {T<:Zeros} = T(sz), Δ->(nothing,)
 @adjoint (::Type{T})(sz) where {T<:Ones} = T(sz), Δ->(nothing,)
 
-@adjoint getindex(x::AbstractArray, inds...) = x[inds...], ∇getindex(x, inds)
+@adjoint function getindex(x::Array, inds...)
+  return x[inds...], ∇getindex(x, inds)
+end
 
-@adjoint view(x::AbstractArray, inds...) = view(x, inds...), ∇getindex(x, inds)
+@adjoint function view(x::AbstractArray, inds...)
+  return view(x, inds...), ∇getindex(x, inds)
+end
 
 ∇getindex(x::AbstractArray, inds) = dy -> begin
   if inds isa  NTuple{<:Any, Integer}


### PR DESCRIPTION
EDIT: it looks like I mis-diagnosed what was causing performance issues -- it was to do with the stability of `literal_getproperty` rather than being related to this. Consequently, I'm stuck for a good example where this fixes something that was broken. Sorry for getting your hopes up @oxinabox !

This is a proposal to introduce a specialised `AContext` type that sacrifices the ability to handle
1. globals
2. tasks
 
in exchange for substantially reduced overhead in certain circumstances. This gives users and rule-writers the ability to tell Zygote not to worry about either globals or tasks if they're not using them and, moreover, is done in (I believe) a safe way in that if such things _are_ encountered, the code errors.

In terms of performance improvements, with the standard `Context`, the following performance is obtained:
```julia
using BenchmarkTools, StaticArrays, Zygote
a = SMatrix{2, 2}(randn(2, 2));

julia> @benchmark Zygote._pullback($(Zygote.Context()), x -> x[1], $a)
BenchmarkTools.Trial:
  memory estimate:  2.11 KiB
  allocs estimate:  26
  --------------
  minimum time:     4.780 μs (0.00% GC)
  median time:      4.951 μs (0.00% GC)
  mean time:        5.368 μs (2.72% GC)
  maximum time:     504.230 μs (98.55% GC)
  --------------
  samples:          10000
  evals/sample:     7

out, pb = Zygote._pullback(Zygote.Context(), x -> x[1], a);

julia> @benchmark $pb($out)
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     0.037 ns (0.00% GC)
  median time:      0.039 ns (0.00% GC)
  mean time:        0.039 ns (0.00% GC)
  maximum time:     0.047 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     1000
```
while the new `NoContext` context yields:
```julia
julia> @benchmark Zygote._pullback(Zygote.NoContext(), x -> x[1], $a)
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     0.036 ns (0.00% GC)
  median time:      0.039 ns (0.00% GC)
  mean time:        0.039 ns (0.00% GC)
  maximum time:     0.046 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     1000

julia> out, pb = Zygote._pullback(Zygote.NoContext(), x -> x[1], a);

julia> @benchmark $pb($out)
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     0.036 ns (0.00% GC)
  median time:      0.039 ns (0.00% GC)
  mean time:        0.039 ns (0.00% GC)
  maximum time:     0.055 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     1000
```
As you can see, the overhead is completely eliminated, which is due to the loss of the cache.

Note that to provide the above example I've temporarily modified the `getindex` implementation because it was the easiest way to provide a MWE. The actual reason I investigated the use of this type was for some work on my [TemporalGPs](https://github.com/willtebbutt/TemporalGPs.jl/) package, where I've managed to get Zygote to derive zero-allocation implementations of some code where it's _really_ crucial that it does so (on the 0.4-DEV branch) -- I had previously hand-written rules for these sections of code but they were a complete nightmare to maintain. The point being that you don't _just_ see performance impovements for `getindex`, it's just one example.

I _believe_ that the main source of performance improvement is that `accum_param` function is always type stable for `NoContext`, whereas for `Context` is it only type-stable if `isbitstype(x)`.

@DhairyaLGandhi do you a) think that this is a good thing to have, and b) what sort of testing do you think we would need?

edit: I should say that I do think that we need to restrict the types to which `getindex` applies for the sake of #863 , but I don't want to address that in this PR.

edit2: this doesn't require the addition of StaticArrays -- the dep would be removed prior merging something like this.