### PR TITLE
added a dispatch for tuples to prevent LoadError

### DIFF
--- a/src/lib/base.jl
+++ b/src/lib/base.jl
@@ -122,10 +122,7 @@ end
   pairs_namedtuple_pullback(dx::NamedTuple) = (dx.data,)
 
   function pairs_namedtuple_pullback(dx::Tuple) 
-    t0 = map(zero, t)
-    for (i, v) in enumerate(dx)
-      t0 = NamedTuple{N}(Base.setindex((t0...,), v, i))
-    end
+    t0 = isempty(dx) ? () : NamedTuple{N}(values(dx))
     return (t0,)
   end
 

--- a/src/lib/base.jl
+++ b/src/lib/base.jl
@@ -120,7 +120,8 @@ end
 @adjoint function pairs(t::NamedTuple{N}) where N
   
   pairs_namedtuple_pullback(dx::NamedTuple) = (dx.data,)
-  pairs_namedtuple_pullback(dx::Tuple) = (dx.data,)
+  
+  pairs_namedtuple_pullback(dx::Tuple) = isempty(dx) ? (dx,) : (dx[1],)
 
   function pairs_namedtuple_pullback(Δ::Dict)
     t0 = map(zero, t)

--- a/src/lib/base.jl
+++ b/src/lib/base.jl
@@ -121,11 +121,7 @@ end
   
   pairs_namedtuple_pullback(dx::NamedTuple) = (dx.data,)
 
-  function pairs_namedtuple_pullback(dx::Tuple) 
-    t0 = isempty(dx) ? () : NamedTuple{N}(values(dx))
-    return (t0,)
-  end
-
+pairs_namedtuple_pullback(dx::Tuple{}) = (NamedTuple(),)
   function pairs_namedtuple_pullback(Δ::Dict)
     t0 = map(zero, t)
     for (idx, v) in Δ

--- a/src/lib/base.jl
+++ b/src/lib/base.jl
@@ -121,7 +121,8 @@ end
   
   pairs_namedtuple_pullback(dx::NamedTuple) = (dx.data,)
 
-pairs_namedtuple_pullback(dx::Tuple{}) = (NamedTuple(),)
+  pairs_namedtuple_pullback(dx::Tuple{}) = (NamedTuple(),)
+  
   function pairs_namedtuple_pullback(Δ::Dict)
     t0 = map(zero, t)
     for (idx, v) in Δ

--- a/src/lib/base.jl
+++ b/src/lib/base.jl
@@ -120,6 +120,7 @@ end
 @adjoint function pairs(t::NamedTuple{N}) where N
   
   pairs_namedtuple_pullback(dx::NamedTuple) = (dx.data,)
+  pairs_namedtuple_pullback(dx::Tuple) = (dx.data,)
 
   function pairs_namedtuple_pullback(Δ::Dict)
     t0 = map(zero, t)

--- a/src/lib/base.jl
+++ b/src/lib/base.jl
@@ -120,8 +120,14 @@ end
 @adjoint function pairs(t::NamedTuple{N}) where N
   
   pairs_namedtuple_pullback(dx::NamedTuple) = (dx.data,)
-  
-  pairs_namedtuple_pullback(dx::Tuple) = isempty(dx) ? (dx,) : (dx[1],)
+
+  function pairs_namedtuple_pullback(dx::Tuple) 
+    t0 = map(zero, t)
+    for (i, v) in enumerate(dx)
+      t0 = NamedTuple{N}(Base.setindex((t0...,), v, i))
+    end
+    return (t0,)
+  end
 
   function pairs_namedtuple_pullback(Δ::Dict)
     t0 = map(zero, t)


### PR DESCRIPTION
Part of the discussion can be found here: 
https://github.com/SciML/Quadrature.jl/pull/74

