### PR TITLE
Faster generic broadcasting

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -215,19 +215,27 @@ _tryreverse(m, x) = x
 _tryreverse(m::typeof(map), x::Union{AbstractVector, Tuple}) = reverse(x)
 
 for (mapfunc,∇mapfunc) in [(:map,:∇map),(:pmap,:∇pmap)]
-  @eval function $∇mapfunc(cx, f, args...)
+  @eval function $∇mapfunc(cx, f::F, args...) where {F}
     ys_and_backs = $mapfunc((args...) -> _pullback(cx, f, args...), args...)
     if isempty(ys_and_backs)
       ys_and_backs, _ -> nothing
     else
-      ys, backs = unzip(ys_and_backs)
+      ys = map(first, ys_and_backs)
       ys, function (Δ)
         isnothing(Δ) && return nothing
-        # Apply pullbacks in reverse order. Needed for correctness if `f` is stateful.
-        Δf_and_args_zipped = $mapfunc((f, δ) -> f(δ), _tryreverse($mapfunc, backs, Δ)...)
-        Δf_and_args = unzip(_tryreverse($mapfunc, Δf_and_args_zipped))
-        Δf = reduce(accum, Δf_and_args[1])
-        (Δf, Δf_and_args[2:end]...)
+        if _purefun(F) && length(args) == 1
+          Δarg = $mapfunc(((_,pb), δ) -> last(pb(δ)), ys_and_backs, Δ) # No unzip needed
+          (nothing, Δarg)
+        elseif _purefun(F)
+          Δargs = unzip($mapfunc(((_,pb), δ) -> Base.tail(pb(δ)), ys_and_backs, Δ))
+          (nothing, Δargs...)
+        else
+          # Apply pullbacks in reverse order. Needed for correctness if `f` is stateful.
+          Δf_and_args_zipped = $mapfunc(((_,pb), δ) -> pb(δ), _tryreverse($mapfunc, ys_and_backs, Δ)...)
+          Δf_and_args = unzip(_tryreverse($mapfunc, Δf_and_args_zipped))
+          Δf = reduce(accum, Δf_and_args[1])
+          (Δf, Δf_and_args[2:end]...)
+        end
       end
     end
   end

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -194,6 +194,7 @@ end
 
 struct StaticGetter{i} end
 (::StaticGetter{i})(v) where {i} = v[i]
+(::StaticGetter{i})(::Nothing) where {i} = nothing
 @generated function _unzip(tuples, ::Val{N}) where {N}
   Expr(:tuple, (:(map($(StaticGetter{i}()), tuples)) for i ∈ 1:N)...)
 end

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -223,10 +223,10 @@ for (mapfunc,∇mapfunc) in [(:map,:∇map),(:pmap,:∇pmap)]
       ys = map(first, ys_and_backs)
       ys, function (Δ)
         isnothing(Δ) && return nothing
-        if _purefun(F) && length(args) == 1
+        if Base.issingletontype(F) && length(args) == 1
           Δarg = $mapfunc(((_,pb), δ) -> last(pb(δ)), ys_and_backs, Δ) # No unzip needed
           (nothing, Δarg)
-        elseif _purefun(F)
+        elseif Base.issingletontype(F) # Ensures `f` is pure: nothing captured & no state
           Δargs = unzip($mapfunc(((_,pb), δ) -> Base.tail(pb(δ)), ys_and_backs, Δ))
           (nothing, Δargs...)
         else

--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -174,7 +174,7 @@ collapse_nothings(xs) = xs
   y∂b = _broadcast((x...) -> _pullback(__context__, f, x...), args...)
   y = map(first, y∂b)
   function ∇broadcasted(ȳ)
-    dxs_zip = map((pair, ȳ₁) -> last(pair)(ȳ₁), y∂b, ȳ)
+    dxs_zip = map(((_, pb), ȳ₁) -> pb(ȳ₁), y∂b, ȳ)
     dxs = ntuple(len) do i
       collapse_nothings(map(StaticGetter{i}(), dxs_zip))
     end

