### PR TITLE
Tidy up a few things in broadcasting

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -8,7 +8,7 @@ using Distributed: pmap, AbstractWorkerPool
 @adjoint Array(xs::AbstractArray) = Array(xs), ȳ -> (ȳ,)
 @adjoint Array(xs::Array) = Array(xs), ȳ -> (ȳ,)
 
-@nograd ones, zeros, Base.OneTo, Colon(), one, zero, sizehint!
+@nograd ones, zeros, Base.OneTo, Colon(), one, zero, sizehint!, count
 
 @adjoint Base.vect(xs...) = Base.vect(xs...), Δ -> (Δ...,)
 

--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -253,10 +253,10 @@ end
     @eval @adjoint broadcasted(::CuArrayStyle, f, args...) =
       broadcast_forward(CUDA.cufunc(f), args...)
 
-  # else CUDA >= 3.0 -- don't need cufunc(f), and ordinary broadcasting calls broadcast_forward when safe
+  else CUDA >= 3.0 -- don't need cufunc(f), and ordinary broadcasting calls broadcast_forward when safe
 
-    # @eval @adjoint function broadcasted(::CuArrayStyle, f, args...) =
-    #   broadcast_forward(f, args...)
+    @eval @adjoint function broadcasted(::CuArrayStyle, f, args...) =
+      broadcast_forward(f, args...)
 
   end
 

--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -255,7 +255,7 @@ end
 
   else # CUDA >= 3.0 -- don't need cufunc(f), and ordinary broadcasting calls broadcast_forward when safe
 
-    @eval @adjoint function broadcasted(::CuArrayStyle, f, args...) =
+    @eval @adjoint broadcasted(::CuArrayStyle, f, args...) =
       broadcast_forward(f, args...)
 
   end

--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -100,10 +100,10 @@ end
 end
 
 @adjoint broadcasted(::typeof(conj), x::Numeric) =
-  conj.(x), z̄ -> (nothing, conj.(z̄))
+  conj(x), z̄ -> (nothing, conj(z̄))
 
 @adjoint broadcasted(::typeof(real), x::Numeric) =
-  real.(x), z̄ -> (nothing, real.(z̄))
+  real(x), z̄ -> (nothing, real(z̄))
 
 @adjoint broadcasted(::typeof(imag), x::Numeric) =
   imag.(x), z̄ -> (nothing, im .* real.(z̄))

--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -253,7 +253,7 @@ end
     @eval @adjoint broadcasted(::CuArrayStyle, f, args...) =
       broadcast_forward(CUDA.cufunc(f), args...)
 
-  else CUDA >= 3.0 -- don't need cufunc(f), and ordinary broadcasting calls broadcast_forward when safe
+  else # CUDA >= 3.0 -- don't need cufunc(f), and ordinary broadcasting calls broadcast_forward when safe
 
     @eval @adjoint function broadcasted(::CuArrayStyle, f, args...) =
       broadcast_forward(f, args...)

--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -251,10 +251,10 @@ end
     @eval @adjoint broadcasted(::CuArrayStyle, f, args...) =
       broadcast_forward(CUDA.cufunc(f), args...)
 
-  else # CUDA >= 3.0
-  
-    @eval @adjoint function broadcasted(::CuArrayStyle, f, args...) =
-      broadcast_forward(f, args...)
+  # else CUDA >= 3.0 -- don't need cufunc(f), and ordinary broadcasting calls broadcast_forward when safe
+
+    # @eval @adjoint function broadcasted(::CuArrayStyle, f, args...) =
+    #   broadcast_forward(f, args...)
 
   end
 

