### PR TITLE
Function to compute the diagonal of the Hessian

### DIFF
--- a/docs/src/utils.md
+++ b/docs/src/utils.md
@@ -6,6 +6,7 @@ or a Hessian (by taking a second derivative).
 ```@docs
 Zygote.jacobian
 Zygote.hessian
+Zygote.diaghessian
 ```
 
 Zygote also provides a set of helpful utilities. These are all "user-level" tools –

--- a/src/Zygote.jl
+++ b/src/Zygote.jl
@@ -12,7 +12,7 @@ using MacroTools, Requires
 using MacroTools: @forward
 
 import Distributed: pmap, CachingPool, workers
-export Params, gradient, jacobian, hessian, pullback, pushforward, @code_adjoint
+export Params, gradient, jacobian, hessian, diaghessian, pullback, pushforward, @code_adjoint
 
 const Numeric{T<:Number} = Union{T, AbstractArray{<:T}}
 

--- a/src/lib/forward.jl
+++ b/src/lib/forward.jl
@@ -81,53 +81,6 @@ function forward_diag(f, x::AbstractArray)
   end
 end
 
-# and another approach: all forward, directly 2nd order
-
-seed_2nd(x::Real, ::Val) = Dual(Dual(x, true), true)
-
-function seed_2nd(xs, ::Val{N}, offset = 0) where N
-  map(xs, reshape(1:length(xs), size(xs))) do x, i
-    b = ntuple(j -> j+offset == i, Val(N))
-    Dual(Dual(x, b), b)
-  end
-end
-function seed_2nd!(xplus, xs, ::Val{N}, offset) where N
-  map!(xplus, xs, reshape(1:length(xs), size(xs))) do x, i
-    b = ntuple(j -> j+offset == i, Val(N))
-    Dual(Dual(x, b), b)
-  end
-end
-
-function extract_2nd!(out, fx::ForwardDiff.Dual{T,V,N}, offset) where {T,V,N}
-  for j in 1:min(N, length(out)-offset)
-    out[j+offset] = fx.partials.values[j].partials.values[j]
-  end
-end
-
-function forward_2nd(f, x::AbstractArray{T}, ::Val{N}) where {N,T}
-  xplus = seed_2nd(x, Val(N), 0)
-  fx = f(xplus)
-  out = similar(x, ForwardDiff.valtype(ForwardDiff.valtype(typeof(fx))))
-  extract_2nd!(out, fx, 0)
-  offset = 0
-  while offset + N < length(x)
-    offset += N
-    fx = f(seed_2nd!(xplus, x, Val(N), offset))
-    extract_2nd!(out, fx, offset)
-  end
-  return fx.value.value, out
-end
-
-function forward_2nd(f, x::AbstractArray)
-  # if length(x) < ForwardDiff.DEFAULT_CHUNK_THRESHOLD
-  #   forward_2nd(f, x, Val(length(x)))
-  # else
-  #   forward_2nd(f, x, Val(ForwardDiff.DEFAULT_CHUNK_THRESHOLD ÷ 2))
-    forward_2nd(f, x, Val(3))
-  # end
-end
-
-
 """
     forwarddiff(f, x) -> f(x)
 

--- a/src/lib/forward.jl
+++ b/src/lib/forward.jl
@@ -131,3 +131,9 @@ forwarddiff(f, x) = f(x)
   y, J = forward_jacobian(f, x)
   return y, ȳ -> (nothing, reshape_scalar(x, J*vec_scalar(ȳ)))
 end
+
+# Second derivatives
+@adjoint ForwardDiff.derivative(f, x) = pullback(forwarddiff, x -> ForwardDiff.derivative(f, x), x)
+@adjoint ForwardDiff.gradient(f, x) = pullback(forwarddiff, x -> ForwardDiff.gradient(f, x), x)
+@adjoint ForwardDiff.jacobian(f, x) = pullback(forwarddiff, x -> ForwardDiff.jacobian(f, x), x)
+

--- a/src/lib/forward.jl
+++ b/src/lib/forward.jl
@@ -137,8 +137,3 @@ forwarddiff(f, x) = f(x)
   return y, ȳ -> (nothing, reshape_scalar(x, J*vec_scalar(ȳ)))
 end
 
-# Second derivatives
-@adjoint ForwardDiff.derivative(f, x) = pullback(forwarddiff, x -> ForwardDiff.derivative(f, x), x)
-@adjoint ForwardDiff.gradient(f, x) = pullback(forwarddiff, x -> ForwardDiff.gradient(f, x), x)
-@adjoint ForwardDiff.jacobian(f, x) = pullback(forwarddiff, x -> ForwardDiff.jacobian(f, x), x)
-

--- a/src/lib/grad.jl
+++ b/src/lib/grad.jl
@@ -50,6 +50,8 @@ is higher-dimensional.
 This uses forward over reverse, ForwardDiff over Zygote, calling `hessian_dual(f, x)`.
 See [`hessian_reverse`](@ref) for an all-Zygote alternative.
 
+See also [`diaghessian`](@ref) to compute only the diagonal part.
+
 # Examples
 
 ```jldoctest; setup=:(using Zygote)
@@ -240,7 +242,7 @@ true
 julia> diaghessian((x,y) -> sum(x .* y .* y'), [1 22; 333 4], [0.5, 0.666])  # two array arguments
 ([0.0 0.0; 0.0 0.0], [2.0, 8.0])
 
-julia> diaghessian(atan, 1, 2)  # scalar arguments
+julia> diaghessian(atan, 1, 2)  # two scalar arguments
 (-0.16, 0.16)
 
 julia> hessian(xy -> atan(xy[1], xy[2]), [1, 2])  # full Hessian is not diagonal

--- a/src/lib/grad.jl
+++ b/src/lib/grad.jl
@@ -217,9 +217,8 @@ end
 """
     diaghessian(f, args...)
 
