### PR TITLE
RFC: more efficient `∇getindex` 

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -46,15 +46,20 @@ end
   return (dx, map(_->nothing, inds)...)
 end
 
+"""
+    OneElement(val, ind, axes) <: AbstractArray
+
+Extremely simple `struct` used for the gradient of scalar `getindex`.
+"""
 struct OneElement{T,N,I,A} <: AbstractArray{T,N}
   val::T
-  index::I
+  ind::I
   axes::A
-  OneElement(x::T, i::I, a::A) where {T,I<:NTuple{N,Int},A} where {N} = new{T,N,I,A}(x, i, a)
+  OneElement(val::T, ind::I, axes::A) where {T<:Number, I<:NTuple{N,Int}, A} where {N} = new{T,N,I,A}(val, ind, axes)
 end
 Base.size(A::OneElement) = map(length, A.axes)
 Base.axes(A::OneElement) = A.axes
-Base.getindex(A::OneElement{T,N}, i::Vararg{Int,N}) where {T,N} = ifelse(i==A.index, A.val, zero(T))
+Base.getindex(A::OneElement{T,N}, i::Vararg{Int,N}) where {T,N} = ifelse(i==A.ind, A.val, zero(T))
 
 
 _zero(xs::AbstractArray{<:Number}, T::Type{Nothing}) = fill!(similar(xs), zero(eltype(xs)))

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -56,6 +56,8 @@ Base.size(A::OneElement) = map(length, A.axes)
 Base.axes(A::OneElement) = A.axes
 Base.getindex(A::OneElement{T,N}, i::Vararg{Int,N}) where {T,N} = ifelse(i==A.index, A.val, zero(T))
 
+accum(x::Array, y::OneElement) = (@inbounds x[y.index...] = accum(x[y.index...], y.val); x)
+
 _zero(xs::AbstractArray{<:Number}, T::Type{Nothing}) = fill!(similar(xs), zero(eltype(xs)))
 _zero(xs::AbstractArray{<:Number}, T) = fill!(similar(xs, T), false)
 _zero(xs::AbstractArray, T) = fill!(similar(xs, Union{Nothing, T}), nothing)

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -56,7 +56,6 @@ Base.size(A::OneElement) = map(length, A.axes)
 Base.axes(A::OneElement) = A.axes
 Base.getindex(A::OneElement{T,N}, i::Vararg{Int,N}) where {T,N} = ifelse(i==A.index, A.val, zero(T))
 
-accum(x::Array, y::OneElement) = (@inbounds x[y.index...] = accum(x[y.index...], y.val); x)
 
 _zero(xs::AbstractArray{<:Number}, T::Type{Nothing}) = fill!(similar(xs), zero(eltype(xs)))
 _zero(xs::AbstractArray{<:Number}, T) = fill!(similar(xs, T), false)

--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -14,6 +14,7 @@ accum(x, y, zs...) = accum(accum(x, y), zs...)
 
 accum(x::Tuple, y::Tuple) = accum.(x, y)
 accum(x::AbstractArray, y::AbstractArray) = accum.(x, y)
+accum(x::DenseArray, y::AbstractArray) = x .= accum.(x, y)
 
 @generated function accum(x::NamedTuple, y::NamedTuple)
   # assumes that y has no keys apart from those also in x

--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -15,6 +15,8 @@ accum(x, y, zs...) = accum(accum(x, y), zs...)
 accum(x::Tuple, y::Tuple) = accum.(x, y)
 accum(x::AbstractArray, y::AbstractArray) = accum.(x, y)
 accum(x::DenseArray, y::AbstractArray) = x .= accum.(x, y)
+# work around bug fixed in https://github.com/JuliaLang/julia/pull/39859
+accum(x::DenseVector, y::AbstractArray) = x .= accum.(x, vec(y))
 
 @generated function accum(x::NamedTuple, y::NamedTuple)
   # assumes that y has no keys apart from those also in x

--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -12,11 +12,8 @@ accum(x, y) =
 
 accum(x, y, zs...) = accum(accum(x, y), zs...)
 