--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -219,16 +219,13 @@ end
 
 @adjoint! (b::typeof(broadcast))(f, args...) = _pullback(__context__, broadcasted, f, args...)
 
-# Forward Mode (mainly necessary for CUDA)
+# Forward Mode -- necessary for CUDA, also used as a fast path above
 
 import ForwardDiff
 using ForwardDiff: Dual
 
 dual(x, p) = x
 dual(x::Real, p) = Dual(x, p)
-
-dualtype(::Type{Dual{G,T,P}}) where {G,T,P} = T
-dualtype(T) = T
 
 function dual_function(f::F) where F
   function (args::Vararg{Any,N}) where N

--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -229,8 +229,8 @@ end
   out = dual_function(f).(args...)
   eltype(out) <: Dual || return (out, _ -> nothing)
   y = map(x -> x.value, out)
-  _back(ȳ, i) = unbroadcast(args[i], ((a, b) -> a*b.partials[i]).(ȳ, out))
-  back(ȳ) = ntuple(i -> _back(ȳ, i), N)
+  _back(ȳ, geti) = unbroadcast(geti(args), ((a, b) -> a * geti(b.partials)).(ȳ, out))
+  back(ȳ) = ntuple(i -> _back(ȳ, StaticGetter{i}()), N)
   return y, back
 end
 

--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -171,6 +171,8 @@ _purefun(::Type{F}) where {F<:Function} = isempty(fieldnames(F))
 _purefun(::Type{ComposedFunction{F,G}}) where {F,G} = _purefun(F) && _purefun(G)
 _purefun(::Type) = false
 
+_purefun(::Type{typeof(^)}) = false  # fix @testset "power" & @testset "diagonal hessian"
+
 @adjoint function broadcasted(::AbstractArrayStyle, f::F, args...) where {F}
   T = Broadcast.combine_eltypes(f, args)
   # Avoid generic broadcasting in two easy cases:

--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -168,9 +168,10 @@ collapse_nothings(xs::AbstractArray{Nothing}) = nothing
 collapse_nothings(xs) = xs
 
 _purefun(::Type{F}) where {F<:Function} = isempty(fieldnames(F))
-_purefun(::Type{ComposedFunction{F,G}}) where {F,G} = _purefun(F) && _purefun(G)
 _purefun(::Type) = false
-
+if VERSION >= v"1.6"
+  _purefun(::Type{ComposedFunction{F,G}}) where {F,G} = _purefun(F) && _purefun(G)
+end
 _purefun(::Type{typeof(^)}) = false  # fix @testset "power" & @testset "diagonal hessian"
 
 @adjoint function broadcasted(::AbstractArrayStyle, f::F, args...) where {F}

--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -179,7 +179,7 @@ _purefun(::Type{typeof(^)}) = false  # fix @testset "power" & @testset "diagonal
   # Avoid generic broadcasting in two easy cases:
   if T == Bool
     return f.(args...), _->nothing
-  elseif T <: Real && _purefun(F) && all(a -> a isa Numeric{<:Real}, args)
+  elseif isconcretetype(T) && T <: Real && _purefun(F) && all(a -> a isa Numeric{<:Real}, args)
     y, back = broadcast_forward(f, args...)
     return y, ȳ -> (nothing, nothing, back(ȳ)...)
   end

--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -167,11 +167,8 @@ _broadcast(f::F, x...) where F = materialize(broadcasted(f, x...))
 collapse_nothings(xs::AbstractArray{Nothing}) = nothing
 collapse_nothings(xs) = xs
 
-_purefun(::Type{F}) where {F<:Function} = isempty(fieldnames(F))
+_purefun(::Type{F}) where {F<:Function} = Base.issingletontype(F)
 _purefun(::Type) = false
