### PR TITLE
minor typo fix

### DIFF
--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -43,7 +43,7 @@ end
 
 sensitivity(y::Number) = one(y)
 sensitivity(y::Complex) = error("Output is complex, so the gradient is not defined.")
-sensitivity(y::AbstractArray) = error("output an array, so the gradient is not defined. Perhaps you wanted jacobian.")
+sensitivity(y::AbstractArray) = error("Output is an array, so the gradient is not defined. Perhaps you wanted jacobian.")
 sensitivity(y) = error("Output should be scalar; gradients are not defined for output $(repr(y))")
 
 """


### PR DESCRIPTION
Minorest of typos, makes it so the user wont confuse the first clause as declarative.