### PR TITLE
Remove incorrect `push!` and `pop!` gradients

### DIFF
--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -184,21 +184,15 @@ function Base.push!(ps::Params, x)
 end
 
 @adjoint! function Base.push!(xs::IdSet, x...)
-  l = length(x)
-  push!(xs, x...), Δ -> begin
-    Δ == nothing && return nothing
-    println("got nontrivial gradient for push!(::IdSet, ...): Δ = ", Δ) 
-    (Δ, ntuple(_ -> nothing, l)...)
-  end
+  back(::Nothing) = nothing
+  back(Δ) = error("can't handle nontrivial gradient for push!(::IdSet, ...): Δ = " * repr(Δ)) 
+  push!(xs, x...), back
 end
 
 @adjoint! function Base.push!(xs::Params, x::AbstractArray...)
-  sz_x = size.(x)
-  push!(xs, x...), Δ -> begin
-    Δ == nothing && return nothing
-    println("got nontrivial gradient for push!(::Params, ...): Δ = ", Δ) 
-    # (Δ, map(x -> Ones{T}(x...), sz_x)...) # don't think this is correct
-  end
+  back(::Nothing) = nothing
+  back(Δ) = error("can't handle nontrivial gradient for push!(::Params, ...): Δ = " * repr(Δ)) 
+  push!(xs, x...), back
 end
 
 Base.push!(ps::Params, x...) = (foreach(x -> push!(ps, x), x); ps)

--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -186,14 +186,18 @@ end
 @adjoint! function Base.push!(xs::IdSet, x...)
   l = length(x)
   push!(xs, x...), Δ -> begin
+    Δ == nothing && return nothing
+    println("got nontrivial gradient for push!(::IdSet, ...): Δ = ", Δ) 
     (Δ, ntuple(_ -> nothing, l)...)
   end
 end
 
-@adjoint! function Base.push!(xs::Params, x::AbstractArray{T}...) where T
+@adjoint! function Base.push!(xs::Params, x::AbstractArray...)
   sz_x = size.(x)
   push!(xs, x...), Δ -> begin
-    (Δ, map(x -> Ones{T}(x...), sz_x)...)
+    Δ == nothing && return nothing
+    println("got nontrivial gradient for push!(::Params, ...): Δ = ", Δ) 
+    # (Δ, map(x -> Ones{T}(x...), sz_x)...) # don't think this is correct
   end
 end
 

--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -183,18 +183,6 @@ function Base.push!(ps::Params, x)
   return ps
 end
 
-@adjoint! function Base.push!(xs::IdSet, x...)
-  back(::Nothing) = nothing
-  back(Δ) = error("can't handle nontrivial gradient for push!(::IdSet, ...): Δ = " * repr(Δ)) 
-  push!(xs, x...), back
-end
-
-@adjoint! function Base.push!(xs::Params, x::AbstractArray...)
-  back(::Nothing) = nothing
-  back(Δ) = error("can't handle nontrivial gradient for push!(::Params, ...): Δ = " * repr(Δ)) 
-  push!(xs, x...), back
-end
-
 Base.push!(ps::Params, x...) = (foreach(x -> push!(ps, x), x); ps)
 
 function Base.delete!(ps::Params, x)

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -79,41 +79,17 @@ for f in [push!, pop!, pushfirst!, popfirst!]
 end
 
 # Exceptions:
-@adjoint! function push!(dst::AbstractVector{<:AbstractArray}, xs::AbstractArray...)
+@adjoint! function push!(dst::AbstractVector, xs::AbstractArray...)
   num_xs = length(xs)
   push!(dst, xs...), Δ -> begin
     (Δ[1:end-num_xs], Δ[end-num_xs+1:end]...)
   end
 end
 
-@adjoint! function pop!(src::AbstractVector{<:AbstractArray{T}}) where T
+@adjoint! function pop!(src::AbstractVector{<:AbstractArray})
   zs = fill(nothing, length(src)-1)
   pop!(src), Δ -> (vcat(zs, [Δ]),)
 end