-if VERSION >= v"1.6"
-  _purefun(::Type{ComposedFunction{F,G}}) where {F,G} = _purefun(F) && _purefun(G)
-end
 _purefun(::Type{typeof(^)}) = false  # fix @testset "power" & @testset "diagonal hessian"
 
 _dualsafe(x::Numeric{<:Real}) = true

--- a/test/features.jl
+++ b/test/features.jl
@@ -535,4 +535,10 @@ end
 
   @test gradient(x -> sum(x ./ [1,2,4]), [1,2,pi]) == ([1.0, 0.5, 0.25],)
   @test gradient(x -> sum(map(/, x, [1,2,4])), [1,2,pi]) == ([1.0, 0.5, 0.25],)
+
+  # negative powers
+  @test gradient((x,p) -> sum(x .^ p), [1.0,2.0,4.0], [1,-1,2])[1] ≈ [1.0, -0.25, 8.0]
+  @test gradient((x,p) -> sum(x .^ p), [1.0,2.0,4.0], -1)[1] ≈ [-1.0, -0.25, -0.0625]
+  @test gradient((x,p) -> sum(z -> z^p, x), [1.0,2.0,4.0], -1)[1] ≈ [-1.0, -0.25, -0.0625]
+  @test gradient((x,p) -> mapreduce(z -> z^p, +, x), [1.0,2.0,4.0], -1)[1] ≈ [-1.0, -0.25, -0.0625]
 end

--- a/test/features.jl
+++ b/test/features.jl
@@ -528,6 +528,11 @@ end
   @test gradient(x -> sum(x .+ (x[1],)), [1,2,3]) == ([4,1,1],)
   @test gradient(x -> sum((first∘tuple).(x, :ignore)), [1,2,3]) == ([1,1,1],)
   @test gradient(x -> sum((first∘tuple).(x, Symbol)), [1,2,3]) == ([1,1,1],)
-  _f(x,::Val{y}) where {y} = x/y
+  _f(x,::Val{y}=Val(2)) where {y} = x/y
   @test gradient(x -> sum(_f.(x, Val(2))), [1,2,3]) == ([0.5, 0.5, 0.5],)
+  @test gradient(x -> sum(_f.(x)), [1,2,3]) == ([0.5, 0.5, 0.5],)
+  @test gradient(x -> sum(map(_f, x)), [1,2,3]) == ([0.5, 0.5, 0.5],)
+
+  @test gradient(x -> sum(x ./ [1,2,4]), [1,2,pi]) == ([1.0, 0.5, 0.25],)
+  @test gradient(x -> sum(map(/, x, [1,2,4])), [1,2,pi]) == ([1.0, 0.5, 0.25],)
 end

--- a/test/features.jl
+++ b/test/features.jl
@@ -522,4 +522,12 @@ end
   @test gradient(xs -> sum((x -> x<2 ? false : x^2), xs), [1,2,3])[1][2:3] == [4, 6]
   @test gradient(xs -> sum(map((x -> x<2 ? false : x^2), xs)), [1,2,3])[1][2:3] == [4, 6]
   @test gradient(xs -> mapreduce((x -> x<2 ? false : x^2), +, xs), [1,2,3])[1][2:3] == [4, 6]
+
+  # with Ref, Val, Symbol
+  @test gradient(x -> sum(x .+ Ref(x[1])), [1,2,3]) == ([4,1,1],)
+  @test gradient(x -> sum(x .+ (x[1],)), [1,2,3]) == ([4,1,1],)
+  @test gradient(x -> sum((first∘tuple).(x, :ignore)), [1,2,3]) == ([1,1,1],)
+  @test gradient(x -> sum((first∘tuple).(x, Symbol)), [1,2,3]) == ([1,1,1],)
+  _f(x,::Val{y}) where {y} = x/y
+  @test gradient(x -> sum(_f.(x, Val(2))), [1,2,3]) == ([0.5, 0.5, 0.5],)
 end

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -1295,7 +1295,8 @@ end
 end
 
 @testset "broadcast" begin
