### PR TITLE
Add short-circuit to `rrule_via_ad`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Zygote"
 uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
-version = "0.6.20"
+version = "0.6.21"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -175,6 +175,10 @@ As per [`chain_rrule`](@ref) but with support for kwargs.
 end
 
 function ChainRulesCore.rrule_via_ad(config::ZygoteRuleConfig, f_args...; kwargs...)
+    # first check whether there is an `rrule` which handles this directly
+    direcct = rrule(config, f_args...; kwargs...)
+    direcct === nothing || return direcct
+
     # create a closure to work around _pullback not accepting kwargs
     # but avoid creating a closure unnecessarily (pullbacks of closures do not infer)
     y, pb = if !isempty(kwargs)

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -334,8 +334,6 @@ end
         # but x -> cbrt(x) has no rule, so will be done by Zygote
         test_rrule(ZygoteRuleConfig(), sum, x -> cbrt(x), randn(5))
         test_rrule(ZygoteRuleConfig(), sum, x -> cbrt(x), randn(5); rrule_f=rrule_via_ad)
-
-        test_rrule(ZygoteRuleConfig(), identity∘sum, x -> cbrt(x), randn(5); rrule_f=rrule_via_ad, check_inferred=false)
     end
 end
 

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -325,6 +325,18 @@ end
         test_rrule(ZygoteRuleConfig(), +, rand(3), rand(3); rrule_f=rrule_via_ad)
         test_rrule(ZygoteRuleConfig(), *, rand(1, 3), rand(3); rrule_f=rrule_via_ad)
     end
+
+    @testset "rules which call rrule_via_ad" begin
+        # since cbrt has a rule, this will test the shortcut:
+        test_rrule(ZygoteRuleConfig(), sum, cbrt, randn(5))
+        test_rrule(ZygoteRuleConfig(), sum, cbrt, randn(5); rrule_f=rrule_via_ad)
+
+        # but x -> cbrt(x) has no rule, so will be done by Zygote
+        test_rrule(ZygoteRuleConfig(), sum, x -> cbrt(x), randn(5))
+        test_rrule(ZygoteRuleConfig(), sum, x -> cbrt(x), randn(5); rrule_f=rrule_via_ad)
+
+        test_rrule(ZygoteRuleConfig(), identity∘sum, x -> cbrt(x), randn(5); rrule_f=rrule_via_ad, check_inferred=false)
+    end
 end
 
 @testset "FastMath support" begin


### PR DESCRIPTION
This makes some cases I tested much quicker, and none much slower. 

What would be a great test of whether this adds overhead sometimes? 