### PR TITLE
delete rule for prod to use ChainRules'

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,7 +23,7 @@ ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 
 [compat]
 AbstractFFTs = "0.5, 1.0"
-ChainRules = "0.7.55, 0.8"
+ChainRules = "0.7.66, 0.8"
 ChainRulesCore = "0.9.44, 0.10"
 DiffRules = "1.0"
 FillArrays = "0.8, 0.9, 0.10, 0.11"

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -300,11 +300,6 @@ end
   return sum(abs2, X; dims=dims), Δ::Union{Number, AbstractArray}->(nothing, ((2Δ) .* X))
 end
 
-@adjoint function prod(xs::AbstractArray; dims = :)
-  p = prod(xs; dims = dims)
-  p, Δ -> (p ./ xs .* Δ,)
-end
-
 function _pullback(cx::AContext, ::typeof(prod), f, xs::AbstractArray)
   y, back = pullback(cx, ((f, xs) -> prod(f.(xs))), f, xs)
   y, ȳ -> (nothing, back(ȳ)...)


### PR DESCRIPTION
@mcabbott  added a rule for prod into ChainRules
https://github.com/JuliaDiff/ChainRules.jl/pull/335

It's better than the one in Zygote as it gets the right answer even if one of the elements is zero.

So we can delete the old one here.
But leaving the tests in place per our policy, as a double check against regressions in ChainRules