### PR TITLE
Fix resolver message at initialization

### DIFF
--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -247,7 +247,6 @@ end
 end
 
 @init @require CUDA="052768ef-5323-5732-b1bb-66c8b64840ba" begin
-  using CUDA
   const CuArrayStyle = CUDA.AbstractGPUArrayStyle
 
   if isdefined(CUDA, :cufunc)


### PR DESCRIPTION
Presently: 

```
julia> using Flux
[ Info: Precompiling Flux [587475ba-b771-5e3f-ad9e-33799f191a9c]
┌ Warning: Error requiring `CUDA` from `Zygote`
│   exception =
│    ArgumentError: Package Zygote does not have CUDA in its dependencies:
│    - If you have Zygote checked out for development and have
│      added CUDA as a dependency but haven't updated your primary
│      environment's manifest file, try `Pkg.resolve()`.
│    - Otherwise you may need to report an issue with Zygote
│    Stacktrace:
│      [1] require(into::Module, mod::Symbol)
│        @ Base ./loading.jl:884
│      [2] top-level scope
│        @ ~/Downloads/temp/tryzyg/Zygote.jl/src/lib/broadcast.jl:250
│      [3] eval
│        @ ./boot.jl:360 [inlined]
│      [4] eval
│        @ ~/Downloads/temp/tryzyg/Zygote.jl/src/Zygote.jl:1 [inlined]
```