### PR TITLE
Make `OneElement` constructor safer

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -50,7 +50,7 @@ struct OneElement{T,N,I,A} <: AbstractArray{T,N}
   val::T
   ind::I
   axes::A
-  OneElement(val::T, ind::I, axes::A) where {T<:Number, I<:NTuple{N,Int}, A} where {N} = new{T,N,I,A}(val, ind, axes)
+  OneElement(val::T, ind::I, axes::A) where {T<:Number, I<:NTuple{N,Int}, A<:NTuple{N,AbstractUnitRange}} where {N} = new{T,N,I,A}(val, ind, axes)
 end
 Base.size(A::OneElement) = map(length, A.axes)
 Base.axes(A::OneElement) = A.axes


### PR DESCRIPTION
This makes the construction of OneElement arrays with wrong-length `axes` more difficult, by restricting the types accepted by the constructor. Should not change any intentional functionality.

Examples of this came up in #1080, but constructed by hand there, not by `∇getindex`. There is some chance that https://github.com/SciML/DiffEqFlux.jl/issues/632 had other examples, which I have not verified, but will (eventually) try with this branch.