-
-#=
-
-
-julia> gradient((xs, y) -> sum(abs2, push!(xs, y)[1]), [[1,2], [3,4]], [5,6])
-([[2, 4], nothing, nothing], 2-element Ones{Int64})
-([[2, 4], nothing], nothing)  # correct
-
-julia> gradient((xs, y) -> sum(abs2, push!(xs, y)[2]), [[1,2], [3,4]], [5,6])
-([nothing, [6, 8], nothing], 2-element Ones{Int64})
-([nothing, [6, 8]], nothing)  # correct
-
-julia> gradient((xs, y) -> sum(abs2, push!(xs, y)[3]), [[1,2], [3,4]], [5,6])
-([nothing, nothing, [10, 12]], 2-element Ones{Int64})
-([nothing, nothing], [10, 12])  # correct
-
-(jl_aA0cjy) pkg> st Zygote
-      Status `/private/var/folders/yq/4p2zwd614y59gszh7y9ypyhh0000gn/T/jl_aA0cjy/Project.toml`
-  [e88e6eb3] Zygote v0.6.14
-
-julia> gradient(xs -> sum(abs2, pop!(xs)), [[1,2], [3,4]])
-(Union{Nothing, Vector{Int64}}[nothing, nothing, [6, 8]],)
-
-=#
 
 # General
 

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -74,8 +74,8 @@ _droplike(dy::Union{LinearAlgebra.Adjoint, LinearAlgebra.Transpose}, dxv::Abstra
   _ -> error("Mutating arrays is not supported -- called copyto!(::$(typeof(xs)), _...)")
 
 for f in [push!, pop!, pushfirst!, popfirst!]
-  @eval @adjoint! $f(xs, x...) = $f(xs, x...), 
-    _ -> error("Mutating arrays is not supported -- called $($f)(::$(typeof(xs)), _...)")
+  @eval @adjoint! $f(x::AbstractVector, ys...) = $f(x, ys...), 
+    _ -> error("Mutating arrays is not supported -- called $($f)(::$(typeof(x)), _...)")
 end
 
 # General

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -79,17 +79,25 @@ for f in [push!, pop!, pushfirst!, popfirst!]
 end
 
 # Exceptions:
-@adjoint! function push!(dst::AbstractVector, xs::AbstractArray...)
-  num_xs = length(xs)
+@adjoint! function push!(dst::AbstractVector, xs...)
+  # num_xs = length(xs)
+  n = length(xs)
+  valn = Val(n)
   push!(dst, xs...), Δ -> begin
-    (Δ[1:end-num_xs], Δ[end-num_xs+1:end]...)
+    # (Δ[1:end-num_xs], Δ[end-num_xs+1:end]...)
+    (Δ[1:end-n], ntuple(i -> Δ[end-n+i], valn)...)
   end
 end
 
-@adjoint! function pop!(src::AbstractVector{<:AbstractArray})
+@adjoint! function pop!(src::AbstractVector)
   zs = fill(nothing, length(src)-1)
   pop!(src), Δ -> (vcat(zs, [Δ]),)
 end
+@adjoint! function pop!(src::AbstractVector{<:Number})
+  zs = falses(length(src)-1)
+  pop!(src), Δ -> (vcat(zs, Δ),)
+end
+
 
 # General
 

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -78,24 +78,42 @@ for f in [push!, pop!, pushfirst!, popfirst!]
     _ -> error("Mutating arrays is not supported -- called $($f)(::$(typeof(xs)), _...)")
 end
 
-# This is kind of bad, but at least we don't materialize the whole
-# array. Prefer to use `Buffer`
-# function _pullback(cx::Context, ::typeof(push!), xs::AbstractVector{<:AbstractArray}, x::AbstractArray{T}...) where T
-@adjoint! function push!(xs::AbstractVector{<:AbstractArray}, x::AbstractArray{T}...) where T
-  sz_xs = size.(xs)
-  sz_x = size.(x)
-  push!(xs, x...), Δ -> begin
-    (Δ, map(x -> Ones{T}(x...), sz_x)...)
+# Exceptions:
+@adjoint! function push!(dst::AbstractVector{<:AbstractArray}, xs::AbstractArray...)
+  num_xs = length(xs)
+  push!(dst, xs...), Δ -> begin
+    (Δ[1:end-num_xs], Δ[end-num_xs+1:end]...)
   end
 end
 
-@adjoint! function pop!(xs::AbstractVector{<:AbstractArray{T}}) where T
-  sz_xs = size.(xs)
-  op = pop!(xs)
-  op, Δ -> begin
-    ([Ones{T}(sz...) for sz in sz_xs], )
-  end
+@adjoint! function pop!(src::AbstractVector{<:AbstractArray{T}}) where T
+  zs = fill(nothing, length(src)-1)
+  pop!(src), Δ -> (vcat(zs, [Δ]),)
 end
+
+#=
+
+
+julia> gradient((xs, y) -> sum(abs2, push!(xs, y)[1]), [[1,2], [3,4]], [5,6])
+([[2, 4], nothing, nothing], 2-element Ones{Int64})
+([[2, 4], nothing], nothing)  # correct
+
+julia> gradient((xs, y) -> sum(abs2, push!(xs, y)[2]), [[1,2], [3,4]], [5,6])
+([nothing, [6, 8], nothing], 2-element Ones{Int64})
+([nothing, [6, 8]], nothing)  # correct
+
+julia> gradient((xs, y) -> sum(abs2, push!(xs, y)[3]), [[1,2], [3,4]], [5,6])
+([nothing, nothing, [10, 12]], 2-element Ones{Int64})
+([nothing, nothing], [10, 12])  # correct
+
+(jl_aA0cjy) pkg> st Zygote
+      Status `/private/var/folders/yq/4p2zwd614y59gszh7y9ypyhh0000gn/T/jl_aA0cjy/Project.toml`
+  [e88e6eb3] Zygote v0.6.14
+
+julia> gradient(xs -> sum(abs2, pop!(xs)), [[1,2], [3,4]])
+(Union{Nothing, Vector{Int64}}[nothing, nothing, [6, 8]],)
+
+=#
 
 # General
 

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -84,6 +84,7 @@ end
   n = length(xs)
   valn = Val(n)
   push!(dst, xs...), Δ -> begin
+    Δ === nothing && return nothing
     # (Δ[1:end-num_xs], Δ[end-num_xs+1:end]...)
     (Δ[1:end-n], ntuple(i -> Δ[end-n+i], valn)...)
   end

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -78,28 +78,6 @@ for f in [push!, pop!, pushfirst!, popfirst!]
     _ -> error("Mutating arrays is not supported -- called $($f)(::$(typeof(xs)), _...)")
 end
 
-# Exceptions:
-@adjoint! function push!(dst::AbstractVector, xs...)
-  # num_xs = length(xs)
-  n = length(xs)
-  valn = Val(n)
-  push!(dst, xs...), Δ -> begin
-    Δ === nothing && return nothing
-    # (Δ[1:end-num_xs], Δ[end-num_xs+1:end]...)
-    (Δ[1:end-n], ntuple(i -> Δ[end-n+i], valn)...)
-  end
-end
-
-@adjoint! function pop!(src::AbstractVector)
-  zs = fill(nothing, length(src)-1)
-  pop!(src), Δ -> (vcat(zs, [Δ]),)
-end
-@adjoint! function pop!(src::AbstractVector{<:Number})
-  zs = falses(length(src)-1)
-  pop!(src), Δ -> (vcat(zs, Δ),)
-end
-
-
 # General
 
 @adjoint collect(x::Array) = collect(x), Δ -> (Δ,)

--- a/test/features.jl
+++ b/test/features.jl
@@ -351,10 +351,10 @@ end
 
 @test Zygote.@code_adjoint(f(1)) isa Zygote.Adjoint
 
-# @test_throws ErrorException Zygote.gradient(1) do x
-#   push!([], x)
-#   return x
-# end
+@test_throws ErrorException Zygote.gradient(1) do x
+  push!([], x)
+  return x
+end
 
 @test gradient(1) do x
   stk = []

--- a/test/features.jl
+++ b/test/features.jl
@@ -351,10 +351,10 @@ end
 
 @test Zygote.@code_adjoint(f(1)) isa Zygote.Adjoint
 
-@test_throws ErrorException Zygote.gradient(1) do x
-  push!([], x)
-  return x
-end
+# @test_throws ErrorException Zygote.gradient(1) do x
+#   push!([], x)
+#   return x
+# end
 
 @test gradient(1) do x
   stk = []

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -1365,50 +1365,6 @@ using Zygote: Buffer
     prod(copy(b))
   end == (3,)
 
-  @testset "push!" begin # push! returns the whole new vector
-    # vector of numbers
-    @test gradient((xs, y) -> push!(xs,y)[1], [1,2,3], 4) == ([1, 0, 0], 0)
-    @test gradient((xs, y) -> push!(xs,y)[end], [1,2,3], 4) == ([0, 0, 0], 1)
-
-    @test_skip gradient([1,2,3], 4) do xs, y
-      a = sum(xs)
-      b = sum(push!(xs, y))
-      c = sum(xs)
-      a+b+c
-    end # DimensionMismatch("arrays could not be broadcast to a common size; got a dimension with lengths 3 and 4")
-
-    # push! into vectors of arrays
-    @test gradient((xs, y) -> sum(abs2, push!(xs, y)[1]), [[1,2], [3,4]], [5,6]) == ([[2, 4], nothing], nothing)
-    @test gradient((xs, y) -> sum(abs2, push!(xs, y)[2]), [[1,2], [3,4]], [5,6]) == ([nothing, [6, 8]], nothing)
-    @test gradient((xs, y) -> sum(abs2, push!(xs, y)[3]), [[1,2], [3,4]], [5,6]) == ([nothing, nothing], [10, 12])
-
-    @test_skip gradient([[1,2], [3,4]], [5,6]) do xs, y
-      z = sum(sum(abs2, x) for x in xs)
-      z + sum(sum, push!(xs, y))
-    end  # DimensionMismatch("arrays could not be broadcast to a common size; got a dimension with lengths 2 and 3")
-
-    # multiple arguments
-    @test gradient((xs, y, z) -> 3 * sum(push!(xs, y, z)[1]), [ones(2,2)], ones(2,2), ones(2,2)) == ([fill(3,2,2)], nothing, nothing)
-    @test gradient((xs, y, z) -> 4 * sum(push!(xs, y, z)[2]), [ones(2,2)], ones(2,2), ones(2,2)) == ([nothing], fill(4,2,2), nothing)
-    @test gradient((xs, y, z) -> 5 * sum(push!(xs, y, z)[3]), [ones(2,2)], ones(2,2), ones(2,2)) == ([nothing], nothing, fill(5,2,2))
-
-    # Vector{Any}
-    @test gradient(x -> sum(abs2, only(push!([], x))), [1 2; 3 4]) == ([2 4; 6 8],)
-    # @test_throws ErrorException gradient(x -> sum(abs2, push!([], x)), 1)
-
-  end
-  @testset "pop!" begin # pop! returns only the removed element
-    @test gradient(xs -> pop!(xs)^2, [1,2,3]) == ([0,0,6],)
-    @test_skip gradient([1,2,3], 4) do xs, y
-      z = pop!(xs) + y^2
-      z + sum(abs2, xs)
-    end # DimensionMismatch("arrays could not be broadcast to a common size; got a dimension with lengths 2 and 3")
-
-    # pop! of vectors of arrays
-    @test gradient(xs -> sum(abs2, pop!(xs)), [[1,2], [3,4]]) == ([nothing, [6, 8]],)
-    # @test_throws ErrorException gradient(xs -> pop!(xs), [1,2,3])
-  end
-
 end
 
 @testset "FillArrays" begin

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -1365,11 +1365,25 @@ using Zygote: Buffer
     prod(copy(b))
   end == (3,)
 
-  @testset "limited mutation" begin
-    # push! into vectors of arrays -- it returns the whole new vector
+  @testset "push!" begin # push! returns the whole new vector
+    # vector of numbers
+    @test gradient((xs, y) -> push!(xs,y)[1], [1,2,3], 4) == ([1, 0, 0], 0)
+    @test gradient((xs, y) -> push!(xs,y)[end], [1,2,3], 4) == ([0, 0, 0], 1)
+
+    @test_skip gradient([1,2,3], 4) do xs, y
+      z = sum(xs)
+      z + sum(push!(xs, y))
+    end # DimensionMismatch("arrays could not be broadcast to a common size; got a dimension with lengths 3 and 4")
+
+    # push! into vectors of arrays
     @test gradient((xs, y) -> sum(abs2, push!(xs, y)[1]), [[1,2], [3,4]], [5,6]) == ([[2, 4], nothing], nothing)
     @test gradient((xs, y) -> sum(abs2, push!(xs, y)[2]), [[1,2], [3,4]], [5,6]) == ([nothing, [6, 8]], nothing)
     @test gradient((xs, y) -> sum(abs2, push!(xs, y)[3]), [[1,2], [3,4]], [5,6]) == ([nothing, nothing], [10, 12])
+
+    @test_skip gradient([[1,2], [3,4]], [5,6]) do xs, y
+      z = sum(sum(abs2, x) for x in xs)
+      z + sum(sum, push!(xs, y))
+    end  # DimensionMismatch("arrays could not be broadcast to a common size; got a dimension with lengths 2 and 3")
 
     # multiple arguments
     @test gradient((xs, y, z) -> 3 * sum(push!(xs, y, z)[1]), [ones(2,2)], ones(2,2), ones(2,2)) == ([fill(3,2,2)], nothing, nothing)
@@ -1380,7 +1394,15 @@ using Zygote: Buffer
     @test gradient(x -> sum(abs2, only(push!([], x))), [1 2; 3 4]) == ([2 4; 6 8],)
     @test_throws ErrorException gradient(x -> sum(abs2, push!([], x)), 1)
 
-    # pop! of vectors of arrays -- it returns only the removed element
+  end
+  @testset "pop!" begin # pop! returns only the removed element
+    @test gradient(xs -> pop!(xs)^2, [1,2,3]) == ([0,0,6],)
+    @test_skip gradient([1,2,3], 4) do xs, y
+      z = pop!(xs) + y^2
+      z + sum(abs2, xs)
+    end # DimensionMismatch("arrays could not be broadcast to a common size; got a dimension with lengths 2 and 3")
+
+    # pop! of vectors of arrays
     @test gradient(xs -> sum(abs2, pop!(xs)), [[1,2], [3,4]]) == ([nothing, [6, 8]],)
     @test_throws ErrorException gradient(xs -> pop!(xs), [1,2,3])
   end

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -1372,12 +1372,17 @@ using Zygote: Buffer
     @test gradient((xs, y) -> sum(abs2, push!(xs, y)[3]), [[1,2], [3,4]], [5,6]) == ([nothing, nothing], [10, 12])
 
     # multiple arguments
-    gradient((xs, y, z) -> 3 * sum(push!(xs, y, z)[1]), [ones(2,2)], ones(2,2), ones(2,2)) == ([fill(3,2,2)], nothing, nothing)
-    gradient((xs, y, z) -> 4 * sum(push!(xs, y, z)[2]), [ones(2,2)], ones(2,2), ones(2,2)) == ([nothing], fill(4,2,2), nothing)
-    gradient((xs, y, z) -> 5 * sum(push!(xs, y, z)[3]), [ones(2,2)], ones(2,2), ones(2,2)) == ([nothing], nothing, fill(5,2,2))
+    @test gradient((xs, y, z) -> 3 * sum(push!(xs, y, z)[1]), [ones(2,2)], ones(2,2), ones(2,2)) == ([fill(3,2,2)], nothing, nothing)
+    @test gradient((xs, y, z) -> 4 * sum(push!(xs, y, z)[2]), [ones(2,2)], ones(2,2), ones(2,2)) == ([nothing], fill(4,2,2), nothing)
+    @test gradient((xs, y, z) -> 5 * sum(push!(xs, y, z)[3]), [ones(2,2)], ones(2,2), ones(2,2)) == ([nothing], nothing, fill(5,2,2))
+
+    # Vector{Any}
+    @test gradient(x -> sum(abs2, only(push!([], x))), [1 2; 3 4]) == ([2 4; 6 8],)
+    @test_throws ErrorException gradient(x -> sum(abs2, push!([], x)), 1)
 
     # pop! of vectors of arrays -- it returns only the removed element
     @test gradient(xs -> sum(abs2, pop!(xs)), [[1,2], [3,4]]) == ([nothing, [6, 8]],)
+    @test_throws ErrorException gradient(xs -> pop!(xs), [1,2,3])
   end
 
 end

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -1371,8 +1371,10 @@ using Zygote: Buffer
     @test gradient((xs, y) -> push!(xs,y)[end], [1,2,3], 4) == ([0, 0, 0], 1)
 
     @test_skip gradient([1,2,3], 4) do xs, y
-      z = sum(xs)
-      z + sum(push!(xs, y))
+      a = sum(xs)
+      b = sum(push!(xs, y))
+      c = sum(xs)
+      a+b+c
     end # DimensionMismatch("arrays could not be broadcast to a common size; got a dimension with lengths 3 and 4")
 
     # push! into vectors of arrays
@@ -1392,7 +1394,7 @@ using Zygote: Buffer
 
     # Vector{Any}
     @test gradient(x -> sum(abs2, only(push!([], x))), [1 2; 3 4]) == ([2 4; 6 8],)
-    @test_throws ErrorException gradient(x -> sum(abs2, push!([], x)), 1)
+    # @test_throws ErrorException gradient(x -> sum(abs2, push!([], x)), 1)
 
   end
   @testset "pop!" begin # pop! returns only the removed element
@@ -1404,7 +1406,7 @@ using Zygote: Buffer
 
     # pop! of vectors of arrays
     @test gradient(xs -> sum(abs2, pop!(xs)), [[1,2], [3,4]]) == ([nothing, [6, 8]],)
-    @test_throws ErrorException gradient(xs -> pop!(xs), [1,2,3])
+    # @test_throws ErrorException gradient(xs -> pop!(xs), [1,2,3])
   end
 
 end


### PR DESCRIPTION
This is a replacement for #876, which doesn't seem to get the right gradients at all.

It also looks into fixing #992, where similar gradients appear never to be called with nontrivial input.