### PR TITLE
Add convenience function to return primal & cotangents together

### DIFF
--- a/docs/src/utils.md
+++ b/docs/src/utils.md
@@ -14,6 +14,8 @@ in other words you could have written them easily yourself, but they live in
 Zygote for convenience.
 
 ```@docs
+Zygote.withgradient
+Zygote.withjacobian
 Zygote.@showgrad
 Zygote.hook
 Zygote.dropgrad

--- a/src/Zygote.jl
+++ b/src/Zygote.jl
@@ -13,7 +13,7 @@ using MacroTools, Requires
 using MacroTools: @forward
 
 import Distributed: pmap, CachingPool, workers
-export Params, gradient, jacobian, hessian, diaghessian, pullback, pushforward, @code_adjoint
+export Params, withgradient, gradient, withjacobian, jacobian, hessian, diaghessian, pullback, pushforward, @code_adjoint
 export rrule_via_ad
 
 const Numeric{T<:Number} = Union{T, AbstractArray{<:T}}

--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -53,6 +53,9 @@ Returns a tuple containing `∂f/∂x` for each argument `x`,
 the derivative (for scalar x) or the gradient.
 
 `f(args...)` must be a real number, see [`jacobian`](@ref) for array output.
+
+See also [`withgradient`](@ref) to keep the value `f(args...)`,
+and `pullback`](@ref) for value and back-propagator.
 """
 function gradient(f, args...)
   y, back = pullback(f, args...)
@@ -60,6 +63,25 @@ function gradient(f, args...)
 end
 
 Base.adjoint(f::Function) = x -> gradient(f, x)[1]
+
+"""
+    withgradient(f, args...)
+
+Returns both the value `f(args...)` and the [`gradient`](@ref), 
+`∂f/∂x` for each argument `x`, as a named tuple.
+
+```jldoctest
+julia> y, ∇ = withgradient(/, 1, 2)
+(val = 0.5, grad = (0.5, -0.25))
+
+julia> ∇ == gradient(/, 1, 2)
+true
+```
+"""
+function withgradient(f, args...)
+  y, back = pullback(f, args...)
+  (val=y, grad=back(sensitivity(y)))
+end
 
 # Param-style wrappers
 

--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -78,8 +78,8 @@ Base.adjoint(f::Function) = x -> gradient(f, x)[1]
     withgradient(f, args...)
     withgradient(f, ::Params)
 
-Returns both the value `f(args...)` and the [`gradient`](@ref)
-as a named tuple. With implicit parameters, the value is `f()`.
+Returns both the value of the function and the [`gradient`](@ref),
+as a named tuple. 
 
 ```jldoctest; setup=:(using Zygote)
 julia> y, ∇ = withgradient(/, 1, 2)
@@ -103,26 +103,29 @@ Gradient with implicit parameters. Takes a zero-argument function,
 and returns a dictionary-like container, whose keys are arrays `x in ps`.
 
 ```jldoctest; setup=:(using Zygote)
-julia> x = [1 2; 3 4]; y = [5, 6];
+julia> x = [1 2 3; 4 5 6]; y = [7, 8]; z = [1, 10, 100];
 
 julia> g = gradient(Params([x, y])) do
-         sum(x .* y .* y')
+         sum(x .* y .* z')
        end
 Grads(...)
 
 julia> g[x]
-2×2 Matrix{Int64}:
- 25  30
- 30  36
+2×3 Matrix{Int64}:
+ 7  70  700
+ 8  80  800
+
+julia> haskey(g, z)  # only x and y are parameters
+false
 ```
 """
 gradient
 
 """
-    Params([A, B, C])
+    Params([A, B])
 
 Container for implicit parameters, used when differentiating
-a zero-argument funtion `() -> loss()` with respect to `A, B, C`.
+a zero-argument funtion `() -> loss(A, B)` with respect to `A, B`.
 """
 struct Params
   order::Buffer # {Any, Vector{Any}}

--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -72,7 +72,7 @@ Returns both the value `f(args...)` and the [`gradient`](@ref),
 `∂f/∂x` for each argument `x`, as a named tuple.
 With imiplicit parameters, the value is `f()`.
 
-```jldoctest
+```jldoctest; setup=:(using Zygote)
 julia> y, ∇ = withgradient(/, 1, 2)
 (val = 0.5, grad = (0.5, -0.25))
 

--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -61,10 +61,14 @@ and [`pullback`](@ref) for value and back-propagator.
 julia> gradient(*, 2, 3, 5)
 (15, 10, 6)
 
-julia> gradient([7,11,13]) do x
-         sum(abs2, x)
-       end
+julia> gradient(x -> sum(abs2,x), [7, 11, 13])
 ([14, 22, 26],)
+
+julia> gradient([7, 11], 0, 1) do x, y, d
+         p = size(x, d)
+         sum(x.^p .+ y)
+       end
+([14.0, 22.0], 2, nothing)
 ```
 """
 function gradient(f, args...)

