### PR TITLE
Store the primal value in Grads

### DIFF
--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -123,12 +123,13 @@ function copy!(x::AbstractVector, ps::Params)
 end
 
 
-struct Grads
+struct Grads{T}
   grads::IdDict{Any,Any}
   params::Params
+  value::T
 end
 
-Base.show(io::IO, ps::Grads) = print(io, "Grads(...)")
+Base.show(io::IO, gs::Grads) = print(io, "Grads([...], value = ", gs.value, ")")
 
 @forward Grads.grads Base.getindex, Base.haskey
 
@@ -170,7 +171,7 @@ function pullback(f, ps::Params)
       cache(cx)[p] = nothing
     end
     back(Δ)
-    Grads(cx.cache, ps) # TODO make a copy
+    Grads(cx.cache, ps, y) # TODO make a copy
   end
 end
 

--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -122,12 +122,22 @@ function copy!(x::AbstractVector, ps::Params)
   ps
 end
 
+"""
+    gradient(() -> loss(), ::Params) -> Grads
+
+Gradient with implicit parameters. Returns a container, from which
+`grads[W]` extracts the gradient with respect to `W`.
+This contains as `grads.value` the value of the function.
+"""
+function gradient end
 
 struct Grads{T}
   grads::IdDict{Any,Any}
   params::Params
   value::T
 end
+
+Grads(gs, ps) = Grads(gs, ps, nothing)
 
 Base.show(io::IO, gs::Grads) = print(io, "Grads([...], value = ", gs.value, ")")
 

--- a/test/features.jl
+++ b/test/features.jl
@@ -296,6 +296,7 @@ let
     p′[1]
   end
   @test θ̄[p][1] == 1
+  @test θ̄.value == 1
 end
 
 @test gradient(2) do x


### PR DESCRIPTION
This alters the `Grads` struct to also keep the forward value. Occasionally this will save you from having to write `y,b=pullback(...); b(1.0)` (or is it `b(1f0)` today?). It's already calculated, there seems no reason not to return it, in case it's useful. Should  be non-breaking. 

For `gradient(f, args...)` with explicit arguments, no change. There too it would sometimes be nice to have the primal available, but since it just returns a tuple there's no super-easy way to add it.