Basically, Zygote could not handle empty Tuples and was erroring whenever we ran Zygote.gradient() on Quadrature.jl with infinite bounds (MWE here https://github.com/SciML/Quadrature.jl/pull/74#issuecomment-927304089)

This fixes the error by adding a dispatch for tuples so it can recognize empty tuples.


MWE with dependency

```julia
using Quadrature, Cuba, Cubature, Zygote
using Test

f(x , p) = sum((p ./ (x.^2 .+ 1)))
p = [1.0]
prob = QuadratureProblem(f, [0] , [Inf],p)
sol = solve(prob,HCubatureJL(),reltol=1e-3,abstol=1e-3)

function testf(p)
    prob = QuadratureProblem(f, [0] , [Inf], p)
    solve(prob,HCubatureJL(),reltol=1e-3,abstol=1e-3)[1]
end
testf(p)
@test  (pi/2 - testf(p))^2  < 1e-6

julia> dlb1,dub1,dp1 = Zygote.gradient(testf,p)
ERROR: MethodError: no method matching (::Zygote.var"#pairs_namedtuple#351"{(), NamedTuple{(), Tuple{}}})(::Tuple{})
Closest candidates are:
  (::Zygote.var"#pairs_namedtuple#351"{N, t} where t)(::NamedTuple) where N at /Users/kirillzubov/.julia/packages/Zygote/TaBlo/src/lib/base.jl:121
  (::Zygote.var"#pairs_namedtuple#351"{N, t} where t)(::Dict) where N at /Users/kirillzubov/.julia/packages/Zygote/TaBlo/src/lib/base.jl:122
Stacktrace:
  [1] (::Zygote.var"#2120#back#352"{Zygote.var"#pairs_namedtuple#351"{(), NamedTuple{(), Tuple{}}}})(Δ::Tuple{})
    @ Zygote ~/.julia/packages/ZygoteRules/OjfTt/src/adjoint.jl:59
  [2] Pullback
    @ ~/.julia/packages/SciMLBase/UIp7W/src/problems/basic_problems.jl:87 [inlined]
  [3] (::typeof(∂(QuadratureProblem{false, P, F, L, U, K} where {P, F, L, U, K})))(Δ::NamedTuple{(:f, :lb, :ub, :nout, :p, :batch, :kwargs), Tuple{Nothing, Nothing, Nothing, Nothing, Vector{Float64}, Nothing, Tuple{}}})
    @ Zygote ~/.julia/packages/Zygote/TaBlo/src/compiler/interface2.jl:0
  [4] (::Zygote.var"#209#210"{Tuple{Tuple{Nothing, Nothing, Nothing}, Tuple{Nothing}}, typeof(∂(QuadratureProblem{false, P, F, L, U, K} where {P, F, L, U, K}))})(Δ::NamedTuple{(:f, :lb, :ub, :nout, :p, :batch, :kwargs), Tuple{Nothing, Nothing, Nothing, Nothing, Vector{Float64}, Nothing, Tuple{}}})
    @ Zygote ~/.julia/packages/Zygote/TaBlo/src/lib/lib.jl:203
  [5] (::Zygote.var"#1778#back#211"{Zygote.var"#209#210"{Tuple{Tuple{Nothing, Nothing, Nothing}, Tuple{Nothing}}, typeof(∂(QuadratureProblem{false, P, F, L, U, K} where {P, F, L, U, K}))}})(Δ::NamedTuple{(:f, :lb, :ub, :nout, :p, :batch, :kwargs), Tuple{Nothing, Nothing, Nothing, Nothing, Vector{Float64}, Nothing, Tuple{}}})
    @ Zygote ~/.julia/packages/ZygoteRules/OjfTt/src/adjoint.jl:59
  [6] Pullback
    @ ~/.julia/packages/SciMLBase/UIp7W/src/problems/basic_problems.jl:92 [inlined]
  [7] (::typeof(∂(#QuadratureProblem#199)))(Δ::NamedTuple{(:f, :lb, :ub, :nout, :p, :batch, :kwargs), Tuple{Nothing, Nothing, Nothing, Nothing, Vector{Float64}, Nothing, Tuple{}}})
    @ Zygote ~/.julia/packages/Zygote/TaBlo/src/compiler/interface2.jl:0
  [8] (::Zygote.var"#209#210"{Tuple{NTuple{5, Nothing}, Tuple{Nothing}}, typeof(∂(#QuadratureProblem#199))})(Δ::NamedTuple{(:f, :lb, :ub, :nout, :p, :batch, :kwargs), Tuple{Nothing, Nothing, Nothing, Nothing, Vector{Float64}, Nothing, Tuple{}}})
    @ Zygote ~/.julia/packages/Zygote/TaBlo/src/lib/lib.jl:203
  [9] #1778#back
    @ ~/.julia/packages/ZygoteRules/OjfTt/src/adjoint.jl:59 [inlined]
 [10] Pullback
    @ ~/.julia/packages/SciMLBase/UIp7W/src/problems/basic_problems.jl:92 [inlined]
 [11] (::typeof(∂(QuadratureProblem)))(Δ::NamedTuple{(:f, :lb, :ub, :nout, :p, :batch, :kwargs), Tuple{Nothing, Nothing, Nothing, Nothing, Vector{Float64}, Nothing, Tuple{}}})
    @ Zygote ~/.julia/packages/Zygote/TaBlo/src/compiler/interface2.jl:0
 [12] Pullback
    @ ./none:2 [inlined]
 [13] (::typeof(∂(testf)))(Δ::Float64)
    @ Zygote ~/.julia/packages/Zygote/TaBlo/src/compiler/interface2.jl:0
 [14] (::Zygote.var"#46#47"{typeof(∂(testf))})(Δ::Float64)
    @ Zygote ~/.julia/packages/Zygote/TaBlo/src/compiler/interface.jl:41
 [15] gradient(f::Function, args::Vector{Float64})
    @ Zygote ~/.julia/packages/Zygote/TaBlo/src/compiler/interface.jl:76
 [16] top-level scope
    @ none:1
```