-Diagonal part of the Hessian. Returns a tuple containing 
-an array `h` the same shape as each argument `x`,
-with `Hᵢᵢ = h[i] = ∂²y/∂x[i]∂x[i]`. 
+Diagonal part of the Hessian. Returns a tuple containing, for each argument `x`,
+`h` of the same shape with `h[i] = Hᵢᵢ = ∂²y/∂x[i]∂x[i]`. 
 The original evaluation `y = f(args...)` must give a real number `y`.
 
 For one vector argument `x`, this is equivalent to `(diag(hessian(f,x)),)`.
@@ -252,14 +251,14 @@ julia> hessian(xy -> atan(xy[1], xy[2]), [1, 2])  # full Hessian is not diagonal
 """
 function diaghessian(f, args...)
   ntuple(length(args)) do n
-    x = args[n]
-    if x isa AbstractArray
-      forward_diag(x -> gradient(f, _splice(x, args, Val(n))...)[n], x)[2]
-    elseif x isa Number
-      ForwardDiff.derivative(x -> gradient(f, _splice(x, args, Val(n))...)[n], x)
+    let x = args[n], valn = Val(n)  # let Val improves speed, sometimes
+      if x isa AbstractArray
+        forward_diag(x -> gradient(f, _splice(x, args, valn)...)[n], x)[2]
+      elseif x isa Number
+        ForwardDiff.derivative(x -> gradient(f, _splice(x, args, valn)...)[n], x)
+      end
     end
   end
 end
 
 _splice(x, args, ::Val{n}) where {n} = ntuple(i -> i==n ? x : args[i], length(args))
-

--- a/src/lib/grad.jl
+++ b/src/lib/grad.jl
@@ -264,17 +264,3 @@ function diaghessian(f, args...)
 end
 
 _splice(x, args, ::Val{n}) where {n} = ntuple(i -> i==n ? x : args[i], length(args))
-
-function diaghessian_2nd(f, args...)
-  ntuple(length(args)) do n
-    let x = args[n], valn = Val(n)
-      if x isa AbstractArray
-        forward_2nd(x -> f(_splice(x, args, valn)...), x)[2]
-      elseif x isa Number
-        ForwardDiff.hessian(x -> f(_splice(x[1], args, valn)...), [x])[1]
-      end
-    end
-  end
-end
-
-export diaghessian_2nd

--- a/src/lib/grad.jl
+++ b/src/lib/grad.jl
@@ -217,14 +217,30 @@ end
 """
     diaghessian(f, args...)
 
-Diagonal part of the Hessian, literally `diaghessian(f, x)[1] == diag(hessian(f,x))` 
-for one vector argument `x`. In general this returns a tuple, with an array the same shape 
-as each argument, `d[i] = ∂²y/∂x[i]∂x[i]`, where `y = f(args...)` must be a real number.
+Diagonal part of the Hessian. Returns a tuple containing 
+an array `h` the same shape as each argument `x`,
+with `Hᵢᵢ = h[i] = ∂²y/∂x[i]∂x[i]`. 
+The original evaluation `y = f(args...)` must give a real number `y`.
 
+For one vector argument `x`, this is equivalent to `(diag(hessian(f,x)),)`.
 Like [`hessian`](@ref) it uses ForwardDiff over Zygote. 
 
 !!! warning
     For arguments of any type except `Number` & `AbstractArray`, the result is `nothing`.
