### PR TITLE
Adjoint for `ForwardDiff.jacobian`

### DIFF
--- a/src/lib/forward.jl
+++ b/src/lib/forward.jl
@@ -102,6 +102,7 @@ forwarddiff(f, x) = f(x)
   return y, ȳ -> (nothing, reshape_scalar(x, J*vec_scalar(ȳ)))
 end
 
-# Use this to allow second derivatives
+# Use this to allow second derivatives -- this is forward-over-forward, 
+# see  https://github.com/FluxML/Zygote.jl/issues/769  for a forward-over-reverse proposal
 @adjoint ForwardDiff.gradient(f, x) = pullback(forwarddiff, x -> ForwardDiff.gradient(f, x), x)
 @adjoint ForwardDiff.jacobian(f, x) = pullback(forwarddiff, x -> ForwardDiff.jacobian(f, x), x)

--- a/src/lib/forward.jl
+++ b/src/lib/forward.jl
@@ -106,3 +106,8 @@ end
 # see  https://github.com/FluxML/Zygote.jl/issues/769  for a forward-over-reverse proposal
 @adjoint ForwardDiff.gradient(f, x) = pullback(forwarddiff, x -> ForwardDiff.gradient(f, x), x)
 @adjoint ForwardDiff.jacobian(f, x) = pullback(forwarddiff, x -> ForwardDiff.jacobian(f, x), x)
+
+@adjoint ForwardDiff.derivative(f, x) = pullback(forwarddiff, x -> ForwardDiff.derivative(f, x), x)
+@adjoint ForwardDiff.hessian(f, x) = pullback(forwarddiff, x -> ForwardDiff.hessian(f, x), x)
+
+

--- a/src/lib/forward.jl
+++ b/src/lib/forward.jl
@@ -101,3 +101,7 @@ forwarddiff(f, x) = f(x)
   y, J = forward_jacobian(f, x)
   return y, ȳ -> (nothing, reshape_scalar(x, J*vec_scalar(ȳ)))
 end
+
+# Use this to allow second derivatives
+@adjoint ForwardDiff.gradient(f, x) = pullback(forwarddiff, x -> ForwardDiff.gradient(f, x), x)
+@adjoint ForwardDiff.jacobian(f, x) = pullback(forwarddiff, x -> ForwardDiff.jacobian(f, x), x)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -61,3 +61,13 @@ end
   @test Jxy[ys] ≈ [1 0 0; 0 1 0]
   @test Jxy[xs] ≈ [2 6 4 8; 2 6 4 8]
 end
+
+@testset "adjoints of ForwardDiff functions" begin
+  f1(x) = ForwardDiff.gradient(x -> sum(exp.(x.+1)), x)
+  x1 = randn(3,7)
+  @test Zygote.jacobian(f1, x1)[1] ≈ ForwardDiff.jacobian(f1, x1)
+
+  f2(x) = ForwardDiff.jacobian(x -> log.(x[1:3] .+ x[2:4]), x)
+  x2 = rand(5) .+ 1
+  @test Zygote.jacobian(f2, x2)[1] ≈ ForwardDiff.jacobian(f2, x2)
+end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -73,6 +73,15 @@ using ForwardDiff
   x2 = rand(5) .+ 1
   @test Zygote.jacobian(f2, x2)[1] ≈ ForwardDiff.jacobian(f2, x2)
 
+  f3(x) = sum(ForwardDiff.hessian(x -> sum(x .^2 .* x'), x)[1:4:end])
+  x3 = rand(3)
+  @test Zygote.gradient(f3, x3)[1] ≈ ForwardDiff.gradient(f3, x3)
+
+  @test gradient(x -> ForwardDiff.derivative(x -> x^4, x), 7) == (4 * 3 * 7^2,)
+
+  f4(x) = ForwardDiff.derivative(x -> [x,x^2,x^3], x)
+  @test Zygote.jacobian(f4, pi)[1] ≈ ForwardDiff.derivative(f4, pi)
+
   # Tests from https://github.com/FluxML/Zygote.jl/issues/769
   f(x) = [2x[1]^2 + x[1],x[2]^2 * x[1]]
   g1(x) = sum(ForwardDiff.jacobian(f,x))


### PR DESCRIPTION
This adds one-line adjoint definitions for `ForwardDiff.gradient` and `ForwardDiff.jacobian`, using `forwarddiff`. This is a simpler version of what was proposed in #769. 

Perhaps ideally, calling Zygote over ForwardDiff would actually do reverse mode over forward mode. The proposal in #769 was in fact to turn that into forward over reverse, while this PR is forward over forward. Maybe there are cases where one is much better than the other?

But it doesn't work at all right now. Errors involved are, BTW, these: 
```
Mutating arrays is not supported

Need an adjoint for constructor ForwardDiff.Partials{1, Float64}. Gradient is of type Vector{ForwardDiff.Dual{ForwardDiff.Tag{var"#66#67", Float64}, Float64, 1}}
```

Closes #305 (gradient of a function containing `Zygote.forward_jacobian`, replace with `ForwardDiff.jacobian`) and maybe #953 (gradient of a function containing `jacobian`, could perhaps use `ForwardDiff.jacobian`). 