-accum(x::Tuple, y::Tuple) = accum.(x, y)
-accum(x::AbstractArray, y::AbstractArray) = accum.(x, y)
-accum(x::DenseArray, y::AbstractArray) = x .= accum.(x, y)
-# work around bug fixed in https://github.com/JuliaLang/julia/pull/39859
-accum(x::DenseVector, y::AbstractArray) = x .= accum.(x, vec(y))
+accum(x::Tuple, ys::Tuple...) = accum.(x, ys...)
+accum(x::AbstractArray, ys::AbstractArray...) = accum.(x, ys...)
 
 @generated function accum(x::NamedTuple, y::NamedTuple)
   # assumes that y has no keys apart from those also in x

--- a/test/features.jl
+++ b/test/features.jl
@@ -481,3 +481,22 @@ end
   Zygote.gradient(loss_adjoint,[1.0])
   @test x[1] == x[2]
 end
+
+@testset "accumulation" begin
+  # from https://github.com/FluxML/Zygote.jl/issues/905
+  function net(x1)
+    x2  = x1
+    x3  = x1 + x2
+    x4  = x1 + x2 + x3
+    x5  = x1 + x2 + x3 + x4
+    x6  = x1 + x2 + x3 + x4 + x5
+    x7  = x1 + x2 + x3 + x4 + x5 + x6
+    x8  = x1 + x2 + x3 + x4 + x5 + x6 + x7
+    x9  = x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8
+    x10 = x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9
+  end
+  loss(x) = sum(abs2, net(x))
+  @test gradient(loss, ones(10,10))[1] == fill(131072, 10, 10)
+  @test 150_000_000 > @allocated gradient(loss, ones(1000,1000))
+end
+


### PR DESCRIPTION
This is a small improvement to the gradient for `getindex` in the easiest case, by returning a very simple one-nonzero-element array. 

~~It also changes how `accum` works: adding two of these will produce an `Array`, but accumulating the next one may as well mutate that. Maybe it is safe to do that in general, I am not 100% sure? Maybe CI will tell us?~~ [It is not, and it didn't, see below]

Note that it will never produce a SparseArray. ~~My take is that if you call getindex once then this `OneElement` is fine, and if you call it on every element in the array, then accumulating in an Array is optimal; in-between cases where you call it on 1% of the elements seem likely to be very rare, and sparse arrays add all sorts of complication.~~ [This won't apply anymore]

And, are there `CuArray` concerns? `∇getindex` is careful about making a similar zero to write into, but this change is only for scalar indexing, which is (usually) disallowed anyway. 

This doesn't give a huge speedup, but it does save a lot of memory. I'm not too sure what the "10089 allocations" here actually are, maybe there is some further trick to remove them? (Might also be useful for someone to time this on a different computer too -- these are M1 mac, which has unusual memory, and Julia 1.7 native.)
```julia
f4(x) = sum([x[i]^2 for i in eachindex(x)])
@btime gradient(f4, $(collect(1:1000)))
#  1.997 ms (12829 allocations: 16.05 MiB)  originally
#  1.502 ms (11087 allocations: 8.46 MiB)   with OneElement alone
#  1.520 ms (11830 allocations: 8.31 MiB)   with accum(x::DenseArray,...) alone
#    992.917 μs (10089 allocations: 738.44 KiB)  this PR

@btime gradient(x -> sum(x * x'), $(rand(10,1000)));  # no getindex
#  79.625 μs (30 allocations: 237.06 KiB)  original
#  79.334 μs (28 allocations: 158.86 KiB)  with accum
```
On the example from https://github.com/FluxML/Zygote.jl/issues/644 -- discussion there had other comparable proposals:
```julia
function _evalpoly(x, p)
    N = length(p)
    ex = p[end]
    for i in N-1:-1:1
        ex = muladd(x, ex, p[i])
    end
    ex
end
x, p = rand(), randn(10000);

@btime _evalpoly(x, p);
# 12.416 μs (1 allocation: 16 bytes)

@btime Zygote.gradient(_evalpoly, x, p);
# 170.356 ms (730104 allocations: 1.53 GiB)     original
# 139.957 ms (710106 allocations: 800.45 MiB)   with accum(x::DenseArray,...) alone
# 136.468 ms (740104 allocations: 801.90 MiB)   with OneElement alone
#  87.931 ms (720108 allocations: 38.35 MiB)    with both
#  59.191 ms (720108 allocations: 38.35 MiB)    with accum(..., y::OneElement) too
```
Xref also #365 (getindex) and #905 (accumulation).