--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -55,7 +55,7 @@ the derivative (for scalar `x`) or the gradient.
 `f(args...)` must be a real number, see [`jacobian`](@ref) for array output.
 
 See also [`withgradient`](@ref) to keep the value `f(args...)`,
-and `pullback`](@ref) for value and back-propagator.
+and [`pullback`](@ref) for value and back-propagator.
 
 ```jldoctest; setup=:(using Zygote)
 julia> gradient(*, 2, 3, 5)

--- a/src/lib/grad.jl
+++ b/src/lib/grad.jl
@@ -144,7 +144,7 @@ jacobian(f, args...) = withjacobian(f, args...).grad
 
 Returns both the value `f(args...)` and the [`jacobian`](@ref) as a named tuple.
 
-```jldoctest
+```jldoctest; setup=:(using Zygote)
 julia> withjacobian(cumsum, [1,2,3])
 (val = [1, 3, 6], grad = ([1 0 0; 1 1 0; 1 1 1],))
 ```

--- a/test/features.jl
+++ b/test/features.jl
@@ -111,6 +111,7 @@ dx = back(4)
 @test dx == (12, 8)
 
 @test gradient(mul, 2, 3) == (3, 2)
+@test withgradient(mul, 2, 3) == (val = 6, grad = (3, 2))
 
 bool = true
 b(x) = bool ? 2x : x
@@ -287,6 +288,9 @@ y, back = pullback(() -> layer(x), Params([W]))
 @test back([1, 1])[W] == [1 2; 1 2]
 
 @test gradient(() -> sum(W * x), Params([W]))[W] == [1 2; 1 2]
+y, grad = withgradient(() -> sum(W * x), Params([W]))
+@test y == 3
+@test grad[W] == [1 2; 1 2]
 
 let
   p = [1]

--- a/test/features.jl
+++ b/test/features.jl
@@ -288,9 +288,9 @@ y, back = pullback(() -> layer(x), Params([W]))
 @test back([1, 1])[W] == [1 2; 1 2]
 
 @test gradient(() -> sum(W * x), Params([W]))[W] == [1 2; 1 2]
-y, grad = withgradient(() -> sum(W * x), Params([W]))
+y, gr = withgradient(() -> sum(W * x), Params([W]))
 @test y == 3
-@test grad[W] == [1 2; 1 2]
+@test gr[W] == [1 2; 1 2]
 
 let
   p = [1]

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -83,6 +83,10 @@ end
   Jxy = jacobian(() -> ys[1:2] .+ sum(xs.^2), Params([xs, ys]))
   @test Jxy[ys] ≈ [1 0 0; 0 1 0]
   @test Jxy[xs] ≈ [2 6 4 8; 2 6 4 8]
+
+  z, grad = withjacobian(() -> ys[1:2] .+ sum(xs.^2), Params([xs, ys]))
+  @test z == [35, 37]
+  @test grad[ys] ≈ [1 0 0; 0 1 0]
 end
 
 using ForwardDiff

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -42,6 +42,7 @@ end
 
 @testset "jacobian(f, args...)" begin
   @test jacobian(identity, [1,2])[1] == [1 0; 0 1]
+  @test withjacobian(identity, [1,2]) == (val = [1,2], grad = ([1 0; 0 1],))
 
   j1 = jacobian((a,x) -> a.^2 .* x, [1,2,3], 1)
   @test j1[1] ≈ Diagonal([2,4,6])


### PR DESCRIPTION
This adds the long-requested feature of easily getting both the gradient and the loss at once. 

It's a new function to avoid breaking anything. Many worse names for it have been proposed. It returns a named tuple because why not; you can still destructure or index `res[2][1]`  if you prefer.

Closes #892. Also copies across a minimal docstring for `gradient` with implicit parameters.