### PR TITLE
Gradients for `eachcol` & friends

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -331,6 +331,27 @@ end
   end
 end
 
+@adjoint eachrow(x::AbstractVecOrMat) = collect(eachrow(x)), dys -> ∇eachslice(dys, x, 1)
+@adjoint eachcol(x::AbstractVecOrMat) = collect(eachcol(x)), dys -> ∇eachslice(dys, x, 2)
+@adjoint eachslice(x::AbstractArray; dims::Integer) =
+  collect(eachslice(x; dims=dims)), dys -> ∇eachslice(dys, x, dims)
+
+function ∇eachslice(dys, x::AbstractArray, dim::Integer) where {TX}
+  i1 = findfirst(dy -> dy isa AbstractArray, dys)
+  i1 === nothing && return (zero(x),) # all slices get nothing
+  T = promote_type(eltype(dys[i1]), eltype(x))
+  dx = similar(x, T)
+  for i in axes(x, dim)
+    if dys[i] isa AbstractArray
+      copyto!(selectdim(dx,dim,i), dys[i])
+    else
+      selectdim(dx,dim,i) .= 0
+    end
+  end
+  (dx,)
+end
+
+
 # LinearAlgebra
 # =============
 

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -190,6 +190,22 @@ end
   @test gradient(g, ones(3)) == ([1,0,0],)
 end
 
+@testset "eachcol" begin
+    @test gradtest(x -> map(sum, eachcol(x)), (3,4))
+    @test gradtest(x -> map(sum, eachcol(transpose(x))), (3,4))
+
+    @test gradtest(x -> map(norm, eachcol(x)), (3,4))
+    @test gradtest(x -> map(norm, eachrow(x)), (3,4))
+    @test gradtest(x -> map(norm, eachslice(x, dims=3)), (3,4,5))
+
+    # some slices may have gradient nothing
+    @test gradient(x -> sum(y -> rand()>0.5 ? 0 : first(y), eachcol(x)), rand(3,10))[1] isa Matrix
+
+    # strange errors
+    @test_skip gradient(x -> sum(norm, eachcol(x)), [1 2 3; 4 5 6])[1] isa Matrix
+    @test_skip gradient(x -> sum(norm, eachcol(x)), rand(3,400))[1] isa Matrix
+end
+
 @testset "collect" begin
   @test gradient(x -> sum(inv, collect(x)), (1,2)) === ((-1.0, -1/4),)
 
@@ -1040,8 +1056,8 @@ end
         Y = copy(X)
         Δ = randn(P, P)
         Δ_fd = FiniteDifferences.j′vp(
-                  FiniteDifferences.central_fdm(5, 1), 
-                  X -> pairwise(metric, X, Y; dims=2), 
+                  FiniteDifferences.central_fdm(5, 1),
+                  X -> pairwise(metric, X, Y; dims=2),
                   Δ, X)
         _, pb = Zygote.pullback(X -> pairwise(metric, X, Y; dims=2), X)
 


### PR DESCRIPTION
This is an optimisation to work around `getindex`'s gradient. In a few small tests it was twice as fast. 