### PR TITLE
Utilize ChainRulesCore thunks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -38,8 +38,8 @@ ZygoteTrackerExt = "Tracker"
 
 [compat]
 AbstractFFTs = "1.3.1"
-ChainRules = "1.44.1"
-ChainRulesCore = "1.9"
+ChainRules = "1.72.2"
+ChainRulesCore = "1.25"
 ChainRulesTestUtils = "1"
 Colors = "0.12, 0.13"
 DiffRules = "1.4"

--- a/Project.toml
+++ b/Project.toml
@@ -74,7 +74,7 @@ Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [targets]
-test = ["ChainRulesTestUtils", "Conda", "CUDA", "Distances", "FFTW", "FiniteDifferences", "PythonCall", "Test", "Pkg"]
+test = ["ChainRulesTestUtils", "Conda", "CUDA", "Distances", "FFTW", "FiniteDifferences", "PythonCall", "Test"]
 
 [sources]
 ChainRulesCore = {url = "https://github.com/pxl-th/ChainRulesCore.jl.git", rev = "pxl-th/thunks"}

--- a/Project.toml
+++ b/Project.toml
@@ -39,7 +39,7 @@ ZygoteTrackerExt = "Tracker"
 [compat]
 AbstractFFTs = "1.3.1"
 ChainRules = "1.72.2"
-ChainRulesCore = "1.25"
+ChainRulesCore = "1.25.1"
 ChainRulesTestUtils = "1"
 Colors = "0.12, 0.13"
 DiffRules = "1.4"
@@ -71,10 +71,6 @@ FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [targets]
 test = ["ChainRulesTestUtils", "Conda", "CUDA", "Distances", "FFTW", "FiniteDifferences", "PythonCall", "Test"]
-
-[sources]
-ChainRulesCore = {url = "https://github.com/pxl-th/ChainRulesCore.jl.git", rev = "pxl-th/thunks"}

--- a/Project.toml
+++ b/Project.toml
@@ -75,3 +75,6 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [targets]
 test = ["ChainRulesTestUtils", "Conda", "CUDA", "Distances", "FFTW", "FiniteDifferences", "PythonCall", "Test", "Pkg"]
+
+[sources]
+ChainRulesCore = {url = "https://github.com/pxl-th/ChainRulesCore.jl.git", rev = "pxl-th/thunks"}

--- a/Project.toml
+++ b/Project.toml
@@ -71,6 +71,7 @@ FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [targets]
-test = ["ChainRulesTestUtils", "Conda", "CUDA", "Distances", "FFTW", "FiniteDifferences", "PythonCall", "Test"]
+test = ["ChainRulesTestUtils", "Conda", "CUDA", "Distances", "FFTW", "FiniteDifferences", "PythonCall", "Test", "Pkg"]

--- a/src/Zygote.jl
+++ b/src/Zygote.jl
@@ -45,9 +45,6 @@ include("lib/utils.jl")
 include("lib/range.jl")
 include("lib/logexpfunctions.jl")
 
-_usethunks() = true
-ChainRulesCore.rrule(::typeof(_usethunks)) = false, () -> (NoTangent(),)
-
 # we need to define this late, so that the genfuncs see lib.jl
 # Move using statements out of this file to help with sysimage building
 using IRTools: varargs!, inlineable!, pis!, slots!
@@ -86,10 +83,6 @@ using PrecompileTools
 # see https://github.com/SciML/DiffEqFlux.jl/issues/783
 @static if VERSION < v"1.8" || VERSION >= v"1.8.5"
   @compile_workload precompile()
-end
-
-function __init__()
-    ChainRulesCore.UTILIZE_THUNKS[] = _usethunks
 end
 
 end # module

--- a/src/Zygote.jl
+++ b/src/Zygote.jl
@@ -45,6 +45,9 @@ include("lib/utils.jl")
 include("lib/range.jl")
 include("lib/logexpfunctions.jl")
 
