### PR TITLE
Make broadcasting over `Params` in the gradient an error

### DIFF
--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -200,7 +200,6 @@ function Base.delete!(ps::Params, x)
 end
 
 Base.Broadcast.broadcasted(f, ps::Params) = broadcasted(f, ps.order)
-Base.Broadcast.broadcastable(ps::Params) = ps.order
 
 @adjoint function Broadcast.broadcasted(f::Function, ps::Params)
   f.(ps), _ -> throw(ArgumentError("Zygote.Params does not support broadcasting within gradients, try iteration `for p in ps`"))

--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -200,6 +200,11 @@ function Base.delete!(ps::Params, x)
 end
 
 Base.Broadcast.broadcasted(f, ps::Params) = broadcasted(f, ps.order)
+# Broadcast.broadcastable(ps::Params) = ps.order
+
+@adjoint function Broadcast.broadcasted(f::Function, ps::Params)
+  f.(ps), _ -> throw(ArgumentError("Zygote.Params does not support broadcasting within gradients, try iteration `for p in ps`"))
+end
 
 Base.:(==)(x::Params, y::Params) = x.order.data == y.order.data
 

--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -200,7 +200,7 @@ function Base.delete!(ps::Params, x)
 end
 
 Base.Broadcast.broadcasted(f, ps::Params) = broadcasted(f, ps.order)
-# Broadcast.broadcastable(ps::Params) = ps.order
+Base.Broadcast.broadcastable(ps::Params) = ps.order
 
 @adjoint function Broadcast.broadcasted(f::Function, ps::Params)
   f.(ps), _ -> throw(ArgumentError("Zygote.Params does not support broadcasting within gradients, try iteration `for p in ps`"))

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -73,14 +73,14 @@ _droplike(dy::Union{LinearAlgebra.Adjoint, LinearAlgebra.Transpose}, dxv::Abstra
 @adjoint getindex(::Type{T}, xs...) where {T} = T[xs...], dy -> (nothing, dy...)
 
 @adjoint! setindex!(xs::AbstractArray, x...) = setindex!(xs, x...),
-  _ -> error("Mutating arrays is not supported -- called setindex!(::$(typeof(xs)), ...)")
+  _ -> error("Mutating arrays is not supported -- called setindex!(::$(typeof(xs)), _...)")
 
 @adjoint! copyto!(args...) = copyto!(args...),
-  _ -> error("Mutating arrays is not supported -- called copyto!(::$(typeof(xs)), ...)")
+  _ -> error("Mutating arrays is not supported -- called copyto!(::$(typeof(xs)), _...)")
 
 for f in [push!, pop!, pushfirst!, popfirst!]
-  @eval @adjoint! $f(xs, x...) =
-    push!(xs, x...), _ -> error("Mutating arrays is not supported -- called $($f)(::$(typeof(xs)), ...)")
+  @eval @adjoint! $f(xs, x...) = $f(xs, x...), 
+    _ -> error("Mutating arrays is not supported -- called $($f)(::$(typeof(xs)), _...)")
 end
 
 # This is kind of bad, but at least we don't materialize the whole

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -73,14 +73,14 @@ _droplike(dy::Union{LinearAlgebra.Adjoint, LinearAlgebra.Transpose}, dxv::Abstra
 @adjoint getindex(::Type{T}, xs...) where {T} = T[xs...], dy -> (nothing, dy...)
 
 @adjoint! setindex!(xs::AbstractArray, x...) = setindex!(xs, x...),
-  _ -> error("Mutating arrays is not supported")
+  _ -> error("Mutating arrays is not supported -- called setindex!(::$(typeof(xs)), ...)")
 
 @adjoint! copyto!(args...) = copyto!(args...),
-  _ -> error("Mutating arrays is not supported")
+  _ -> error("Mutating arrays is not supported -- called copyto!(::$(typeof(xs)), ...)")
 
 for f in [push!, pop!, pushfirst!, popfirst!]
   @eval @adjoint! $f(xs, x...) =
-    push!(xs, x...), _ -> error("Mutating arrays is not supported")
+    push!(xs, x...), _ -> error("Mutating arrays is not supported -- called $f(::$(typeof(xs)), ...)")
 end
 
 # This is kind of bad, but at least we don't materialize the whole

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -80,7 +80,7 @@ _droplike(dy::Union{LinearAlgebra.Adjoint, LinearAlgebra.Transpose}, dxv::Abstra
 
 for f in [push!, pop!, pushfirst!, popfirst!]
   @eval @adjoint! $f(xs, x...) =
-    push!(xs, x...), _ -> error("Mutating arrays is not supported -- called $f(::$(typeof(xs)), ...)")
+    push!(xs, x...), _ -> error("Mutating arrays is not supported -- called $($f)(::$(typeof(xs)), ...)")
 end
 
 # This is kind of bad, but at least we don't materialize the whole

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -38,7 +38,10 @@ using Zygote: Grads
     x, y = [1,2], [1]
     ps = Params([x, y])
     @test length.(ps) == length.([x, y]) # 617
+    @test size.(ps, 1) == [2, 1]
     @test all(Params([[1,1]]) .== Params([[1,1]]))
+
+    @test_throws ArgumentError gradient(() -> sum(sum.(ps)), ps)
   end
 
   @testset "indexing" begin


### PR DESCRIPTION
According to https://github.com/FluxML/Flux.jl/pull/1614 this never worked. But at least it could have a less mysterious error message. 

And, there are actually 3 different "Mutating arrays is not supported" errors, with the same message, which aren't trivial to distinguish from their stack traces. So I made them more informative.