### PR TITLE
Support functions that splat namedtuples as keyword arguments

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Zygote"
 uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
-version = "0.6.20"
+version = "0.6.21"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/lib/base.jl
+++ b/src/lib/base.jl
@@ -118,17 +118,18 @@ end
 
 # named tuple
 @adjoint function pairs(t::NamedTuple{N}) where N
-
-  pairs_namedtuple_pullback(dx::NamedTuple) = (dx.data,)
   
+  pairs_namedtuple_pullback(dx::NamedTuple) = (dx.data,)
+
   function pairs_namedtuple_pullback(Δ::Dict)
     t0 = map(zero, t)
     for (idx, v) in Δ
-      t0 = NamedTuple{N}(Base.setindex((t0...,), v, idx))
+      ii = idx isa Integer ? idx : findfirst(==(idx), keys(t))
+      t0 = NamedTuple{N}(Base.setindex((t0...,), v, ii))
     end
     return (t0,)
   end
-  
+
   return pairs(t), pairs_namedtuple_pullback
 end
 

--- a/test/features.jl
+++ b/test/features.jl
@@ -463,6 +463,15 @@ end
   @test gradient(d -> Dict(:x => d[:x])[:x], d) == (Dict(:x => 1),)
 end
 
+@testset "kwarg splatting, pass in object" begin
+  g(; kwargs...) = kwargs[:x] * kwargs[:z]
+  h(somedata) = g(; somedata...)
+  @test gradient(h, (; x=3.0, y=4.0, z=2.3)) == ((x = 2.3, y = 0.0, z = 3.0),)
+
+  # Currently broken because we fallback to ADing the `merge(::NamedTuple, itr)` which uses `push!`.
+  @test_broken gradient(h, Dict(:x=>3.0, :y=>4.0, :z=>2.3)) isa Any
+end
+
 # https://github.com/JuliaDiff/ChainRules.jl/issues/257
 @testset "Keyword Argument Passing" begin
   struct Type1{VJP}

--- a/test/features.jl
+++ b/test/features.jl
@@ -467,9 +467,7 @@ end
   g(; kwargs...) = kwargs[:x] * kwargs[:z]
   h(somedata) = g(; somedata...)
   @test gradient(h, (; x=3.0, y=4.0, z=2.3)) == ((x = 2.3, y = 0.0, z = 3.0),)
-
-  # Currently broken because we fallback to ADing the `merge(::NamedTuple, itr)` which uses `push!`.
-  @test_broken gradient(h, Dict(:x=>3.0, :y=>4.0, :z=>2.3)) isa Any
+  @test gradient(h, Dict(:x=>3.0, :y=>4.0, :z=>2.3)) == ((y = 0.0, z = 3.0, x = 2.3),)
 end
 
 # https://github.com/JuliaDiff/ChainRules.jl/issues/257


### PR DESCRIPTION
@lsindoni ran into this.
This problem occurs for Dict and NamedTuples with a error about the methods of `Base.setindex`.

The `Dict` in the `pairs` pullback in this case ends up containing `Symbol`s not `Integer`s.
So we branch to support that.
(unfortunately it is a `Dict{Any,Any}` so we can't branch earlier, and so it is dynamic dispatch).

The chain to the rule for `pairs` is enough to make NamedTuple's work,
If we also want to support Dicts, we need the rule for `merge` as well

I am surprised noone has run into this before.