### PR TITLE
Documentation edit on implicit parameters

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -129,7 +129,7 @@ julia> gradient(colordiff, RGB(1, 0, 0), RGB(0, 1, 0))
 ((r = 0.4590887719632896, g = -9.598786801605689, b = 14.181383399012862), (r = -1.7697549557037275, g = 28.88472330558805, b = -0.044793892637761346))
 ```
 
-## Explicit and implicit parameters of ML models
+## Explicit and Implicit Parameters
 
 It's easy to work with even very large and complex models, and there are few ways to do this. Autograd-style models pass around a collection of weights. There are two ways of passing *explicit* parameters:
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -189,16 +189,9 @@ Grads(...)
 julia> grads[W], grads[b]
 ([0.652543 … 0.683588], [1.0, 1.0])
 ```
-Unlike with explicit gradients, in order to see implicit gradients one needs to do:
+To inspect the `Grads(...)` object returned for implicit parameters, you can index it using the parameters passed to `Params`:
 
 ```julia
-julia> grads.grads
-IdDict{Any, Any} with 5 entries:
-  [0.467471 0.597815 … 0.678126 … => [0.579671 0.215381 … 0.635058 0.623832; 0.579671 0.215381 … …
-  :(Main.x)                       => [1.3377, 0.930234, 0.499161, 1.33827, 1.37791]
-  :(Main.W)                       => [0.579671 0.215381 … 0.635058 0.623832; 0.579671 0.215381 … …
-  [0.106308, 0.705531]            => 2-element Fill{Float64}: entries equal to 1.0
-  :(Main.b)                       => 2-element Fill{Float64}: entries equal to 1.0
-```
+julia> [grads[p] for p in [W, b]]
 
 However, implicit parameters exist mainly for compatibility with Flux's current AD; it's recommended to use the other approaches unless you need this.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -170,7 +170,7 @@ julia> dmodel = gradient(model -> sum(model(x)), model)[1]
 (W = [0.652543 … 0.683588], b = [1.0, 1.0])
 ```
 
-On the other hand, the *implicit* style is the one presently used by [Flux.jl](https://github.com/FluxML/Flux.jl), a closely related machine learning library. It uses structs like `Linear` above to define layers, and the function `Flux.params(model)` returns a `Params` object containing all the parameters of all layers. See [its documentation](https://fluxml.ai/Flux.jl/stable/models/basics/) for more details. When using Zygote for most other purposes, however, the explicit style is usually preferred.
+Zygote also support another way to take gradients, via *implicit parameters*. Here the loss function takes zero arguments, but the variables of interest are indicated by a special `Params` object. The function `linear` which depends on `W` and `b` is executed when the loss function `() -> sum(linear(x))` is called, and hence this dependence is visible to Zygote:
 
 ```julia
 julia> W = rand(2, 5); b = rand(2);
@@ -186,4 +186,3 @@ julia> grads[W], grads[b] # access gradients using arrays as keys
 ```
 
 Here `grads` is a dictionary-like object, whose keys are the same parameters we indicated in `Params`. (In fact it wraps a dictionary using `objectid(W)` as keys, which does not change if the values in `W` are mutated).
-

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -170,7 +170,7 @@ julia> dmodel = gradient(model -> sum(model(x)), model)[1]
 (W = [0.652543 … 0.683588], b = [1.0, 1.0])
 ```
 