+
+# Examples
+```jldoctest; setup=:(using Zygote, LinearAlgebra)
+julia> diaghessian(x -> sum(x.^3), [1 2; 3 4])[1]
+2×2 Matrix{$Int}:
+  6  12
+ 18  24
+
+julia> Diagonal(vec(ans)) == hessian(x -> sum(x.^3), [1 2; 3 4])
+true
+
+julia> diaghessian((x,y) -> sum(x .* y .* y'), [1 22; 333 4], [0.5, 0.666])
+([0.0 0.0; 0.0 0.0], [2.0, 8.0])
+```
 """
 function diaghessian(f, args...)
   ntuple(length(args)) do n
@@ -236,8 +252,6 @@ function diaghessian(f, args...)
     end
   end
 end
-
-# diaghessian(f, x::AbstractArray) = (forward_diag(x -> gradient(f, x)[1], x)[2],)
 
 _splice(x, args, ::Val{n}) where {n} = ntuple(i -> i==n ? x : args[i], length(args))
 

--- a/src/lib/grad.jl
+++ b/src/lib/grad.jl
@@ -264,3 +264,17 @@ function diaghessian(f, args...)
 end
 
 _splice(x, args, ::Val{n}) where {n} = ntuple(i -> i==n ? x : args[i], length(args))
+
+function diaghessian_2nd(f, args...)
+  ntuple(length(args)) do n
+    let x = args[n], valn = Val(n)
+      if x isa AbstractArray
+        forward_2nd(x -> f(_splice(x, args, valn)...), x)[2]
+      elseif x isa Number
+        ForwardDiff.hessian(x -> f(_splice(x[1], args, valn)...), [x])[1]
+      end
+    end
+  end
+end
+
+export diaghessian_2nd

--- a/src/lib/grad.jl
+++ b/src/lib/grad.jl
@@ -235,11 +235,19 @@ julia> diaghessian(x -> sum(x.^3), [1 2; 3 4])[1]
   6  12
  18  24
 
-julia> Diagonal(vec(ans)) == hessian(x -> sum(x.^3), [1 2; 3 4])
+julia> Diagonal(vec(ans)) == hessian(x -> sum(x.^3), [1 2; 3 4])  # full Hessian is diagonal
 true
 
-julia> diaghessian((x,y) -> sum(x .* y .* y'), [1 22; 333 4], [0.5, 0.666])
+julia> diaghessian((x,y) -> sum(x .* y .* y'), [1 22; 333 4], [0.5, 0.666])  # two array arguments
 ([0.0 0.0; 0.0 0.0], [2.0, 8.0])
+
+julia> diaghessian(atan, 1, 2)  # scalar arguments
+(-0.16, 0.16)
+
+julia> hessian(xy -> atan(xy[1], xy[2]), [1, 2])  # full Hessian is not diagonal
+2×2 Matrix{Float64}:
+ -0.16  -0.12
+ -0.12   0.16
 ```
 """
 function diaghessian(f, args...)

--- a/src/lib/grad.jl
+++ b/src/lib/grad.jl
@@ -217,7 +217,7 @@ function jacobian(f, pars::Params)
 end
 
 """
-    diaghessian(f, args...)
+    diaghessian(f, args...) -> Tuple
 
 Diagonal part of the Hessian. Returns a tuple containing, for each argument `x`,
 `h` of the same shape with `h[i] = Hᵢᵢ = ∂²y/∂x[i]∂x[i]`. 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -83,14 +83,3 @@ end
   @test Jxy[ys] ≈ [1 0 0; 0 1 0]
   @test Jxy[xs] ≈ [2 6 4 8; 2 6 4 8]
 end
-
-@testset "adjoints of ForwardDiff functions" begin
-  f1(x) = ForwardDiff.gradient(x -> sum(exp.(x.+1)), x)
-  x1 = randn(3,7)
-  @test Zygote.jacobian(f1, x1)[1] ≈ ForwardDiff.jacobian(f1, x1)
-  
-  f2(x) = ForwardDiff.jacobian(x -> log.(x[1:3] .+ x[2:4]), x)
-  x2 = rand(5) .+ 1
-  @test Zygote.jacobian(f2, x2)[1] ≈ ForwardDiff.jacobian(f2, x2)
-end
-

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,4 +1,5 @@
 using LinearAlgebra
+using ForwardDiff
 using Zygote: hessian_dual, hessian_reverse
 
 @testset "hessian: $hess" for hess in [hessian_dual, hessian_reverse]

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -82,3 +82,14 @@ end
   @test Jxy[ys] ≈ [1 0 0; 0 1 0]
   @test Jxy[xs] ≈ [2 6 4 8; 2 6 4 8]
 end
+
+@testset "adjoints of ForwardDiff functions" begin
+  f1(x) = ForwardDiff.gradient(x -> sum(exp.(x.+1)), x)
+  x1 = randn(3,7)
+  @test Zygote.jacobian(f1, x1)[1] ≈ ForwardDiff.jacobian(f1, x1)
+  
+  f2(x) = ForwardDiff.jacobian(x -> log.(x[1:3] .+ x[2:4]), x)
+  x2 = rand(5) .+ 1
+  @test Zygote.jacobian(f2, x2)[1] ≈ ForwardDiff.jacobian(f2, x2)
+end
+


### PR DESCRIPTION
This adds `diaghessian` which in the simplest case is equal to `(diag(hessian(f,x)),)`, computed more efficiently but otherwise in the same spirit as `hessian`.