### PR TITLE
Don't `unbroadcast` some cases which don't need broadcasting

### DIFF
--- a/src/lib/grad.jl
+++ b/src/lib/grad.jl
@@ -124,7 +124,7 @@ julia> jacobian((a,d) -> prod(a, dims=d), [1 2; 3 4; 5 6], 2)
 !!! warning
     For arguments of any type except `Number` & `AbstractArray`, the result is `nothing`.
 
-```jldoctest; setup=:(using Zygote)
+```
 julia> jacobian((a,s) -> a.^length(s), [1,2,3], "str")
 ([3 0 0; 0 12 0; 0 0 27], nothing)
 
@@ -132,7 +132,7 @@ julia> jacobian((a,t) -> sum(a .* t[1]) + t[2], [1,2,3], (4,5))
 ([4 4 4], nothing)
 
 julia> gradient((a,t) -> sum(a .* t[1]) + t[2], [1,2,3], (4,5))  # gradient undersands the tuple
-([4, 4, 4], (6, 1))
+(Fill(4, 3), (6, 1))
 ```
 """
 function jacobian(f, args...)

--- a/src/lib/grad.jl
+++ b/src/lib/grad.jl
@@ -132,7 +132,7 @@ julia> jacobian((a,t) -> sum(a .* t[1]) + t[2], [1,2,3], (4,5))
 ([4 4 4], nothing)
 
 julia> gradient((a,t) -> sum(a .* t[1]) + t[2], [1,2,3], (4,5))  # gradient undersands the tuple
-(Fill(4, 3), (6, 1))
+([4 4 4], (6, 1))
 ```
 """
 function jacobian(f, args...)

--- a/test/cuda.jl
+++ b/test/cuda.jl
@@ -24,18 +24,6 @@ end
   
 end
 
-@testset "un-broadcasting .*, ./ with scalars" begin
-  cu12 = cu(Float32[1,2])
-  cu55 = cu(Float32[5,5])
-  @test gradient((x,y) -> sum(x .* y), cu12, 5) == (cu55, 3)
-  @test gradient((x,y) -> sum(x .* y), 5, cu12) == (3, cu55)
-  # @test gradient((x,y) -> sum(z -> z, x .* y), cu12, 5) == (cu55, 3)
-  # @test gradient((x,y) -> sum(z -> z, x .* y), 5, cu12) == (3, cu55)
-  cu345 = cu(Float32[3 4 5])
-  @test gradient((x,y) -> sum(x .* y), cu12, cu345) == (cu([12, 12]), cu([3 3 3]))
-  @test all(gradient((x,y) -> sum(x ./ y), cu12, 5) .≈ (cu([0.2, 0.2]), -0.12))
-end
-
 @testset "jacobian" begin
   v1 = cu(collect(1:3f0))
 

--- a/test/cuda.jl
+++ b/test/cuda.jl
@@ -24,11 +24,13 @@ end
   
 end
 
-@testset "un-broadcasting *, / with mapreduce" begin
+@testset "un-broadcasting .*, ./ with scalars" begin
   cu12 = cu(Float32[1,2])
   cu55 = cu(Float32[5,5])
   @test gradient((x,y) -> sum(x .* y), cu12, 5) == (cu55, 3)
   @test gradient((x,y) -> sum(x .* y), 5, cu12) == (3, cu55)
+  # @test gradient((x,y) -> sum(z -> z, x .* y), cu12, 5) == (cu55, 3)
+  # @test gradient((x,y) -> sum(z -> z, x .* y), 5, cu12) == (3, cu55)
   cu345 = cu(Float32[3 4 5])
   @test gradient((x,y) -> sum(x .* y), cu12, cu345) == (cu([12, 12]), cu([3 3 3]))
   @test all(gradient((x,y) -> sum(x ./ y), cu12, 5) .≈ (cu([0.2, 0.2]), -0.12))

--- a/test/cuda.jl
+++ b/test/cuda.jl
@@ -26,11 +26,13 @@ end
 
 @testset "un-broadcasting *, / with mapreduce" begin
   cu12 = cu(Float32[1,2])
-  @test gradient((x,y) -> sum(x .* y), cu12, 5) == ([5, 5], 3)
+  @test gradient((x,y) -> sum(x .* y), cu12, 5) == ([5, 5]), 3)
   @test gradient((x,y) -> sum(x .* y), 5, cu12) == (3, [5, 5])
+  @test gradient((x,y) -> sum(z -> z, x .* y), cu12, 5) == ([5, 5], 3)
+  @test gradient((x,y) -> sum(z -> z, x .* y), 5, cu12) == (3, [5, 5])
   cu345 = cu(Float32[3 4 5])
-  @test all(gradient((x,y) -> sum(x .* y), cu12, cu345) .≈ ([12, 12], [3 3 3]))
-  @test all(gradient((x,y) -> sum(x ./ y), cu12, 5) .≈ ([0.2, 0.2], -0.12))
+  @test all(gradient((x,y) -> sum(x .* y), cu12, cu345) .≈ (cu([12, 12]), cu([3 3 3])))
+  @test all(gradient((x,y) -> sum(x ./ y), cu12, 5) .≈ (cu([0.2, 0.2]), -0.12))
 end
 
 @testset "jacobian" begin

--- a/test/cuda.jl
+++ b/test/cuda.jl
@@ -28,8 +28,9 @@ end
   cu12 = cu(Float32[1,2])
   @test gradient((x,y) -> sum(x .* y), cu12, 5) == ([5, 5], 3)
   @test gradient((x,y) -> sum(x .* y), 5, cu12) == (3, [5, 5])
-  @test gradient((x,y) -> sum(x .* y), cu12, [3 4 5]) == ([12, 12], [3 3 3])
-  @test gradient((x,y) -> sum(x ./ y), cu12, 5) == ([0.2, 0.2], -0.12)
+  cu345 = cu(Float32[3 4 5])
+  @test all(gradient((x,y) -> sum(x .* y), cu12, cu345) .≈ ([12, 12], [3 3 3]))
+  @test all(gradient((x,y) -> sum(x ./ y), cu12, 5) .≈ ([0.2, 0.2], -0.12))
 end
 
 @testset "jacobian" begin

--- a/test/cuda.jl
+++ b/test/cuda.jl
@@ -26,12 +26,11 @@ end
 
 @testset "un-broadcasting *, / with mapreduce" begin
   cu12 = cu(Float32[1,2])
-  @test gradient((x,y) -> sum(x .* y), cu12, 5) == ([5, 5]), 3)
-  @test gradient((x,y) -> sum(x .* y), 5, cu12) == (3, [5, 5])
-  @test gradient((x,y) -> sum(z -> z, x .* y), cu12, 5) == ([5, 5], 3)
-  @test gradient((x,y) -> sum(z -> z, x .* y), 5, cu12) == (3, [5, 5])
+  cu55 = cu(Float32[5,5])
+  @test gradient((x,y) -> sum(x .* y), cu12, 5) == (cu55, 3)
+  @test gradient((x,y) -> sum(x .* y), 5, cu12) == (3, cu55)
   cu345 = cu(Float32[3 4 5])
-  @test all(gradient((x,y) -> sum(x .* y), cu12, cu345) .≈ (cu([12, 12]), cu([3 3 3])))
+  @test gradient((x,y) -> sum(x .* y), cu12, cu345) == (cu([12, 12]), cu([3 3 3]))
   @test all(gradient((x,y) -> sum(x ./ y), cu12, 5) .≈ (cu([0.2, 0.2]), -0.12))
 end
 

--- a/test/cuda.jl
+++ b/test/cuda.jl
@@ -24,6 +24,14 @@ end
   
 end
 
+@testset "un-broadcasting *, / with mapreduce" begin
+  cu12 = cu(Float32[1,2])
+  @test gradient((x,y) -> sum(x .* y), cu12, 5) == ([5, 5], 3)
+  @test gradient((x,y) -> sum(x .* y), 5, cu12) == (3, [5, 5])
+  @test gradient((x,y) -> sum(x .* y), cu12, [3 4 5]) == ([12, 12], [3 3 3])
+  @test gradient((x,y) -> sum(x ./ y), cu12, 5) == ([0.2, 0.2], -0.12)
+end
+
 @testset "jacobian" begin
   v1 = cu(collect(1:3f0))
 

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -1308,6 +1308,12 @@ end
   x1 = rand(3, 3)
   @test gradient(x -> sum(x .== 0.5), x1)[1] === nothing
   @test gradient(x -> sum(x .* (x .== maximum(x, dims=1))), x1)[1] == (x1 .== maximum(x1, dims=1))
+
+  # tests for un-broadcasting *, / with mapreduce
+  @test gradient((x,y) -> sum(x .* y), [1,2], 5) == ([5, 5], 3)
+  @test gradient((x,y) -> sum(x .* y), 5, [1,2]) == (3, [5, 5])
+  @test gradient((x,y) -> sum(x .* y), [1,2], [3 4 5]) == ([12, 12], [3 3 3])
+  @test gradient((x,y) -> sum(x ./ y), [1,2], 5) == ([0.2, 0.2], -0.12)
 end
 
 using Zygote: Buffer

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -1309,11 +1309,11 @@ end
   @test gradient(x -> sum(x .== 0.5), x1)[1] === nothing
   @test gradient(x -> sum(x .* (x .== maximum(x, dims=1))), x1)[1] == (x1 .== maximum(x1, dims=1))
 
-  # tests for un-broadcasting *, / with mapreduce
-  @test gradient((x,y) -> sum(x .* y), [1,2], 5) == ([5, 5], 3)
-  @test gradient((x,y) -> sum(x .* y), 5, [1,2]) == (3, [5, 5])
-  @test gradient((x,y) -> sum(x .* y), [1,2], [3 4 5]) == ([12, 12], [3 3 3])
-  @test gradient((x,y) -> sum(x ./ y), [1,2], 5) == ([0.2, 0.2], -0.12)
+  # tests for un-broadcasting *, / via scalar rules
+  @test all(gradient((x,y) -> sum(x .* y), [1,2], 5) .≈ ([5, 5], 3))
+  @test all(gradient((x,y) -> sum(x .* y), 5, [1,2]) .≈ (3, [5, 5]))
+  @test all(gradient((x,y) -> sum(x .* y), [1,2], [3 4 5]) .≈ ([12, 12], [3 3 3]))
+  @test all(gradient((x,y) -> sum(x ./ y), [1,2], 5) .≈ ([0.2, 0.2], -0.12))
 end
 
 using Zygote: Buffer


### PR DESCRIPTION
This is a small optimisation of what I think are fairly common broadcasts:
```julia
julia> @btime gradient((x,y) -> sum(x .* y), $(rand(100,100)), pi);
  20.125 μs (7 allocations: 234.62 KiB)
  13.750 μs (3 allocations: 78.22 KiB)  # this PR

julia> @btime gradient((x,y) -> sum(x ./ y), $(rand(100,100)), pi);
  19.667 μs (7 allocations: 234.62 KiB)
  13.958 μs (3 allocations: 78.22 KiB)  # this PR
```
For best effect it will need https://github.com/JuliaLang/julia/pull/39053, which you can simulate via
```julia
@eval Base function mapreduce(f, op, A::AbstractArrayOrBroadcasted...; kw...)
   get(kw, :dims, :) === (:) && return mapreduce(A -> f(A...), op, zip(A...); kw...)
   return reduce(op, map(f, A...); kw...)
end
```