+_usethunks() = true
+ChainRulesCore.rrule(::typeof(_usethunks)) = false, () -> (NoTangent(),)
+
 # we need to define this late, so that the genfuncs see lib.jl
 # Move using statements out of this file to help with sysimage building
 using IRTools: varargs!, inlineable!, pis!, slots!
@@ -83,6 +86,10 @@ using PrecompileTools
 # see https://github.com/SciML/DiffEqFlux.jl/issues/783
 @static if VERSION < v"1.8" || VERSION >= v"1.8.5"
   @compile_workload precompile()
+end
+
+function __init__()
+    ChainRulesCore.UTILIZE_THUNKS[] = _usethunks
 end
 
 end # module

--- a/src/Zygote.jl
+++ b/src/Zygote.jl
@@ -3,11 +3,12 @@ module Zygote
 using LinearAlgebra, Statistics
 using LinearAlgebra: copytri!, AbstractTriangular
 
+import ZygoteRules
 import ZygoteRules: @adjoint, @adjoint!, AContext, adjoint, _pullback, pullback,
   literal_getproperty, literal_getfield, unthunk_tangent
 
 using ChainRulesCore
-using ChainRules: ChainRules, rrule, unthunk, canonicalize
+using ChainRules: ChainRules, AbstractThunk, rrule, unthunk, canonicalize
 using IRTools
 using MacroTools, Requires
 using MacroTools: @forward

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -271,7 +271,9 @@ function ChainRulesCore.rrule_via_ad(config::ZygoteRuleConfig, f_args...; kwargs
         _pullback(config.context, f_args...)
     end
 
-    ad_pullback(Δ) = zygote2differential(pb(wrap_chainrules_output(Δ)), f_args)
+    ad_pullback(Δ) = zygote2differential(
+        pb(wrap_chainrules_output(unthunk_tangent(Δ))),
+        f_args)
     return y, ad_pullback
 end
 

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -1,5 +1,5 @@
 @inline unthunk_tangent(x::AbstractThunk) = wrap_chainrules_output(unthunk(x))
-@inline unthunk_tangent(x::AbstractArray{<:AbstractThunk}) = wrap_chainrules_output(map(unthunk, x))
+@inline unthunk_tangent(x::AbstractArray{<:AbstractThunk}) = map(unthunk_tangent, x)
 
 struct ZygoteRuleConfig{CTX<:AContext} <: RuleConfig{Union{HasReverseMode,NoForwardsMode}}
   context::CTX

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -1,6 +1,10 @@
 @inline unthunk_tangent(x::AbstractThunk) = wrap_chainrules_output(unthunk(x))
 @inline unthunk_tangent(x::AbstractArray{<:AbstractThunk}) = map(unthunk_tangent, x)
 unthunk_tangent(d::IdDict) = IdDict([unthunk_tangent(k) => unthunk_tangent(v) for (k, v) in d])
+function ChainRulesCore.rrule(::typeof(unthunk_tangent), d::IdDict)
+  unthunk_iddict_pullback(_) = (NoTangent(), ChainRulesCore.@not_implemented "unthunking IdDict")
+  return d, unthunk_iddict_pullback
+end
 @non_differentiable unthunk_tangent(::IdDict)
 
 

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -1,5 +1,7 @@
 @inline unthunk_tangent(x::AbstractThunk) = wrap_chainrules_output(unthunk(x))
 @inline unthunk_tangent(x::AbstractArray{<:AbstractThunk}) = map(unthunk_tangent, x)
+unthunk_tangent(d::IdDict) = IdDict([unthunk_tangent(k) => unthunk_tangent(v) for (k, v) in d])
+
 
 struct ZygoteRuleConfig{CTX<:AContext} <: RuleConfig{Union{HasReverseMode,NoForwardsMode}}
   context::CTX

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -1,6 +1,7 @@
 @inline unthunk_tangent(x::AbstractThunk) = wrap_chainrules_output(unthunk(x))
 @inline unthunk_tangent(x::AbstractArray{<:AbstractThunk}) = map(unthunk_tangent, x)
 unthunk_tangent(d::IdDict) = IdDict([unthunk_tangent(k) => unthunk_tangent(v) for (k, v) in d])
+@non_differentiable unthunk_tangent(::IdDict)
 
 
 struct ZygoteRuleConfig{CTX<:AContext} <: RuleConfig{Union{HasReverseMode,NoForwardsMode}}

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -1,5 +1,5 @@
-@inline unthunk_tangent(x::AbstractThunk) = unthunk(x)
-@inline unthunk_tangent(x::AbstractArray{<:AbstractThunk}) = map(unthunk, x)
+@inline unthunk_tangent(x::AbstractThunk) = wrap_chainrules_output(unthunk(x))
+@inline unthunk_tangent(x::AbstractArray{<:AbstractThunk}) = wrap_chainrules_output(map(unthunk, x))
 
 struct ZygoteRuleConfig{CTX<:AContext} <: RuleConfig{Union{HasReverseMode,NoForwardsMode}}
   context::CTX

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -1,5 +1,10 @@
+# ToDo: Move some of this to ZygoteRules, or move unthunk_tangent for Tuple and NamedTuple from
+# Zygote rules here?
+function unthunk_tangent end
 @inline unthunk_tangent(x::AbstractThunk) = wrap_chainrules_output(unthunk(x))
-@inline unthunk_tangent(x::AbstractArray{<:AbstractThunk}) = map(unthunk_tangent, x)
+@inline unthunk_tangent(x::NTuple{N,<:Number}) where N = x
+@inline unthunk_tangent(x::AbstractArray{<:Number,N}) where N = x
+@inline unthunk_tangent(x::AbstractArray) = map(unthunk_tangent, x)
 unthunk_tangent(d::IdDict) = IdDict([unthunk_tangent(k) => unthunk_tangent(v) for (k, v) in d])
 @non_differentiable unthunk_tangent(::IdDict)
 

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -1,10 +1,6 @@
 @inline unthunk_tangent(x::AbstractThunk) = wrap_chainrules_output(unthunk(x))
 @inline unthunk_tangent(x::AbstractArray{<:AbstractThunk}) = map(unthunk_tangent, x)
 unthunk_tangent(d::IdDict) = IdDict([unthunk_tangent(k) => unthunk_tangent(v) for (k, v) in d])
-function ChainRulesCore.rrule(::typeof(unthunk_tangent), d::IdDict)
-  unthunk_iddict_pullback(_) = (NoTangent(), ChainRulesCore.@not_implemented "unthunking IdDict")
-  return d, unthunk_iddict_pullback
-end
 @non_differentiable unthunk_tangent(::IdDict)
 
 

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -1,3 +1,6 @@
+@inline unthunk_tangent(x::AbstractThunk) = unthunk(x)
+@inline unthunk_tangent(x::AbstractArray{<:AbstractThunk}) = map(unthunk, x)
+
 struct ZygoteRuleConfig{CTX<:AContext} <: RuleConfig{Union{HasReverseMode,NoForwardsMode}}
   context::CTX
 end
@@ -107,7 +110,6 @@ is_kwfunc(k, ::Type{<:NamedTuple}, f, args...) = k===Core.kwftype(f)
 Convert `x` from the differentials types ChainRules uses to the format Zygote uses internally.
 """
 @inline wrap_chainrules_output(x) = x
-@inline wrap_chainrules_output(x::AbstractThunk) = wrap_chainrules_output(unthunk(x))  # For now we are just not going to deal with thunks
 @inline wrap_chainrules_output(x::Tuple) = map(wrap_chainrules_output, x)
 # Zygote convention: even if many AbstractZero partials (i.e. multi-input function), make just 1 nothing.
 @inline wrap_chainrules_output(x::Tuple{Vararg{ChainRules.AbstractZero}}) = nothing

--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -474,7 +474,7 @@ function pullback(f, ps::Params)
       cache(cx)[p] = nothing
     end
     back(Δ)
-    Grads(IdDict([k => unthunk_tangent(v) for (k, v) in cx.cache]), ps) # TODO make a copy
+    Grads(unthunk_tangent(cx.cache), ps) # TODO make a copy
   end
 end
 

--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -357,6 +357,9 @@ function copy!(x::AbstractVector, ps::Params)
   x
 end
 
+_maybe_unthunk(x::AbstractThunk) = unthunk(x)
+_maybe_unthunk(x) = x
+
 """
     Grads(...)
 
@@ -391,7 +394,7 @@ end
 
 function Base.getindex(gs::Grads, x)
   isbits(x) && error("Only reference types can be differentiated with `Params`.")
-  return gs.grads[x]
+  return _maybe_unthunk(gs.grads[x])
 end
 
 """
@@ -474,7 +477,7 @@ function pullback(f, ps::Params)
       cache(cx)[p] = nothing
     end
     back(Δ)
-    Grads(unthunk_tangent(cx.cache), ps) # TODO make a copy
+    Grads(_maybe_unthunk(cx.cache), ps)
   end
 end
 

--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -37,7 +37,13 @@ end
 _pullback(f, args...) = _pullback(Context(), f, args...)
 
 tailmemaybe(::Nothing) = nothing
-tailmemaybe(x::Tuple) = Base.tail(x)
+tailmemaybe(x::Tuple) = unthunk_tangent(Base.tail(x))
+
+# unthunking is essentially an identity operation on a lazy value, but
+# `@adjoint unthunk_tangent(x) = unthunk_tangent(x), ȳ -> (ȳ,)` is not enough to make
+# nested AD work, so define
+@adjoint tailmemaybe(xs::Tuple) = tailmemaybe(xs), x̄s -> ((nothing, x̄s...),)
+
 
 """
     pullback(f, args...)
@@ -468,7 +474,7 @@ function pullback(f, ps::Params)
       cache(cx)[p] = nothing
     end
     back(Δ)
-    Grads(cx.cache, ps) # TODO make a copy
+    Grads(IdDict([k => unthunk_tangent(v) for (k, v) in cx.cache]), ps) # TODO make a copy
   end
 end
 

--- a/src/compiler/reverse.jl
+++ b/src/compiler/reverse.jl
@@ -3,6 +3,18 @@ using IRTools: IR, Variable, Pipe, xcall, var, prewalk, postwalk,
   insertafter!, finish, expand!, prune!, substitute!, substitute,
   block, block!, branch!, return!, stmt, meta
 
+
+# TODO: Temporary, to be removed when ChainRulesCore rrules are required to
+# support thunks as an input and all instances of _adjoint_keepthunks in
+# Zygote have been replaces by rrules:
+macro _adjoint_keepthunks(ex)
+  ZygoteRules.gradm(ex, false, true)
+end
+macro _adjoint_keepthunks!(ex)
+  ZygoteRules.gradm(ex, true, true)
+end
+
+
 @inline tuple_va(N, xs) = xs
 @inline tuple_va(N, x, xs...) = (x, tuple_va(N, xs...)...)
 @inline tuple_va(::Val{N}, ::Nothing) where N = ntuple(_ -> nothing, Val(N))

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -237,7 +237,7 @@ function _pullback(cx::AContext, ::typeof(collect), g::Base.Generator)
     x̄ = reconstruct_if_dict(x̄, _keys) # return a dictionary if needed
     (nothing, (f = f̄, iter = x̄),)
   end
-  y, collect_pullback
+  y, collect_pullback ∘ unthunk_tangent
 end
 
 collect_if_dict(x::Dict) = collect(x), collect(keys(x))

--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -53,8 +53,7 @@ function Base.reducedim_init(::typeof(identity), ::typeof(accum), A::AbstractArr
   Base.reducedim_initarray(A, region, nothing, Union{Nothing,eltype(A)})
 end
 
-function unbroadcast(x::AbstractArray, maybethunked_x̄)
-  x̄ = unthunk_tangent(maybethunked_x̄)
+function unbroadcast(x::AbstractArray, x̄)
   N = ndims(x̄)
   if length(x) == length(x̄)
     _project(x, x̄)  # ProjectTo handles reshape, offsets, structured matrices, row vectors

--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -53,7 +53,8 @@ function Base.reducedim_init(::typeof(identity), ::typeof(accum), A::AbstractArr
   Base.reducedim_initarray(A, region, nothing, Union{Nothing,eltype(A)})
 end
 
-function unbroadcast(x::AbstractArray, x̄)
+function unbroadcast(x::AbstractArray, maybethunked_x̄)
+  x̄ = unthunk_tangent(maybethunked_x̄)
   N = ndims(x̄)
   if length(x) == length(x̄)
     _project(x, x̄)  # ProjectTo handles reshape, offsets, structured matrices, row vectors

--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -37,9 +37,12 @@ function accum(x::RefValue, y::RefValue)
   return x
 end
 
-accum(x, y::AbstractThunk) = @thunk(accum(x, unthunk_tangent(y)))
-accum(x::AbstractThunk, y) = @thunk(accum(unthunk_tangent(x), y))
-accum(x::AbstractThunk, y::AbstractThunk) = @thunk(accum(unthunk_tangent(x), unthunk_tangent(y)))
+accum(x::NamedTuple, y::ChainRulesCore.Tangent) = accum(x, wrap_chainrules_output(y))
+accum(x::ChainRulesCore.Tangent, y::NamedTuple) = accum(wrap_chainrules_output(x), y)
+
+accum(x, y::AbstractThunk) = @thunk(accum(x, unthunk(y)))
+accum(x::AbstractThunk, y) = @thunk(accum(unthunk(x), y))
+accum(x::AbstractThunk, y::AbstractThunk) = @thunk(accum(unthunk(x), unthunk(y)))
 
 # Core functions
 @_adjoint_keepthunks deepcopy(x) = deepcopy(x), ȳ -> (ȳ,)

--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -37,6 +37,10 @@ function accum(x::RefValue, y::RefValue)
   return x
 end
 
+accum(x, y::AbstractThunk) = @thunk(accum(x, unthunk_tangent(y)))
+accum(x::AbstractThunk, y) = @thunk(accum(unthunk_tangent(x), y))
+accum(x::AbstractThunk, y::AbstractThunk) = @thunk(accum(unthunk_tangent(x), unthunk_tangent(y)))
+
 # Core functions
 @_adjoint_keepthunks deepcopy(x) = deepcopy(x), ȳ -> (ȳ,)
 

--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -38,15 +38,15 @@ function accum(x::RefValue, y::RefValue)
 end
 
 # Core functions
-@adjoint deepcopy(x) = deepcopy(x), ȳ -> (ȳ,)
+@_adjoint_keepthunks deepcopy(x) = deepcopy(x), ȳ -> (ȳ,)
 
-@adjoint (::Type{V})(x...) where V<:Val = V(x...), _ -> nothing
+@_adjoint_keepthunks (::Type{V})(x...) where V<:Val = V(x...), _ -> nothing
 
-@adjoint ifelse(cond::Bool, t, f) =
+@_adjoint_keepthunks ifelse(cond::Bool, t, f) =
   ifelse(cond, t, f),
   Δ -> cond ? (nothing, Δ, zero(Δ)) : (nothing, zero(Δ), Δ)
 
-@adjoint Base.typeassert(x, T) = Base.typeassert(x, T), Δ -> (Δ, nothing)
+@_adjoint_keepthunks Base.typeassert(x, T) = Base.typeassert(x, T), Δ -> (Δ, nothing)
 
 accum_param(::Context{false}, _, Δ) = Δ
 @generated function accum_param(cx::Context, x, Δ)
@@ -70,11 +70,11 @@ end
 
 unwrap(x) = x
 
-@adjoint unwrap(x) = unwrap(x), x̄ -> (accum_param(__context__, x, x̄),)
+@_adjoint_keepthunks unwrap(x) = unwrap(x), x̄ -> (accum_param(__context__, x, x̄),)
 
 unwrap(ref, x) = x
 
-@adjoint unwrap(ref, x) = unwrap(x), function (x̄)
+@_adjoint_keepthunks unwrap(ref, x) = unwrap(x), function (x̄)
   accum_global(__context__, ref, x̄)
   (accum_param(__context__, x, x̄),)
 end
@@ -88,7 +88,7 @@ function global_set(ref, val)
   end
 end
 
-@adjoint! function global_set(ref, x)
+@_adjoint_keepthunks! function global_set(ref, x)
   global_set(ref, x), function (x̄)
     gs = cache(__context__)
     x̄ = accum(get(gs, ref, nothing), x̄)
@@ -101,9 +101,9 @@ end
 
 using Base: tail
 
-@adjoint tuple(xs...) = xs, identity
+@_adjoint_keepthunks tuple(xs...) = xs, identity
 
-@adjoint function literal_getindex(xs::NTuple{N,Any}, ::Val{i}) where {N,i}
+@_adjoint_keepthunks function literal_getindex(xs::NTuple{N,Any}, ::Val{i}) where {N,i}
   val = xs[i]
   function back(Δ)
     accum_param(__context__, val, Δ) === nothing && return
@@ -112,7 +112,7 @@ using Base: tail
   val, back
 end
 
-@adjoint function getindex(xs::NTuple{N,Any}, i::Integer) where N
+@_adjoint_keepthunks function getindex(xs::NTuple{N,Any}, i::Integer) where N
   val = xs[i]
   function back(Δ)
     accum_param(__context__, val, Δ) === nothing && return
@@ -121,10 +121,10 @@ end
   return val, back
 end
 
-@adjoint getindex(xs::NTuple{N,Any}, r::AbstractUnitRange) where N =
+@_adjoint_keepthunks getindex(xs::NTuple{N,Any}, r::AbstractUnitRange) where N =
   (xs[r], Δ -> (ntuple(j -> j in r ? Δ[findfirst(isequal(j), r)] : nothing, Val(N)), nothing))
 
-@adjoint function getindex(xs::NTuple{N,Any}, r::AbstractVector) where N
+@_adjoint_keepthunks function getindex(xs::NTuple{N,Any}, r::AbstractVector) where N
   val = xs[r]
   function back(Δ)
     dxs = ntuple(Val(length(xs))) do x
@@ -155,18 +155,18 @@ function _pullback(cx::AContext, ::typeof(literal_indexed_iterate), xs::Tuple, :
 end
 
 # Needed for iteration lowering
-@adjoint Core.getfield(xs::NTuple{N,Any}, i::Int) where N =
+@_adjoint_keepthunks Core.getfield(xs::NTuple{N,Any}, i::Int) where N =
   (xs[i], Δ -> (ntuple(j -> i == j ? Δ : nothing, Val(N)), nothing))
 
-@adjoint Core.getfield(xs::NamedTuple{K,<:NTuple{N,Any}}, i::Int) where {K,N} =
+@_adjoint_keepthunks Core.getfield(xs::NamedTuple{K,<:NTuple{N,Any}}, i::Int) where {K,N} =
   (xs[i], Δ -> (NamedTuple{K}(ntuple(j -> i == j ? Δ : nothing, Val(N))), nothing))
 
-@adjoint function Base.first(xs::Tuple)
+@_adjoint_keepthunks function Base.first(xs::Tuple)
   drest = map(_->nothing, tail(xs))
   first(xs), Δ -> ((Δ, drest...),)
 end
 
-@adjoint Base.tail(xs::Tuple) = tail(xs), x̄s -> ((nothing, x̄s...),)
+@_adjoint_keepthunks Base.tail(xs::Tuple) = tail(xs), x̄s -> ((nothing, x̄s...),)
 
 _empty(x) = length(x)
 _empty(x::Union{Tuple,NamedTuple}) = map(_->nothing, x)
@@ -188,7 +188,7 @@ end
 
 unapply(t, xs) = _unapply(t, xs)[1]
 
-@adjoint! function Core._apply(f, args...)
+@_adjoint_keepthunks! function Core._apply(f, args...)
   y, back = Core._apply(_pullback, (__context__, f), args...)
   st = map(_empty, args)
   y, function (Δ)
@@ -198,7 +198,7 @@ unapply(t, xs) = _unapply(t, xs)[1]
   end
 end
 
-@adjoint! function Core._apply_iterate(::typeof(iterate), f, args...)
+@_adjoint_keepthunks! function Core._apply_iterate(::typeof(iterate), f, args...)
   y, back = Core._apply(_pullback, (__context__, f), args...)
   st = map(_empty, args)
   y, function (Δ)
@@ -223,7 +223,7 @@ end
 @generated pair(::Val{k}, v, _=nothing) where k = :($k = v,)
 @generated pair(::Val{k}, v, ::NamedTuple{keys}) where {k,keys} = k isa Int ? :($(getfield(keys, k)) = v,) : :($k = v,)
 
-@adjoint function literal_getfield(x, ::Val{f}) where f
+@_adjoint_keepthunks function literal_getfield(x, ::Val{f}) where f
   val = getfield(x, f)
   function back(Δ)
     accum_param(__context__, val, Δ) === nothing && return
@@ -273,8 +273,7 @@ function _get!(default::Base.Callable, ch, x)
   end
 end
 
-
-@adjoint! function setfield!(x, f, val)
+@_adjoint_keepthunks! function setfield!(x, f, val)
   y = setfield!(x, f, val)
   g = grad_mut(__context__, x)
   y, function (_)
@@ -290,13 +289,13 @@ end
 
 Jnew{T}(g) where T = Jnew{T,typeof(g)}(g)
 
-@adjoint! function __new__(T, args...)
+@_adjoint_keepthunks! function __new__(T, args...)
   x = __new__(T, args...)
   g = !ismutabletype(T) || fieldcount(T) == 0 ? nothing : grad_mut(__context__, x)
   x, Jnew{T,typeof(g),false}(g)
 end
 
-@adjoint! function __splatnew__(T, args)
+@_adjoint_keepthunks! function __splatnew__(T, args)
   x = __splatnew__(T, args)
   g = !ismutabletype(T) || fieldcount(T) == 0 ? nothing : grad_mut(__context__, x)
   x, Jnew{T,typeof(g),true}(g)

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -543,8 +543,7 @@ end
   f1244(w, x) = sum(maximum((w * x).^2, dims=1))
   g1244(w, x) = sum(gradient(f1244, w, x)[2].^2)
   h1244(w, x) = gradient(g1244, w, x)[2]
-  # FIXME broken since thunks utilization
-  @test_broken h1244([1 2 3; 4 5 6.0], [7,8,9.0]) ≈ [300608, 375760, 450912]
+  @test h1244([1 2 3; 4 5 6.0], [7,8,9.0]) ≈ [300608, 375760, 450912]
 end
 
 @testset "minimum" begin

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -2191,4 +2191,4 @@ end
   # Check that trivial scalar broadcast hasn't gone weird:
   @test gradient(x -> @.(x * x * x), 2.0) == gradient(x -> x * (x * x), 2.0)
   @test gradient(x -> @.(3.0*x*2.0*x), 2.0) == gradient(x -> 6(x^2), 2.0)
- end
+end

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -1171,13 +1171,6 @@ end
           B = A^p
           return sum(sin.(vcat(vec.(_splitreim(B))...)))
         end === map(_->nothing, _splitreim(A))
-      elseif p == -3 && MT <: Symmetric{Float64}
-        # FIXME Fails due to accuracy issues.
-        @test_broken gradtest(_splitreim(collect(A))...) do (args...)
-          A = ST(_joinreim(_dropimaggrad.(args)...))
-          B = A^p
-          return vcat(vec.(_splitreim(B))...)
-        end
       else
         @static if VERSION >= v"1.11"
           # @show MT p

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -269,5 +269,4 @@ end
     @test sgs[d.b] ≈ fill(1.f0, size(d.b))
   end
 
-
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,6 @@
+import Pkg
+Pkg.add(url="https://github.com/pxl-th/ChainRulesCore.jl.git", rev="pxl-th/thunks")
+
 using Zygote, Test, LinearAlgebra
 using Zygote: gradient, ZygoteRuleConfig
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,3 @@
-# TODO remove once PR is merged
-import Pkg
-Pkg.add(url="https://github.com/pxl-th/ChainRules.jl.git", rev="pxl-th/eachslice")
-
 using Zygote, Test, LinearAlgebra
 using Zygote: gradient, ZygoteRuleConfig
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,7 @@
+# TODO remove once PR is merged
+import Pkg
+Pkg.add(url="https://github.com/pxl-th/ChainRules.jl.git", rev="pxl-th/eachslice")
+
 using Zygote, Test, LinearAlgebra
 using Zygote: gradient, ZygoteRuleConfig
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,3 @@
-import Pkg
-Pkg.add(url="https://github.com/pxl-th/ChainRulesCore.jl.git", rev="pxl-th/thunks")
-
 using Zygote, Test, LinearAlgebra
 using Zygote: gradient, ZygoteRuleConfig
 


### PR DESCRIPTION
**Note: Requires FluxML/ZygoteRules.jl#17**

Currently, Zygote always unthunks `ChainRuleCore` thunks, which is wasteful and may also lead to trouble in cases why a thunks just can't be run for the given types/contents.

With

```julia
using ChainRulesCore, Zygote
foo(a, b) = a * b
function ChainRulesCore.rrule(::typeof(foo), a, b)
    y = foo(a, b)
    function foo_pullback(Ȳ)
        ∂a = @thunk (@info "Thunk ∂a"; return Ȳ * b')
        ∂b = @thunk (@info "Thunk ∂b"; return a' * Ȳ)
        return (NO_FIELDS, ∂a, ∂b)
    end
    return y, foo_pullback
end
a = rand(4,3); b = rand(3,2); Ȳ = rand(4,2);
Zygote.pullback(foo, a, b)[2](Ȳ)
let a = a; Zygote.pullback(b -> foo(a, b), b)[2](Ȳ) end
```

we obviously get

```
julia> Zygote.pullback(foo, a, b)[2](Ȳ)
[ Info: Thunk ∂a
[ Info: Thunk ∂b
([...], [...])
```

but we currently also get

```
julia> let a = a; Zygote.pullback(b -> foo(a, b), b)[2](Ȳ) end
[ Info: Thunk ∂a
[ Info: Thunk ∂b
([...],)
```

so Zygote also executes both thunks if we only require the pullback in respect to `b`.

With this PR, we should get

```
julia> let a = a; Zygote.pullback(b -> foo(a, b), b)[2](Ȳ) end
[ Info: Thunk ∂b
([0.5793294513282393 0.5442572290286626; 0.748469566554706 0.8319235475298901; 0.609222600261931 0.6201995902507516],)
```

instead.

**Note: Requires FluxML/ZygoteRules.jl#17**

CC @oxinabox , @mzgubic 