### PR TITLE
Remove Symmetric/Hermitian matrix function rules

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,7 +22,7 @@ ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 
 [compat]
 AbstractFFTs = "0.5, 1.0"
-ChainRules = "0.7.45"
+ChainRules = "0.7.46"
 DiffRules = "1.0"
 FillArrays = "0.8, 0.9, 0.10, 0.11"
 ForwardDiff = "0.10"

--- a/Project.toml
+++ b/Project.toml
@@ -22,7 +22,7 @@ ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 
 [compat]
 AbstractFFTs = "0.5, 1.0"
-ChainRules = "0.7.46"
+ChainRules = "0.7.47"
 DiffRules = "1.0"
 FillArrays = "0.8, 0.9, 0.10, 0.11"
 ForwardDiff = "0.10"

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -574,7 +574,7 @@ end
 # so we call it manually. This can be removed when the generic rule for exp is moved to
 # ChainRules
 function _pullback(::AContext, ::typeof(exp), A::LinearAlgebra.RealHermSymComplexHerm)
-@adoint exp(A::LinearAlgebra.RealHermSymComplexHerm)
+@adjoint exp(A::LinearAlgebra.RealHermSymComplexHerm)
     Y, back = chain_rrule(exp, A)
     return Y, Δ -> (back(Δ)[2],)
 end

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -574,7 +574,9 @@ end
 # so we call it manually. This can be removed when the generic rule for exp is moved to
 # ChainRules
 function _pullback(::AContext, ::typeof(exp), A::LinearAlgebra.RealHermSymComplexHerm)
-    return chain_rrule(exp, A)
+@adoint exp(A::LinearAlgebra.RealHermSymComplexHerm)
+    Y, back = chain_rrule(exp, A)
+    return Y, Δ -> (back(Δ)[2],)
 end
 
 # Hermitian/Symmetric matrix functions that can be written as power series

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -570,6 +570,13 @@ end
   return (Ā,)
 end
 
+# The adjoint for exp(::AbstractArray) intercepts ChainRules' rrule for exp(::Hermitian),
+# so we call it manually. This can be removed when the generic rule for exp is moved to
+# ChainRules
+function _pullback(::AContext, ::typeof(exp), A::LinearAlgebra.RealHermSymComplexHerm)
+    return chain_rrule(exp, A)
+end
+
 # Hermitian/Symmetric matrix functions that can be written as power series
 _realifydiag!(A::AbstractArray{<:Real}) = A
 function _realifydiag!(A)

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -573,7 +573,7 @@ end
 # The adjoint for exp(::AbstractArray) intercepts ChainRules' rrule for exp(::Hermitian),
 # so we call it manually. This can be removed when the generic rule for exp is moved to
 # ChainRules
-@adjoint exp(A::LinearAlgebra.RealHermSymComplexHerm)
+@adjoint function exp(A::LinearAlgebra.RealHermSymComplexHerm)
     Y, back = chain_rrule(exp, A)
     return Y, Δ -> (back(Δ)[2],)
 end

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -573,7 +573,6 @@ end
 # The adjoint for exp(::AbstractArray) intercepts ChainRules' rrule for exp(::Hermitian),
 # so we call it manually. This can be removed when the generic rule for exp is moved to
 # ChainRules
-function _pullback(::AContext, ::typeof(exp), A::LinearAlgebra.RealHermSymComplexHerm)
 @adjoint exp(A::LinearAlgebra.RealHermSymComplexHerm)
     Y, back = chain_rrule(exp, A)
     return Y, Δ -> (back(Δ)[2],)

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -865,10 +865,17 @@ _randmatseries(rng, ::typeof(atanh), T, n, domain::Type{Complex}) = nothing
 
         @test _gradtest_hermsym(f, ST, A)
 
-        y = Zygote.pullback(f, A)[1]
+        y, back = Zygote.pullback(f, A)
         y2 = f(A)
         @test y ≈ y2
         @test typeof(y) == typeof(y2)
+        ȳ = randn(eltype(y), size(y))
+        if y isa Union{Symmetric,Hermitian}
+            ȳ = typeof(y)(ȳ, y.uplo)
+        end
+        Ā = back(ȳ)[1]
+        @test typeof(Ā) == typeof(A)
+        @test Ā.uplo == A.uplo
 
         @testset "similar eigenvalues" begin
           λ[1] = λ[3] + sqrt(eps(eltype(λ))) / 10


### PR DESCRIPTION
https://github.com/JuliaDiff/ChainRules.jl/pull/193 (which is about to be merged) adds to ChainRules the `rrule`s for  matrix functions (i.e. power series functions) of `Symmetric` and `Hermitian` matrices. This PR removes the corresponding adjoints from Zygote. Tests pass locally but won't here until a new CR release is registered. This PR is blocked until then.