-Zygote also support one more way to take gradients, via *implicit parameters* – this is a lot like autograd-style gradients, except we don't have to thread the parameter collection through all our code. When working with Flux models, this is the recommended way of passing the gradients, as it ensures compatibility with Flux's built-in optimizers. 
+On the other hand, the *implicit* style is the one presently used by [Flux.jl](https://github.com/FluxML/Flux.jl), a closely related machine learning library. It uses structs like `Linear` above to define layers, and the function `Flux.params(model)` returns a `Params` object containing all the parameters of all layers. See [its documentation](https://fluxml.ai/Flux.jl/stable/models/basics/) for more details. When using Zygote for most other purposes, however, the explicit style is usually preferred.
 
 ```julia
 julia> W = rand(2, 5); b = rand(2);
@@ -187,4 +187,3 @@ julia> grads[W], grads[b] # access gradients using arrays as keys
 
 Here `grads` is a dictionary-like object, whose keys are the same parameters we indicated in `Params`. (In fact it wraps a dictionary using `objectid(W)` as keys, which does not change if the values in `W` are mutated).
 
-This implicit style is the one presently used by [Flux.jl](https://github.com/FluxML/Flux.jl), a closely related machine learning library. It uses structs like `Linear` above to define layers, and the function `Flux.params(model)` returns a `Params` object containing all the parameters of all layers. See [its documentation](https://fluxml.ai/Flux.jl/stable/models/basics/) for more details. When using Zygote for most other purposes, however, the explicit style is usually preferred.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -186,3 +186,5 @@ julia> grads[W], grads[b] # access gradients using arrays as keys
 ```
 
 Here `grads` is a dictionary-like object, whose keys are the same parameters we indicated in `Params`. (In fact it wraps a dictionary using `objectid(W)` as keys, which does not change if the values in `W` are mutated).
+
+This implicit style is the one presently used by [Flux.jl](https://github.com/FluxML/Flux.jl), a closely related machine learning library. It uses structs like `Linear` above to define layers, and the function `Flux.params(model)` returns a `Params` object containing all the parameters of all layers. See [its documentation](https://fluxml.ai/Flux.jl/stable/models/basics/) for more details. When using Zygote for most other purposes, however, the explicit style is usually preferred.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -131,6 +131,8 @@ julia> gradient(colordiff, RGB(1, 0, 0), RGB(0, 1, 0))
 
 ## Gradients of ML models
 
+### Explicit parameters
+
 It's easy to work with even very large and complex models, and there are few ways to do this. Autograd-style models pass around a collection of weights.
 
 ```julia
@@ -170,7 +172,9 @@ julia> dmodel = gradient(model -> sum(model(x)), model)[1]
 (W = [0.652543 … 0.683588], b = [1.0, 1.0])
 ```
 
-Zygote also support one more way to take gradients, via *implicit parameters* – this is a lot like autograd-style gradients, except we don't have to thread the parameter collection through all our code.
+### Implicit parameters
+
+Zygote also support one more way to take gradients, via *implicit parameters* – this is a lot like autograd-style gradients, except we don't have to thread the parameter collection through all our code. When working with Flux models, this is the recommended way of passing the gradients, as it ensures compatibility with Flux's built-in optimizers. 
 
 ```julia
 julia> W = rand(2, 5); b = rand(2);
@@ -181,8 +185,20 @@ linear (generic function with 2 methods)
 julia> grads = gradient(() -> sum(linear(x)), Params([W, b]))
 Grads(...)
 
+# Apply gradients to model parameters
 julia> grads[W], grads[b]
 ([0.652543 … 0.683588], [1.0, 1.0])
+```
+Unlike with explicit gradients, in order to see implicit gradients one needs to do:
+
+```julia
+julia> grads.grads
+IdDict{Any, Any} with 5 entries:
+  [0.467471 0.597815 … 0.678126 … => [0.579671 0.215381 … 0.635058 0.623832; 0.579671 0.215381 … …
+  :(Main.x)                       => [1.3377, 0.930234, 0.499161, 1.33827, 1.37791]
+  :(Main.W)                       => [0.579671 0.215381 … 0.635058 0.623832; 0.579671 0.215381 … …
+  [0.106308, 0.705531]            => 2-element Fill{Float64}: entries equal to 1.0
+  :(Main.b)                       => 2-element Fill{Float64}: entries equal to 1.0
 ```
 
 However, implicit parameters exist mainly for compatibility with Flux's current AD; it's recommended to use the other approaches unless you need this.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -153,7 +153,9 @@ Dict{Any,Any} with 2 entries:
   :W => [0.628998 … 0.433006]
 ```
 
-An extension of this is the Flux-style model in which we use call overloading to combine the weight object with the pullback pass (equivalent to a closure).
+We can combine the role of the dictionary and the function here by making a callable struct which
+contains the parameters, equivalent to a closure. Passed explicitly to `gradient`, we get a named tuple
+with the same field names:
 
 ```julia
 julia> struct Linear
@@ -170,7 +172,7 @@ julia> dmodel = gradient(model -> sum(model(x)), model)[1]
 (W = [0.652543 … 0.683588], b = [1.0, 1.0])
 ```
 
-Zygote also support another way to take gradients, via *implicit parameters*. Here the loss function takes zero arguments, but the variables of interest are indicated by a special `Params` object. The function `linear` which depends on `W` and `b` is executed when the loss function `() -> sum(linear(x))` is called, and hence this dependence is visible to Zygote:
+Zygote also supports another way to take gradients, via *implicit parameters*. Here the loss function takes zero arguments, but the variables of interest are indicated by a special `Params` object. The function `linear` which depends on `W` and `b` is executed when the loss function `() -> sum(linear(x))` is called, and hence this dependence is visible to Zygote:
 
 ```julia
 julia> W = rand(2, 5); b = rand(2);

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -180,18 +180,13 @@ linear (generic function with 2 methods)
 
 julia> grads = gradient(() -> sum(linear(x)), Params([W, b]))
 Grads(...)
-```
-To inspect the `Grads(...)` object returned for implicit parameters, you can access it using the parameters passed to `Params`:
 
-```julia
-# Apply gradients to model parameters
-julia> grads[W], grads[b]
+julia> grads[W], grads[b] # access gradients using arrays as keys
 ([0.652543 … 0.683588], [1.0, 1.0])
 ```
 
 Here `grads` is a dictionary-like object, whose keys are the same parameters we 
-indicated in `Params`. (In fact it contains a dictionary using `objectid(W)`, which 
-does not change if the values in `W` are mutated.) These parameters `W, b` are global 
-variables, but gradients with respect to other global variables are not stored.
+indicated in `Params`. (In fact it wraps a dictionary using `objectid(W)` as keys, which 
+does not change if the values in `W` are mutated).
 
 However, implicit parameters exist mainly for compatibility with Flux's current AD; it's recommended to use the other approaches unless you need this.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -129,11 +129,9 @@ julia> gradient(colordiff, RGB(1, 0, 0), RGB(0, 1, 0))
 ((r = 0.4590887719632896, g = -9.598786801605689, b = 14.181383399012862), (r = -1.7697549557037275, g = 28.88472330558805, b = -0.044793892637761346))
 ```
 
-## Gradients of ML models
+## Explicit and implicit parameters of ML models
 
-### Explicit parameters
-
-It's easy to work with even very large and complex models, and there are few ways to do this. Autograd-style models pass around a collection of weights.
+It's easy to work with even very large and complex models, and there are few ways to do this. Autograd-style models pass around a collection of weights. There are two ways of passing *explicit* parameters:
 
 ```julia
 julia> linear(θ, x) = θ[:W] * x .+ θ[:b]
@@ -172,8 +170,6 @@ julia> dmodel = gradient(model -> sum(model(x)), model)[1]
 (W = [0.652543 … 0.683588], b = [1.0, 1.0])
 ```
 
-### Implicit parameters
-
 Zygote also support one more way to take gradients, via *implicit parameters* – this is a lot like autograd-style gradients, except we don't have to thread the parameter collection through all our code. When working with Flux models, this is the recommended way of passing the gradients, as it ensures compatibility with Flux's built-in optimizers. 
 
 ```julia
@@ -184,14 +180,18 @@ linear (generic function with 2 methods)
 
 julia> grads = gradient(() -> sum(linear(x)), Params([W, b]))
 Grads(...)
+```
+To inspect the `Grads(...)` object returned for implicit parameters, you can access it using the parameters passed to `Params`:
 
+```julia
 # Apply gradients to model parameters
 julia> grads[W], grads[b]
 ([0.652543 … 0.683588], [1.0, 1.0])
 ```
-To inspect the `Grads(...)` object returned for implicit parameters, you can index it using the parameters passed to `Params`:
 
-```julia
-julia> [grads[p] for p in [W, b]]
+Here `grads` is a dictionary-like object, whose keys are the same parameters we 
+indicated in `Params`. (In fact it contains a dictionary using `objectid(W)`, which 
+does not change if the values in `W` are mutated.) These parameters `W, b` are global 
+variables, but gradients with respect to other global variables are not stored.
 
 However, implicit parameters exist mainly for compatibility with Flux's current AD; it's recommended to use the other approaches unless you need this.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -185,8 +185,6 @@ julia> grads[W], grads[b] # access gradients using arrays as keys
 ([0.652543 … 0.683588], [1.0, 1.0])
 ```
 
-Here `grads` is a dictionary-like object, whose keys are the same parameters we 
-indicated in `Params`. (In fact it wraps a dictionary using `objectid(W)` as keys, which 
-does not change if the values in `W` are mutated).
+Here `grads` is a dictionary-like object, whose keys are the same parameters we indicated in `Params`. (In fact it wraps a dictionary using `objectid(W)` as keys, which does not change if the values in `W` are mutated).
 
-However, implicit parameters exist mainly for compatibility with Flux's current AD; it's recommended to use the other approaches unless you need this.
+This implicit style is the one presently used by [Flux.jl](https://github.com/FluxML/Flux.jl), a closely related machine learning library. It uses structs like `Linear` above to define layers, and the function `Flux.params(model)` returns a `Params` object containing all the parameters of all layers. See [its documentation](https://fluxml.ai/Flux.jl/stable/models/basics/) for more details. When using Zygote for most other purposes, however, the explicit style is usually preferred.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -131,7 +131,7 @@ julia> gradient(colordiff, RGB(1, 0, 0), RGB(0, 1, 0))
 
 ## Explicit and Implicit Parameters
 
-It's easy to work with even very large and complex models, and there are few ways to do this. Autograd-style models pass around a collection of weights. There are two ways of passing *explicit* parameters:
+It's easy to work with even very large and complex models, and there are few ways to do this. Autograd-style models pass around a collection of weights. Depending on how you write your model, there are multiple ways to *explicity* take gradients with respect to parameters. For example, the function `linear` accepts the parameters as an argument to the model. So, we directly pass in the parameters, `θ`, as an argument to the function being differentiated.
 
 ```julia
 julia> linear(θ, x) = θ[:W] * x .+ θ[:b]


### PR DESCRIPTION
After struggling to handle implicit parameters with a Flux model, and following a discourse discussion (https://discourse.julialang.org/t/unrecognized-gradient-using-zygote-for-ad-with-universal-differential-equations/63791/2) , I have decided to add some extra details on how to access and when to use implicit parameters. I hope this helps new users like me to avoid wasting time looking for this.