### PR TITLE
Make interface2.jl code around generating pullbacks via decomposition

### DIFF
--- a/src/compiler/emit.jl
+++ b/src/compiler/emit.jl
@@ -95,7 +95,7 @@ end
 
 varargs(m::Method, n) = m.isva ? n - m.nargs + 1 : nothing
 
-function _lookup_grad(T)
+function _generate_pullback_via_decomposition(T)
   (m = meta(T)) === nothing && return
   va = varargs(m.method, length(T.parameters))
   forw, back = stacks!(Adjoint(IR(m), varargs = va, normalise = false), T)

--- a/src/compiler/interface2.jl
+++ b/src/compiler/interface2.jl
@@ -24,7 +24,7 @@ end
   hascr && return :($chain_rrule_f(ZygoteRuleConfig(ctx), f, args...))
 
   g = try _lookup_grad(T) catch e e end
-  !(g isa Tuple) && return :(f(args...), Pullback{$T}((f,)))
+  g === nothing && return :(f(args...), Pullback{$T}((f,)))
   meta, forw, _ = g
   argnames!(meta, Symbol("#self#"), :ctx, :f, :args)
   forw = varargs!(meta, forw, 3)

--- a/src/compiler/interface2.jl
+++ b/src/compiler/interface2.jl
@@ -23,7 +23,7 @@ end
 
   hascr && return :($chain_rrule_f(ZygoteRuleConfig(ctx), f, args...))
 
-  g = try _lookup_grad(T) catch e e end
+  g = try _generate_pullback_via_decomposition(T) catch e e end
   g === nothing && return :(f(args...), Pullback{$T}((f,)))
   meta, forw, _ = g
   argnames!(meta, Symbol("#self#"), :ctx, :f, :args)
@@ -37,7 +37,8 @@ end
 
 @generated function (j::Pullback{T})(Δ) where T
   ignore_sig(T) && return :nothing
-  g = try _lookup_grad(T)
+  g = try 
+    _generate_pullback_via_decomposition(T)
   catch e
     rethrow(CompileError(T,e))
   end


### PR DESCRIPTION
Primarily this renames `_lookup_grad` to you `_generate_pullback_via_decomposition`

It's used in like just these 2 places and every time I look at it I need to remember it doesn't do what it says 
It doesn't do a lookup for some predefined rule (that happens before there) it does the thing AD does when it can't lookup the rule.
And it doesn't return the grad, it returns the code to compute the pullback.
It's basically maximum misleading.
And it has been confusing me for years.

