### PR TITLE
make sure to throw explicit `CompileError`

### DIFF
--- a/src/compiler/interface2.jl
+++ b/src/compiler/interface2.jl
@@ -24,7 +24,11 @@ end
   T = Tuple{f,args...}
   ignore_sig(T) && return :(f(args...), Pullback{$T}(()))
 
-  g = try _generate_pullback_via_decomposition(T) catch e e end
+  g = try
+    _generate_pullback_via_decomposition(T)
+  catch e
+    rethrow(CompileError(T,e))
+  end
   g === nothing && return :(f(args...), Pullback{$T}((f,)))
   meta, forw, _ = g
   argnames!(meta, Symbol("#self#"), :ctx, :f, :args)
@@ -38,7 +42,7 @@ end
 
 @generated function (j::Pullback{T})(Δ) where T
   ignore_sig(T) && return :nothing
-  g = try 
+  g = try
     _generate_pullback_via_decomposition(T)
   catch e
     rethrow(CompileError(T,e))

--- a/test/features.jl
+++ b/test/features.jl
@@ -397,6 +397,7 @@ function pow_try(x)
 end
 
 @test_broken gradient(pow_try, 1) == (2,)
+@test_throws Zygote.CompileError gradient(pow_try, 1)
 
 function pow_simd(x, n)
   r = 1
@@ -508,7 +509,7 @@ end
   @test gradient(x -> sum(x .+ ones(2,2)), (1,2)) == ((2,2),)
   @test gradient(x -> sum(x .+ ones(2,2)), (1,)) == ((4,),)
   @test gradient(x -> sum(x .+ ones(2,1)), (1,2)) == ((1,1),)
-  
+
   # https://github.com/FluxML/Zygote.jl/issues/975
   gt = gradient((x,p) -> prod(x .^ p), [3,4], (1,2))
   gv = gradient((x,p) -> prod(x .^ p), [3,4], [1,2])


### PR DESCRIPTION
The previous error handling is user-unfriendly IMHO.

> before
```julia
julia> gradient(pow_try, 1)
ERROR: MethodError: no method matching iterate(::ErrorException)
Closest candidates are:
  iterate(::Union{LinRange, StepRangeLen}) at range.jl:806
  iterate(::Union{LinRange, StepRangeLen}, ::Int64) at range.jl:806
  iterate(::T) where T<:Union{Base.KeySet{<:Any, <:Dict}, Base.ValueIterator{<:Dict}} at dict.jl:695
  ...
Stacktrace:
 [1] indexed_iterate(I::ErrorException, i::Int64)
   @ Base ./tuple.jl:91
 [2] #s3061#1245
   @ ~/julia/packages/Zygote/src/compiler/interface2.jl:34 [inlined]
 ...
```

> after
```julia
julia> gradient(pow_try, 1)
ERROR: Compiling Tuple{typeof(pow_try), Int64}: try/catch is not supported.
Stacktrace:
  [1] error(s::String)
    @ Base ./error.jl:33
  [2] instrument(ir::IRTools.Inner.IR)
    @ Zygote ~/julia/packages/Zygote/src/compiler/reverse.jl:121
  ...
```