### PR TITLE
remove artifact warning

### DIFF
--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -194,7 +194,7 @@ z2d(x, ::Any) = x
 z2d(::Nothing, ::Any) = NoTangent()
 z2d(a::AbstractArray{<:Number}, primal::AbstractArray{T}) where T = a
 z2d(a::AbstractArray, primal::AbstractArray{T}) where T = z2d.(a, primal)
-z2d(x::Union{AbstractZero, Tangent}, ::Any) = (difftype_warn(x); return x)
+z2d(x::Union{AbstractZero, Tangent}, ::Any) = return x
 function z2d(t::Tuple, primal::Tuple)
   tp::Tuple = map(z2d, t, primal)
   primal_type = typeof(primal)

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -194,6 +194,9 @@ z2d(x, ::Any) = x
 z2d(::Nothing, ::Any) = NoTangent()
 z2d(a::AbstractArray{<:Number}, primal::AbstractArray{T}) where T = a
 z2d(a::AbstractArray, primal::AbstractArray{T}) where T = z2d.(a, primal)
+# Note: this should never be hit if we are converting things right, but it seems to be
+# happening in the wild for sufficiently weird functions/types.
+# This fixes most (all?) cases, but it would be good to find what we miss.
 z2d(x::Union{AbstractZero, Tangent}, ::Any) = return x
 function z2d(t::Tuple, primal::Tuple)
   tp::Tuple = map(z2d, t, primal)


### PR DESCRIPTION
I’ve copied most of the `zygote2differential` code from an old PR where I tried to make Zygote use ChainRules types internally. It shouldn’t hit that ever anyway, because `z2d` transforms zygote differential types (like `nothing` or `namedtuple`s) into the ChainRules differential types (e.g. `ZeroTangent()` and `Tangent{Primal}`.