-  @test gradient(x -> sum(sin.(x)), Diagonal(randn(3)))[1][2] == 1
+  # Before https://github.com/FluxML/Zygote.jl/pull/1001 this gave [1 1 1; 1 0 1; 1 1 -1] 
+  @test gradient(x -> sum(sin.(x)), Diagonal([0,pi/2,pi]))[1] ≈ [1 0 0; 0 0 0; 0 0 -1]
 
   a = rand(3)
   b = rand(2,2)


### PR DESCRIPTION
During https://github.com/JuliaDiff/ChainRules.jl/pull/441 we realised there's probably a factor 10 left on the table, for no good reason. Not always a factor 10, but still:
```
julia> xs = randn(10_000);

julia> @btime Zygote.gradient(x -> sum(abs.(x)), $xs);
  478.458 μs (30048 allocations: 1.07 MiB)  # Zygote v0.6.12
  28.625 μs (28 allocations: 469.50 KiB)    # this PR, reverse mode
  19.375 μs (52 allocations: 314.17 KiB)    # this PR, forward mode

julia> @btime Zygote.gradient(x -> sum(cbrt.(x)), $xs);
  545.125 μs (30048 allocations: 938.72 KiB)
  81.500 μs (28 allocations: 391.38 KiB)    # this PR, reverse
  87.417 μs (52 allocations: 314.17 KiB)    # this PR, forward

julia> @btime copy($xs);  # to compare time & memory
  2.644 μs (2 allocations: 78.20 KiB)

julia> @btime Zygote.gradient(x -> sum(tanh.(x)), $xs);  # has its own gradient
  114.250 μs (5 allocations: 156.42 KiB)

julia> @btime Zygote.gradient(x -> sum((identity∘tanh).(x)), $xs); # force generic version
  31.097 ms (339593 allocations: 6.56 MiB)
  29.680 ms (309574 allocations: 5.87 MiB)  # this PR, reverse
  131.667 μs (60 allocations: 314.58 KiB)   # this PR, forward
  128.833 μs (52 allocations: 314.17 KiB)   # ... with (y -> tanh(y)) instead

julia> @btime Zygote.gradient(x -> sum(x .> 0.1), $xs)
  10.042 μs (27 allocations: 20.55 KiB)
  8.347 μs (18 allocations: 20.25 KiB)   # this PR, reverse
  12.708 μs (11 allocations: 5.72 KiB)   # this PR, forward
(nothing,)
```
Edit -- latest version does what's suggested in #336, roughly, marked "forward" above. Examples linked there  [discourse](https://discourse.julialang.org/t/zygote-performance/29028) & #592 both get about 5x faster.

Edit' -- perhaps worth timing `map` on the same problems. Not certain we should do this here, but the same purity check used for "forward" should also make it safe to skip `reverse` stuff in `map`. Which gives modest speedups & some memory savings:
```
julia> @btime Zygote.gradient(x -> sum(map(abs, x)), $xs);
  53.666 μs (42 allocations: 938.83 KiB)
  25.791 μs (29 allocations: 391.55 KiB)  # this PR

julia> @btime Zygote.gradient(x -> sum(map(cbrt, x)), $xs);
  108.542 μs (42 allocations: 704.44 KiB)
  76.750 μs (29 allocations: 313.42 KiB)  # this PR

julia> @btime Zygote.gradient(x -> sum(map(tanh, x)), $xs);
  149.917 μs (42 allocations: 704.44 KiB)
  124.875 μs (29 allocations: 313.42 KiB)  # this PR

julia> @btime Zygote.gradient(x -> sum(map(identity∘tanh, x)), $xs);
  32.160 ms (300048 allocations: 6.33 MiB)
  31.064 ms (300034 allocations: 5.65 MiB)  # this PR

julia> @btime Zygote.gradient(x -> sum(map(>(0.1), x)), $xs)
  26.565 ms (330034 allocations: 11.07 MiB)
  25.745 ms (330029 allocations: 10.69 MiB)
(nothing,)
```