### PR TITLE
fix cat with Val dims

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -117,9 +117,10 @@ end
 @adjoint function cat(Xs...; dims)
   cat(Xs...; dims = dims), Δ -> begin
     start = ntuple(_ -> 0, ndims(Δ))
+    catdims = Base.dims2cat(dims)
     dXs = map(Xs) do x
-      move = ntuple(d -> d in dims ? size(x,d) : 0, ndims(Δ))
-      x_in_Δ = ntuple(d -> d in dims ? (start[d]+1:start[d]+move[d]) : Colon(), ndims(Δ))
+      move = ntuple(d -> (d<=length(catdims) && catdims[d]) ? size(x,d) : 0, ndims(Δ))
+      x_in_Δ = ntuple(d -> (d<=length(catdims) && catdims[d]) ? (start[d]+1:start[d]+move[d]) : Colon(), ndims(Δ))
       start = start .+ move
       dx = reshape(Δ[x_in_Δ...], size(x))
     end

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -122,7 +122,7 @@ end
       move = ntuple(d -> (d<=length(catdims) && catdims[d]) ? size(x,d) : 0, ndims(Δ))
       x_in_Δ = ntuple(d -> (d<=length(catdims) && catdims[d]) ? (start[d]+1:start[d]+move[d]) : Colon(), ndims(Δ))
       start = start .+ move
-      dx = reshape(Δ[x_in_Δ...], size(x))
+      dx = Δ[x_in_Δ...]
     end
   end
 end

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -1143,6 +1143,13 @@ end
   @test gradtest(catdim, rand(2,5,3), rand(2,5,3), rand(2,5,3))
 end
 
+@testset "cat(..., dims = Val($dim))" for dim in 1:5
+  catdim = (x...) -> cat(x..., dims = Val(dim))
+  @test gradtest(catdim, rand(5), rand(5))
+  @test gradtest(catdim, rand(2,5), rand(2,5), rand(2,5))
+  @test gradtest(catdim, rand(2,5,3), rand(2,5,3), rand(2,5,3))
+end
+
 @testset "cat empty" begin
   catdim = (x...) -> cat(x..., dims = (1, 2))
   @test gradtest(catdim, rand(0,5,3), rand(2,5,3), rand(2,5,3))


### PR DESCRIPTION
Fixes `Base.cat` when `dims` is specified as a `Val` (Base has this to help make some things type stable). The code uses `Base.dims2cat` which is the same thing `Base.cat` uses. Thanks to @sethaxen for pointing me in this direction on Slack.