### PR TITLE
Improve performance of `Base.Fix1` and `Base.Fix2`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -38,14 +38,12 @@ ZygoteRules = "0.2.1"
 julia = "1.3"
 
 [extras]
-BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
-StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["BenchmarkTools", "CUDA", "Distances", "FFTW", "FiniteDifferences", "LogExpFunctions", "Test"]
+test = ["CUDA", "Distances", "FFTW", "FiniteDifferences", "LogExpFunctions", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -43,6 +43,7 @@ Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
+StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c" # otherwise we can't add a compat bound
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]

--- a/Project.toml
+++ b/Project.toml
@@ -37,6 +37,7 @@ ZygoteRules = "0.2.1"
 julia = "1.3"
 
 [extras]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
@@ -45,4 +46,4 @@ StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["CUDA", "Distances", "FFTW", "FiniteDifferences", "StatsFuns", "Test"]
+test = ["BenchmarkTools", "CUDA", "Distances", "FFTW", "FiniteDifferences", "StatsFuns", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Zygote"
 uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
-version = "0.6.10"
+version = "0.6.11"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Zygote"
 uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
-version = "0.6.9"
+version = "0.6.10"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/lib/base.jl
+++ b/src/lib/base.jl
@@ -140,3 +140,17 @@ end
 @adjoint Base.nameof(x::UnionAll) = nameof(x), _ -> (nothing,)
 
 @nograd typeintersect
+
+# Base.Fix1 and Base.Fix2: https://github.com/FluxML/Zygote.jl/issues/957
+@adjoint function (g::Base.Fix1)(y)
+    f = g.f
+    x = g.x
+    fallback_Fix1(y) = f(x, y)
+    return _pullback(__context__, fallback_Fix1, y)
+end
+@adjoint function (g::Base.Fix2)(y)
+    f = g.f
+    x = g.x
+    fallback_Fix2(y) = f(y, x)
+    return _pullback(__context__, fallback_Fix2, y)
+end

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -1672,3 +1672,18 @@ end
     gradient(x->norm(x*[1im, 1]), 1.23)
     gradient(x->norm(x*[1im 1]), 1.23)
 end
+
+@testset "Fix1 and Fix2" begin
+    @test gradcheck(x -> prod(Base.Fix1(+, 1), x), randn(100))
+    @test gradcheck(x -> prod(Base.Fix2(+, 1), x), randn(100))
+
+    # compile once and check the execution times compared with a closure
+    # https://github.com/FluxML/Zygote.jl/issues/957
+    x = randn(100)
+    gradient(x -> prod(y -> y + 1, x), x)
+    t = @elapsed(gradient(x -> prod(y -> y + 1, x), x))
+    gradient(x -> prod(Base.Fix1(+, 1), x), x)
+    @test @elapsed(gradient(x -> prod(Base.Fix1(+, 1), x), x)) < 2 * t
+    gradient(x -> prod(Base.Fix1(+, 1), x), x)
+    @test @elapsed(gradient(x -> prod(Base.Fix2(+, 1), x), x)) < 2 * t
+end

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -4,7 +4,6 @@ using Zygote: gradient
 using Base.Broadcast: broadcast_shape
 using Distributed: pmap, CachingPool, workers
 import FiniteDifferences
-using BenchmarkTools
 
 function ngradient(f, xs::AbstractArray...)
   grads = zero.(xs)
@@ -1719,6 +1718,7 @@ end
     @test gradcheck(x -> prod(Base.Fix1(+, 1), x), randn(100))
     @test gradcheck(x -> prod(Base.Fix2(+, 1), x), randn(100))
 
+#= regression tests are not included to reduce CI times
     # check the execution times compared with a closure
     # https://github.com/FluxML/Zygote.jl/issues/957
     x = randn(100)
@@ -1727,4 +1727,5 @@ end
     tfix2 = @belapsed(gradient($(x -> prod(Base.Fix2(+, 1), x)), $x))
     @test tfix1 < 2 * tclosure
     @test tfix2 < 2 * tclosure
+=#
 end


### PR DESCRIPTION
This PR addresses https://github.com/FluxML/Zygote.jl/issues/957.

Currently (copied from the issue above):
```julia
julia> using Zygote, BenchmarkTools

julia> x = rand(100);

julia> @btime Zygote.gradient($(x -> prod(y -> y + 1, x)), $x);
  10.373 μs (343 allocations: 13.27 KiB)

julia> @btime Zygote.gradient($(x -> prod(Base.Fix1(+, 1), x)), $x);
  342.138 μs (3608 allocations: 138.08 KiB)

julia> @btime Zygote.gradient($(x -> prod(Base.Fix2(+, 1), x)), $x);
  352.705 μs (3607 allocations: 138.06 KiB)
```

With this PR:
```julia
julia> using Zygote, BenchmarkTools

julia> x = rand(100);

julia> @btime Zygote.gradient($(x -> prod(y -> y + 1, x)), $x);
  10.033 μs (343 allocations: 13.27 KiB)

julia> @btime Zygote.gradient($(x -> prod(Base.Fix1(+, 1), x)), $x);
  12.150 μs (453 allocations: 27.73 KiB)

julia> @btime Zygote.gradient($(x -> prod(Base.Fix2(+, 1), x)), $x);
  12.223 μs (453 allocations: 27.73 KiB)
```

My main questions are:
- Why is it still slower and causes many more allocations?
- Why are `Base.Fix1` and `Base.Fix2` so slow in the first place and don't just work?