### PR TITLE
Update ChainRules and ChainRulesCore

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Zygote"
 uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
-version = "0.6.11"
+version = "0.6.12"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
@@ -23,8 +23,8 @@ ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 
 [compat]
 AbstractFFTs = "0.5, 1.0"
-ChainRules = "0.7.55"
-ChainRulesCore = "0.9.44"
+ChainRules = "0.7.55, 0.8"
+ChainRulesCore = "0.9.44, 0.10"
 DiffRules = "1.0"
 FillArrays = "0.8, 0.9, 0.10, 0.11"
 ForwardDiff = "0.10"


### PR DESCRIPTION
Replaces #983 and #984 doing both at once.
We should wait for https://github.com/JuliaMath/SpecialFunctions.jl/pull/319 to be merged first though as without that SpecialFunctions.jl holds us back to ChainRulesCore 0.9
which means CI will not actually tell us