### PR TITLE
collect OneElement when used with implicit Params

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -61,6 +61,8 @@ Base.size(A::OneElement) = map(length, A.axes)
 Base.axes(A::OneElement) = A.axes
 Base.getindex(A::OneElement{T,N}, i::Vararg{Int,N}) where {T,N} = ifelse(i==A.ind, A.val, zero(T))
 
+# Do not store OneElement in Params, as that expects a mutable gradient:
+Base.setindex!(dict::IdDict, dx::OneElement, x) = setindex!(dict, collect(dx), x)
 
 _zero(xs::AbstractArray{<:Number}, T::Type{Nothing}) = fill!(similar(xs), zero(eltype(xs)))
 _zero(xs::AbstractArray{<:Number}, T) = fill!(similar(xs, T), false)

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -61,7 +61,7 @@ Base.size(A::OneElement) = map(length, A.axes)
 Base.axes(A::OneElement) = A.axes
 Base.getindex(A::OneElement{T,N}, i::Vararg{Int,N}) where {T,N} = ifelse(i==A.ind, A.val, zero(T))
 
-# Do not store OneElement in Params, as that expects a mutable gradient:
+# Do not store OneElement in Grads, as Flux's optimisers expect this to be mutable:
 Base.setindex!(dict::IdDict, dx::OneElement, x) = setindex!(dict, collect(dx), x)
 
 _zero(xs::AbstractArray{<:Number}, T::Type{Nothing}) = fill!(similar(xs), zero(eltype(xs)))

--- a/test/features.jl
+++ b/test/features.jl
@@ -498,6 +498,12 @@ end
   loss(x) = sum(abs2, net(x))
   @test gradient(loss, ones(10,10))[1] == fill(131072, 10, 10)
   @test 150_000_000 > @allocated gradient(loss, ones(1000,1000))
+
+  # inspired by https://github.com/SciML/Surrogates.jl/pull/279
+  W = rand(3)
+  G = gradient(() -> W[1], Params([W]))
+  @test G[W] == [1,0,0]
+  @test G[W] isa Vector # mutable
 end
 
 @testset "tuples & broadcasting" begin


### PR DESCRIPTION
This is to address https://github.com/SciML/Surrogates.jl/pull/279, by ensuring that when using implicit parameters, the arrays in `Grads` are mutable ones. Current behaviour:
```
julia> W = rand(3);

julia> gradient(() -> W[1], Params([W]))
Grads(...)

julia> ans[W]  # perhaps surprising? Changed by this PR
3-element Zygote.OneElement{Float64, 1, Tuple{Int64}, Tuple{Base.OneTo{Int64}}}:
 1.0
 0.0
 0.0

julia> gradient(() -> W[1] + W[2], Params([W]))  # with two calls, accumulation does already work:
Grads(...)

julia> ans[W]
3-element Vector{Float64}:
 1.0
 1.0
 0.0
```
Perhaps deserves a bit more thought before merging. Do we insist that gradients in Grads are mutable?

The stack trace from Flux looks like this, shouldn't it be updating `x::Vector{Float32}` from `xs::Zygote.Params`, not updating `x̄::Zygote.OneElement`? 
```
ERROR: LoadError: setindex! not defined for Zygote.OneElement{Float64, 1, Tuple{Int64}, Tuple{Base.OneTo{Int64}}}
...
 [10] apply!
    @ ~/.julia/dev/Flux/src/optimise/optimisers.jl:42 [inlined]
 [11] update!(opt::Descent, x::Vector{Float32}, x̄::Zygote.OneElement{Float64, 1, Tuple{Int64}, Tuple{Base.OneTo{Int64}}})
    @ Flux.Optimise ~/.julia/dev/Flux/src/optimise/train.jl:23
 [12] update!(opt::Descent, xs::Zygote.Params, gs::Zygote.Grads)
    @ Flux.Optimise ~/.julia/dev/Flux/src/optimise/train.jl:29
```
But before updating `x`, Flux scales the gradient, to apply the learning rate from the optimiser. That's a slightly strange feature, maybe it shouldn't do that?
```
function apply!(o::Descent, x, Δ)
  Δ .*= o.eta
end
```