### PR TITLE
Bump the patch

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Zygote"
 uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
-version = "0.6.0"
+version = "0.6.1"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"


### PR DESCRIPTION
There have been a lot of non-breaking commits since 0.6.0. We appear to have not been bumping the patch, which is unfortunate as it prevents (particularly compat-related) changes being propagated to other packages. The result is that the ecosystem gets stuck on old versions of packages, ultimately preventing useful bug fixes from being utilised. It also stops useful feedback from the community on any changes that were made in Zygote that we didn't think were breaking but actually were.

Anyway, this PR bumps the patch version.