### PR TITLE
Remove rules for Array, vect, circshift, fill, reverse -- ChainRules 1.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 [compat]
 AbstractFFTs = "0.5, 1.0"
 ChainRules = "1.5"
-ChainRulesCore = "1.0.1"
+ChainRulesCore = "1.1"
 ChainRulesTestUtils = "1"
 DiffRules = "1.0"
 FillArrays = "0.8, 0.9, 0.10, 0.11, 0.12"

--- a/Project.toml
+++ b/Project.toml
@@ -23,7 +23,7 @@ ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 
 [compat]
 AbstractFFTs = "0.5, 1.0"
-ChainRules = "1"
+ChainRules = "1.5"
 ChainRulesCore = "1.0.1"
 ChainRulesTestUtils = "1"
 DiffRules = "1.0"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Zygote"
 uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
-version = "0.6.18"
+version = "0.6.19"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -3,14 +3,10 @@ using FillArrays: AbstractFill, getindex_value
 using Base.Broadcast: broadcasted, broadcast_shape
 using Distributed: pmap, AbstractWorkerPool
 
-@adjoint (::Type{T})(::UndefInitializer, args...) where T<:Array = T(undef, args...), Δ -> nothing
-
 @adjoint Array(xs::AbstractArray) = Array(xs), ȳ -> (ȳ,)
 @adjoint Array(xs::Array) = Array(xs), ȳ -> (ȳ,)
 
 @nograd ones, zeros, Base.OneTo, Colon(), one, zero, sizehint!, count
-
-@adjoint Base.vect(xs...) = Base.vect(xs...), Δ -> (Δ...,)
 
 @adjoint copy(x::AbstractArray) = copy(x), ȳ -> (ȳ,)
 
@@ -18,7 +14,6 @@ using Distributed: pmap, AbstractWorkerPool
 @adjoint collect(x::AbstractArray) = collect(x), dy -> (dy,)
 
 # Array Constructors
-@adjoint (::Type{T})(x::T) where T<:Array = T(x), ȳ -> (ȳ,)
 @adjoint function (::Type{T})(x::Number, sz) where {T <: Fill}
     back(Δ::AbstractArray) = (sum(Δ), nothing)
     back(Δ::NamedTuple) = (Δ.value, nothing)

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -101,17 +101,6 @@ end
 
 @adjoint collect(x::Array) = collect(x), Δ -> (Δ,)
 
-@adjoint fill(x::Real, dims...) = fill(x, dims...), Δ->(sum(Δ), map(_->nothing, dims)...)
-
-@adjoint function circshift(A, shifts)
-  circshift(A, shifts), Δ -> (circshift(Δ, map(-, shifts)), nothing)
-end
-
-@adjoint function reverse(x::AbstractArray, args...; kwargs...)
-  _reverse(t) = reverse(t, args...; kwargs...)
-  _reverse(x), Δ->(_reverse(Δ), map(_->nothing, args)...)
-end
-
 @adjoint permutedims(xs) = permutedims(xs), Δ -> (permutedims(Δ),)
 
 @adjoint permutedims(xs::AbstractVector) = permutedims(xs), Δ -> (vec(permutedims(Δ)),)


### PR DESCRIPTION
New rules added in CR-1.5 should make the rules removed here redundant. I've left the corresponding tests to ensure nothing breaks.