### PR TITLE
Fix docs deployment

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,6 @@
 using Pkg;
 Pkg.activate(joinpath(@__DIR__, "..")); Pkg.instantiate()
-Pkg.activate(); Pkg.instantiate()
+Pkg.activate(@__DIR__); Pkg.instantiate()
 
 pushfirst!(LOAD_PATH, joinpath(@__DIR__, ".."))
 


### PR DESCRIPTION
I'm not sure when/how this affected things, but the current `docs/make.jl` activates the v1.6 environment instead of the `docs/Project.toml` environment. This means that Documenter is not available to the CI.

I minimized the changes to just what's necessary to get things working, but there's generally a bunch of weird path related stuff happening with the environments in this package. I'd like to clean it up @DhairyaLGandhi @CarloLucibello (not sure if it is necessary for Zygote.jl for some reason, but I don't see why it should be).