### PR TITLE
add tests for stateful sum(f,x)

### DIFF
--- a/test/lib/array.jl
+++ b/test/lib/array.jl
@@ -6,3 +6,28 @@ using Zygote: ZygoteRuleConfig
 
 test_rrule(ZygoteRuleConfig(), x->sum(sin, Diagonal(x)), ones(2); rrule_f=rrule_via_ad, check_inferred=false)
 test_rrule(ZygoteRuleConfig(), x->sum(sin, Diagonal(x)), rand(3); rrule_f=rrule_via_ad, check_inferred=false)
+
+using Test, ChainRulesTestUtils, FiniteDifferences, Zygote
+@testset "sum(f, x)" begin
+    mutable struct F
+        s
+    end 
+    function (f::F)(x) 
+        f.s += x
+        return f.s
+    end
+    gfd = FiniteDifferences.grad(FiniteDifferences.central_fdm(5,1),
+        x -> begin  
+            f = F(0)
+            sum(f, x)
+            end
+        , [1.0, 2.0, 3.0])[1]
+
+    
+    gad = gradient([1.,2.,3.]) do x
+                f = F(0.)
+                sum(f, x)
+            end[1]
+            
+    @test gad ≈ gfd
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,56 +2,56 @@ using Zygote, Test
 using Zygote: gradient, ZygoteRuleConfig
 using CUDA: has_cuda
 
-if has_cuda()
-  @testset "CUDA tests" begin
-    include("cuda.jl")
-  end
-else
-  @warn "CUDA not found - Skipping CUDA Tests"
-end
+# if has_cuda()
+#   @testset "CUDA tests" begin
+#     include("cuda.jl")
+#   end
+# else
+#   @warn "CUDA not found - Skipping CUDA Tests"
+# end
 
-@testset "Interface" begin
-  include("interface.jl")
-end
+# @testset "Interface" begin
+#   include("interface.jl")
+# end
 
-@testset "Tools" begin
-  include("tools.jl")
-end
+# @testset "Tools" begin
+#   include("tools.jl")
+# end
 
-@testset "Utils" begin
-  include("utils.jl")
-end
+# @testset "Utils" begin
+#   include("utils.jl")
+# end
 
-@testset "lib" begin
-  include("lib/number.jl")
-  include("lib/lib.jl")
+# @testset "lib" begin
+#   include("lib/number.jl")
+#   include("lib/lib.jl")
   include("lib/array.jl")
-end
+# end
 
-@testset "Features" begin
-  include("features.jl")
-end
+# @testset "Features" begin
+#   include("features.jl")
+# end
 
-@testset "Forward" begin
-  include("forward/forward.jl")
-end
+# @testset "Forward" begin
+#   include("forward/forward.jl")
+# end
 
-@testset "Data Structures" begin
-  include("structures.jl")
-end
+# @testset "Data Structures" begin
+#   include("structures.jl")
+# end
 
-@testset "ChainRules" begin
-  include("chainrules.jl")
-end
+# @testset "ChainRules" begin
+#   include("chainrules.jl")
+# end
 
-@testset "Gradients" begin
-  include("gradcheck.jl")
-end
+# @testset "Gradients" begin
+#   include("gradcheck.jl")
+# end
 
-@testset "Complex" begin
-  include("complex.jl")
-end
+# @testset "Complex" begin
+#   include("complex.jl")
+# end
 
-@testset "Compiler" begin
-  include("compiler.jl")
-end
+# @testset "Compiler" begin
+#   include("compiler.jl")
+# end


### PR DESCRIPTION
looks like we have a problem induced by https://github.com/JuliaDiff/ChainRules.jl/pull/441.
On ChainRules 0.8.10 the test introduced in this PR passes, while on 0.8.15 the zygote gradient  errors out with
```julia
sum(f, x): Error During Test at /home/carlo/.julia/dev/Zygote/test/lib/array.jl:11
  Got exception outside of a @test
  MethodError: no method matching +(::Base.RefValue{Any}, ::Base.RefValue{Any})
  Closest candidates are:
    +(::Any, ::Any, ::Any, ::Any...) at operators.jl:560
    +(::ChainRulesCore.AbstractThunk, ::Any) at /home/carlo/.julia/packages/ChainRulesCore/e5hAX/src/differential_arithmetic.jl:138
    +(::ChainRulesCore.Tangent{P, T} where T, ::P) where P at /home/carlo/.julia/packages/ChainRulesCore/e5hAX/src/differential_arithmetic.jl:162
    ...
  Stacktrace:
    [1] add_sum(x::Base.RefValue{Any}, y::Base.RefValue{Any})
      @ Base ./reduce.jl:24
    [2] _mapreduce(f::typeof(first), op::typeof(Base.add_sum), #unused#::IndexLinear, A::Vector{Tuple{Base.RefValue{Any}, Float64}})
      @ Base ./reduce.jl:408
    [3] _mapreduce_dim(f::Function, op::Function, #unused#::Base._InitialValue, A::Vector{Tuple{Base.RefValue{Any}, Float64}}, #unused#::Colon)
      @ Base ./reducedim.jl:318
    [4] #mapreduce#672
      @ ./reducedim.jl:310 [inlined]
    [5] mapreduce
      @ ./reducedim.jl:310 [inlined]
    [6] #_sum#682
      @ ./reducedim.jl:878 [inlined]
    [7] _sum
      @ ./reducedim.jl:878 [inlined]
    [8] #sum#680
      @ ./reducedim.jl:874 [inlined]
    [9] sum(f::Function, a::Vector{Tuple{Base.RefValue{Any}, Float64}})
      @ Base ./reducedim.jl:874
   [10] (::ChainRules.var"#sum_pullback#1262"{F, Vector{Zygote.var"#ad_pullback#41"{F, Tuple{Float64}, typeof(∂(λ))}}})(ȳ::Float64)
      @ ChainRules ~/.julia/packages/ChainRules/VDG9a/src/rulesets/Base/mapreduce.jl:58
   [11] ZBack
      @ ~/.julia/dev/Zygote/src/compiler/chainrules.jl:91 [inlined]
   [12] Pullback
      @ ~/.julia/dev/Zygote/test/lib/array.jl:29 [inlined]
   [13] (::typeof(∂(#6)))(Δ::Float64)
      @ Zygote ~/.julia/dev/Zygote/src/compiler/interface2.jl:0
   [14] (::Zygote.var"#46#47"{typeof(∂(#6))})(Δ::Float64)
      @ Zygote ~/.julia/dev/Zygote/src/compiler/interface.jl:41
   [15] gradient(f::Function, args::Vector{Float64})
      @ Zygote ~/.julia/dev/Zygote/src/compiler/interface.jl:59
   [16] macro expansion
```


Besides the problem in the ChainRules' rule, I wonder why we don't hit the Zygote adjoint instead https://github.com/FluxML/Zygote.jl/blob/8d5efcb7d54f36c5bc67d61c60f65ce5c97d4ace/src/lib/array.jl#L299
I thought zygote's adjoints had priority over ChainRules' rules