### PR TITLE
Remove eigen and eigvals adjoints for Symmetric/Hermitian

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,7 +22,7 @@ ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 
 [compat]
 AbstractFFTs = "0.5, 1.0"
-ChainRules = "0.7.34"
+ChainRules = "0.7.44"
 DiffRules = "1.0"
 FillArrays = "0.8, 0.9, 0.10, 0.11"
 ForwardDiff = "0.10"

--- a/Project.toml
+++ b/Project.toml
@@ -22,7 +22,7 @@ ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 
 [compat]
 AbstractFFTs = "0.5, 1.0"
-ChainRules = "0.7.44"
+ChainRules = "0.7.45"
 DiffRules = "1.0"
 FillArrays = "0.8, 0.9, 0.10, 0.11"
 ForwardDiff = "0.10"

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -570,32 +570,6 @@ end
   return (Ā,)
 end
 
-@adjoint function LinearAlgebra.eigen(A::LinearAlgebra.RealHermSymComplexHerm)
-  dU = eigen(A)
-  return dU, function (Δ)
-    d, U = dU
-    d̄, Ū = Δ
-    if Ū === nothing
-      P = Diagonal(d̄)
-    else
-      F = inv.(d' .- d)
-      P = F .* (U' * Ū)
-      if d̄ === nothing
-        P[diagind(P)] .= 0
-      else
-        P[diagind(P)] = d̄
-      end
-    end
-    return (U * P * U',)
-  end
-end
-
-@adjoint function LinearAlgebra.eigvals(A::LinearAlgebra.RealHermSymComplexHerm)
-  d, U = eigen(A)
-  return d, d̄ -> (U * Diagonal(d̄) * U',)
-end
-
-
 # Hermitian/Symmetric matrix functions that can be written as power series
 _realifydiag!(A::AbstractArray{<:Real}) = A
 function _realifydiag!(A)

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -775,49 +775,6 @@ function _gradtest_hermsym(f, ST, A)
   end
 end
 
-@testset "eigen(::RealHermSymComplexHerm)" begin
-  MTs = (Symmetric{Float64}, Hermitian{Float64}, Hermitian{ComplexF64})
-  rng, N = MersenneTwister(123), 7
-  @testset "eigen(::$MT)" for MT in MTs
-    T = eltype(MT)
-    ST = _hermsymtype(MT)
-
-    A = ST(randn(rng, T, N, N))
-    U = eigvecs(A)
-
-    @test _gradtest_hermsym(ST, A) do (A)
-      d, U = eigen(A)
-      return U * Diagonal(exp.(d)) * U'
-    end
-
-    y = Zygote.pullback(eigen, A)[1]
-    y2 = eigen(A)
-    @test y.values ≈ y2.values
-    @test y.vectors ≈ y2.vectors
-
-    @testset "low rank" begin
-      A2 = Symmetric(U * Diagonal([randn(rng), zeros(N-1)...]) * U')
-      @test_broken _gradtest_hermsym(ST, A2) do (A)
-        d, U = eigen(A)
-        return U * Diagonal(exp.(d)) * U'
-      end
-    end
-  end
-end
-
-@testset "eigvals(::RealHermSymComplexHerm)" begin
-  MTs = (Symmetric{Float64}, Hermitian{Float64}, Hermitian{ComplexF64})
-  rng, N = MersenneTwister(123), 7
-  @testset "eigvals(::$MT)" for MT in MTs
-    T = eltype(MT)
-    ST = _hermsymtype(MT)
-
-    A = ST(randn(rng, T, N, N))
-    @test _gradtest_hermsym(A ->eigvals(A), ST, A)
-    @test Zygote.pullback(eigvals, A)[1] ≈ eigvals(A)
-  end
-end
-
 _randmatunitary(rng, T, n) = qr(randn(rng, T, n, n)).Q
 function _randvectorin(rng, n, r)
   l, u = r


### PR DESCRIPTION
https://github.com/JuliaDiff/ChainRules.jl/pull/323 added rrules for `eigen` and `eigvals` for Symmetric/Hermitian matrices. This PR removes those rules from Zygote. Once the old tests pass, I'll remove them, since the rrules are more thoroughly tested.

Depends on https://github.com/JuliaRegistries/General/pull/27508 is merged.