### PR TITLE
construct Params with empty tuple

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Zygote"
 uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
-version = "0.6.16"
+version = "0.6.17"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/tools/idset.jl
+++ b/src/tools/idset.jl
@@ -3,18 +3,22 @@ struct IdSet{T} <: AbstractSet{T}
   IdSet{T}() where T = new(IdDict{T,Nothing}())
 end
 
-Base.eltype(::IdSet{T}) where T = T
+IdSet(xs) = IdSet{eltype(xs)}(xs)
 
 IdSet() = IdSet{Any}()
+
+function IdSet{T}(xs) where T
+  s = IdSet{T}()
+  for x in xs
+    push!(s, x)
+  end
+  return s
+end
 
 Base.push!(s::IdSet{T}, x::T) where T = (s.dict[x] = nothing; s)
 Base.delete!(s::IdSet{T}, x::T) where T = (delete!(s.dict, x); s)
 Base.in(x, s::IdSet) = haskey(s.dict, x)
-
-IdSet{T}(xs) where T = push!(IdSet{T}(), xs...)
-
-IdSet(xs) = IdSet{eltype(xs)}(xs)
-
+Base.eltype(::IdSet{T}) where T = T
 Base.collect(s::IdSet) = Base.collect(keys(s.dict))
 Base.similar(s::IdSet, T::Type) = IdSet{T}()
 

--- a/src/tools/idset.jl
+++ b/src/tools/idset.jl
@@ -7,7 +7,7 @@ IdSet(xs) = IdSet{eltype(xs)}(xs)
 
 IdSet() = IdSet{Any}()
 
-IdSet{T}(xs) = isempty(xs) ? IdSet{T}() : push!(IdSet{T}(), xs...)
+IdSet{T}(xs) where T = isempty(xs) ? IdSet{T}() : push!(IdSet{T}(), xs...)
 
 Base.push!(s::IdSet{T}, x::T) where T = (s.dict[x] = nothing; s)
 Base.delete!(s::IdSet{T}, x::T) where T = (delete!(s.dict, x); s)

--- a/src/tools/idset.jl
+++ b/src/tools/idset.jl
@@ -7,13 +7,7 @@ IdSet(xs) = IdSet{eltype(xs)}(xs)
 
 IdSet() = IdSet{Any}()
 
-function IdSet{T}(xs) where T
-  s = IdSet{T}()
-  for x in xs
-    push!(s, x)
-  end
-  return s
-end
+IdSet{T}(xs) = isempty(xs) ? IdSet{T}() : push!(IdSet{T}(), xs...)
 
 Base.push!(s::IdSet{T}, x::T) where T = (s.dict[x] = nothing; s)
 Base.delete!(s::IdSet{T}, x::T) where T = (delete!(s.dict, x); s)

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -86,6 +86,7 @@ using Zygote: Grads
   @testset "constructor with empty args" begin
     @test length(Params()) == 0
     @test length(Params(())) == 0
+    @test length(Params([])) == 0
   end
 end
 

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -82,6 +82,11 @@ using Zygote: Grads
     @test ps isa Params
     @test issetequal(ps, Set([y]))
   end
+
+  @testset "constructor with empty args" begin
+    @test length(Params()) == 0
+    @test length(Params(())) == 0
+  end
 end
 
 @testset "Grads" begin


### PR DESCRIPTION
Fixes a bug encountered in Flux's tests https://github.com/FluxML/Flux.jl/pull/1531#discussion_r672035454.
The test has been there since forever, and it creates a `Params` from an empty tuple. I don't know what changed on the Zygote side now leading to the error, but the change in this PR is pretty safe

Fix. #1032 