### PR TITLE
Remove rules for matrix exponential

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Zygote"
 uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
-version = "0.6.1"
+version = "0.6.2"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/Project.toml
+++ b/Project.toml
@@ -22,7 +22,7 @@ ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 
 [compat]
 AbstractFFTs = "0.5, 1.0"
-ChainRules = "0.7.47"
+ChainRules = "0.7.49"
 DiffRules = "1.0"
 FillArrays = "0.8, 0.9, 0.10, 0.11"
 ForwardDiff = "0.10"


### PR DESCRIPTION
https://github.com/JuliaDiff/ChainRules.jl/pull/351 added rules for the dense matrix exponential to ChainRules. This PR removes the corresponding adjoint from Zygote.