### PR TITLE
Support kwargs in `rrule_via_ad`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Zygote"
 uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
-version = "0.6.19"
+version = "0.6.20"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -175,8 +175,9 @@ As per [`chain_rrule`](@ref) but with support for kwargs.
 end
 
 
-function ChainRulesCore.rrule_via_ad(config::ZygoteRuleConfig, f, args...)
-    y, pb = _pullback(config.context, f, args...)
+function ChainRulesCore.rrule_via_ad(config::ZygoteRuleConfig, f, args...; kwargs...)
+    kwf(args...) = f(args...; kwargs...)
+    y, pb = _pullback(config.context, kwf, args...)
     ad_pullback(Δ) = zygote2differential(pb(wrap_chainrules_output(Δ)), (f, args...))
     return y, ad_pullback
 end

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -180,7 +180,7 @@ function ChainRulesCore.rrule_via_ad(config::ZygoteRuleConfig, f_args...; kwargs
     y, pb = if !isempty(kwargs)
         kwf() = first(f_args)(Base.tail(f_args)...; kwargs...)
         _y, _pb = _pullback(config.context, kwf)
-        _y, Δ -> only(_pb(Δ)).f_args
+        _y, Δ -> first(_pb(Δ)).f_args  # `first` should be `only`
     else
         _pullback(config.context, f_args...)
     end

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -185,9 +185,7 @@ function ChainRulesCore.rrule_via_ad(config::ZygoteRuleConfig, f_args...; kwargs
         _pullback(config.context, f_args...)
     end
 
-    function ad_pullback(Δ)
-        return zygote2differential(pb(wrap_chainrules_output(Δ)), f_args)
-    end
+    ad_pullback(Δ) = zygote2differential(pb(wrap_chainrules_output(Δ)), f_args)
     return y, ad_pullback
 end
 

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -174,22 +174,16 @@ As per [`chain_rrule`](@ref) but with support for kwargs.
   return y, kw_zpullback
 end
 
-function ChainRulesCore.rrule_via_ad(config::ZygoteRuleConfig, f, args...; kwargs...)
-    kwf(args...) = f(args...; kwargs...)
-    y, pb = _pullback(config.context, kwf, args...)
+
+function ChainRulesCore.rrule_via_ad(config::ZygoteRuleConfig, f_args...; kwargs...)
+    kwf() = first(f_args)(Base.tail(f_args)...; kwargs...)
+    y, pb = _pullback(config.context, kwf)
     function ad_pullback(Δ)
-        Δfargs = _unwrap_kwf_pullback(pb(wrap_chainrules_output(Δ)))
-        return zygote2differential(Δfargs, (f, args...))
+        pbres = only(pb(wrap_chainrules_output(Δ))).f_args
+        return zygote2differential(pbres, f_args)
     end
     return y, ad_pullback
 end
-
-# `kwf` is a closure, and its tangent is a NamedTuple for each of the closed-over objects.
-# If `f` is also a closure, we extract that field and ignore the kwargs.
-# If `f` is not a closure, all the NamedTuple fields are `nothing`s and Zygote collapses
-# them into a single `nothing`.
-_unwrap_kwf_pullback(Δ::Tuple{Nothing, Vararg}) = Δ
-_unwrap_kwf_pullback(Δ::Tuple{NamedTuple, Vararg}) = (first(Δ).f, Base.tail(Δ)...)
 
 """
     zygote2differential(x)

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -174,16 +174,22 @@ As per [`chain_rrule`](@ref) but with support for kwargs.
   return y, kw_zpullback
 end
 
-
-function ChainRulesCore.rrule_via_ad(config::ZygoteRuleConfig, f_args...; kwargs...)
-    kwf() = first(f_args)(Base.tail(f_args)...; kwargs...)
-    y, pb = _pullback(config.context, kwf)
+function ChainRulesCore.rrule_via_ad(config::ZygoteRuleConfig, f, args...; kwargs...)
+    kwf(args...) = f(args...; kwargs...)
+    y, pb = _pullback(config.context, kwf, args...)
     function ad_pullback(Δ)
-        pbres = only(pb(wrap_chainrules_output(Δ))).f_args
-        return zygote2differential(pbres, f_args)
+        Δfargs = _unwrap_kwf_pullback(pb(wrap_chainrules_output(Δ)))
+        return zygote2differential(Δfargs, (f, args...))
     end
     return y, ad_pullback
 end
+
+# `kwf` is a closure, and its tangent is a NamedTuple for each of the closed-over objects.
+# If `f` is also a closure, we extract that field and ignore the kwargs.
+# If `f` is not a closure, all the NamedTuple fields are `nothing`s and Zygote collapses
+# them into a single `nothing`.
+_unwrap_kwf_pullback(Δ::Tuple{Nothing, Vararg}) = Δ
+_unwrap_kwf_pullback(Δ::Tuple{NamedTuple, Vararg}) = (first(Δ).f, Base.tail(Δ)...)
 
 """
     zygote2differential(x)

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -275,6 +275,13 @@ end
         test_rrule(ZygoteRuleConfig(), getindex, rand(5), 3; rrule_f=rrule_via_ad)
     end
 
+    @testset "kwargs" begin
+        test_rrule(
+            ZygoteRuleConfig(), sum, [1.0 2; 3 4];
+            rrule_f=rrule_via_ad, check_inferred=false, fkwargs=(;dims=1)
+        )
+    end
+
     @testset "struct" begin
         struct Foo
             x


### PR DESCRIPTION
Adds support for kwargs in `rrule_via_ad`. cc @niklasschmitz @oxinabox 