--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -45,18 +45,18 @@ function Base.reducedim_init(::typeof(identity), ::typeof(accum), A::AbstractArr
   Base.reducedim_initarray(A, region, nothing, Union{Nothing,eltype(A)})
 end
 
-_trim(x, Δ) = reshape(Δ, ntuple(i -> size(Δ, i), Val(ndims(x))))
-_trim(x::Tuple, Δ) = NTuple{length(x)}(Δ)
+trim(x, Δ) = reshape(Δ, ntuple(i -> size(Δ, i), Val(ndims(x))))
+trim(x::Tuple, Δ) = NTuple{length(x)}(Δ)
 
 unbroadcast(x::AbstractArray, x̄) =
   size(x) == size(x̄) ? x̄ :
-  length(x) == length(x̄) ? _trim(x, x̄) :
-    _trim(x, accum_sum(x̄, dims = ntuple(i -> size(x, i) == 1 ? i : ndims(x̄)+1, Val(ndims(x̄)))))
+  length(x) == length(x̄) ? trim(x, x̄) :
+    trim(x, accum_sum(x̄, dims = ntuple(i -> size(x, i) == 1 ? i : ndims(x̄)+1, Val(ndims(x̄)))))
 
 unbroadcast(x::Number, x̄) = accum_sum(x̄)
 unbroadcast(x::Tuple{<:Any}, x̄) = (accum_sum(x̄),)
 unbroadcast(x::Base.RefValue, x̄) = (x=accum_sum(x̄),)
-unbroadcast(x::Tuple, x̄) = _trim(x, length(x) == length(x̄) ? x̄ : accum_sum(x̄; dims=2:ndims(x̄))) # case length(x) > 1
+unbroadcast(x::Tuple, x̄) = trim(x, length(x) == length(x̄) ? x̄ : accum_sum(x̄; dims=2:ndims(x̄))) # case length(x) > 1
 
 unbroadcast(x::AbstractArray, x̄::Nothing) = nothing
 

--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -253,7 +253,10 @@ end
     @eval @adjoint broadcasted(::CuArrayStyle, f, args...) =
       broadcast_forward(CUDA.cufunc(f), args...)
 
-  else # CUDA >= 3.0 -- don't need cufunc(f), and ordinary broadcasting calls broadcast_forward when safe
+  else # CUDA >= 3.0 -- don't need cufunc(f). 
+       # Ordinary broadcasting calls broadcast_forward anyway when certain its' safe,
+       # so perhaps this can be deleted? Possible edge case here:
+       # https://github.com/FluxML/Zygote.jl/pull/1018#issuecomment-873629415
 
     @eval @adjoint broadcasted(::CuArrayStyle, f, args...) =
       broadcast_forward(f, args...)

--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -219,6 +219,7 @@ using ForwardDiff: Dual
 
 dual(x, p) = x
 dual(x::Real, p) = Dual(x, p)
+dual(x::Bool, p) = x
 
 function dual_function(f::F) where F
   function (args::Vararg{Any,N}) where N

--- a/test/cuda.jl
+++ b/test/cuda.jl
@@ -27,8 +27,8 @@ end
 
   # https://github.com/FluxML/Zygote.jl/issues/1027
   @test gradient(x -> sum(x .!= 0), a_gpu) == (nothing,)
-  g3 = gradient(x -> sum(x .^ 3) ./ count(x .> 3), a)[1]
-  @test cu(g3) ≈ gradient(x -> sum(x .^ 3) ./ sum(x .> 3), a_gpu)[1]
+  g3 = gradient(x -> sum(x .^ 3) / count(x .> 3), a)[1]
+  @test cu(g3) ≈ gradient(x -> sum(x .^ 3) / sum(x .> 3), a_gpu)[1]
 end
 
 @testset "sum(f, x)" begin

--- a/test/cuda.jl
+++ b/test/cuda.jl
@@ -25,10 +25,12 @@ end
   @test g_gpu isa CuArray
   @test g_gpu |> collect ≈ g
 
-  # https://github.com/FluxML/Zygote.jl/issues/1027
+  # https://github.com/FluxML/Zygote.jl/issues/1027                  # status on Zygote v0.6.14, CUDA v3.3.0 in comments:
   @test gradient(x -> sum(x .!= 0), a_gpu) == (nothing,)             # was MethodError: no method matching iterate(::Nothing)
+  @test gradient(x -> sum(x .> 3), a_gpu) == (nothing,)
   g3 = gradient(x -> sum(x .^ 3) / count(x .> 3), a)[1]              # was Can't differentiate gc_preserve_end expression
-  @test cu(g3) ≈ gradient(x -> sum(x .^ 3) / sum(x .> 3), a_gpu)[1]  # was KernelException -- Zygote v0.6.14, CUDA v3.3.0
+  @test_skip cu(g3) ≈ gradient(x -> sum(x .^ 3) / sum(x .> 3), a_gpu)[1]  # was KernelException -- not fixed by PR #1018
+  @test cu(g3) ≈ gradient(x -> sum(x .^ 3) / count(x .> 3), a_gpu)[1] 
 end
 
 @testset "sum(f, x)" begin

--- a/test/cuda.jl
+++ b/test/cuda.jl
@@ -26,9 +26,9 @@ end
   @test g_gpu |> collect ≈ g
 
   # https://github.com/FluxML/Zygote.jl/issues/1027
-  @test gradient(x -> sum(x .!= 0), a_gpu) == (nothing,)
-  g3 = gradient(x -> sum(x .^ 3) / count(x .> 3), a)[1]
-  @test cu(g3) ≈ gradient(x -> sum(x .^ 3) / sum(x .> 3), a_gpu)[1]
+  @test gradient(x -> sum(x .!= 0), a_gpu) == (nothing,)             # was MethodError: no method matching iterate(::Nothing)
+  g3 = gradient(x -> sum(x .^ 3) / count(x .> 3), a)[1]              # was Can't differentiate gc_preserve_end expression
+  @test cu(g3) ≈ gradient(x -> sum(x .^ 3) / sum(x .> 3), a_gpu)[1]  # was KernelException -- Zygote v0.6.14, CUDA v3.3.0
 end
 
 @testset "sum(f, x)" begin

--- a/test/cuda.jl
+++ b/test/cuda.jl
@@ -9,7 +9,7 @@ CUDA.allowscalar(false)
   @test gradient(x -> sum(cu(x)), r)[1] isa Array{Float32, 2}
 end
 
-@testset "basic bcasting" begin
+@testset "broadcasting" begin
   a = Float32.(1:9)
   a_gpu = a |> cu
 
@@ -24,6 +24,11 @@ end
   g_gpu = gradient(x -> w(x), a_gpu)[1]
   @test g_gpu isa CuArray
   @test g_gpu |> collect ≈ g
+
+  # https://github.com/FluxML/Zygote.jl/issues/1027
+  @test gradient(x -> sum(x .!= 0), a_gpu) == (nothing,)
+  g3 = gradient(x -> sum(x .^ 3) ./ count(x .> 3), a)[1]
+  @test cu(g3) ≈ gradient(x -> sum(x .^ 3) ./ sum(x .> 3), a_gpu)[1]
 end
 
 @testset "sum(f, x)" begin


### PR DESCRIPTION
This removes some functions like `z, Δ -> (nothing, back(Δ)...)` by calling `_pullback` immediately, or  by altering `broadcast_forward` (which is also tidied up a bit). Closes #1027 which was a bug in that function.

~~It also deletes the special case of broadcasting for CuArrays.~~ [now removed] Broadcasting over real numbers, with a pure enough `f`, now always uses `broadcast_forward`, thus should work on CuArrays too. Broadcasting over complex numbers will give an error instead of a wrong answer, seen in #961. Broadcasting a closure, or a stateful function, ditto. However, I'm less than 100% confident that there aren't some functions which currently do give correct answers, but will now give an error. Can anyone see how to construct one?

Note BTW buildkite Julia 1.5 tests CUDA 2 so misses this change, and Julia 1.6 seems broken before this change.