### PR TITLE
Add `project` utility

### DIFF
--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -42,7 +42,7 @@ function pullback(f, args...)
 end
 
 sensitivity(y::Number) = one(y)
-sensitivity(y::Complex) = error("Output is complex, so the gradient is not defined.")
+# sensitivity(y::Complex) = error("Output is complex, so the gradient is not defined.")
 sensitivity(y::AbstractArray) = error("Output is an array, so the gradient is not defined. Perhaps you wanted jacobian.")
 sensitivity(y) = error("Output should be scalar; gradients are not defined for output $(repr(y))")
 

--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -57,7 +57,7 @@ the derivative (for scalar `x`) or the gradient.
 See also [`withgradient`](@ref) to keep the value `f(args...)`,
 and [`pullback`](@ref) for value and back-propagator.
 
-```jldoctest; setup=:(using Zygote)
+```jldoctest; setup = :(using Zygote)
 julia> gradient(*, 2.0, 3.0, 5.0)
 (15.0, 10.0, 6.0)
 
@@ -74,14 +74,9 @@ julia> gradient([7, 11], 0, 1) do x, y, d
 function gradient(f, args...)
   y, back = pullback(f, args...)
   grad = back(sensitivity(y))
-  isnothing(grad) ? nothing : map(_project, args, grad)
 end
 
-# Base.adjoint(f::Function) = x -> gradient(f, x)[1]  # piracy!
-Base.adjoint(f::Function) = x -> begin  # still piracy! avoids projection for legacy reasons
-  y, back = pullback(f, x)
-  back(sensitivity(y))[1]
-end
+Base.adjoint(f::Function) = x -> gradient(f, x)[1]  # piracy!
 
 """
     withgradient(f, args...)
@@ -101,8 +96,7 @@ true
 function withgradient(f, args...)
   y, back = pullback(f, args...)
   grad = back(sensitivity(y))
-  results = isnothing(grad) ? map(_ -> nothing, args) : map(_project, args, grad)
-  (val=y, grad=results)
+  (val = y, grad = grad)
 end
 
 # Param-style wrappers

--- a/src/compiler/reverse.jl
+++ b/src/compiler/reverse.jl
@@ -248,7 +248,7 @@ branchfor(ir, (from,to)) =
   get(filter(br -> br.block == to, branches(block(ir, from))), 1, nothing)
 
 xaccum(ir) = nothing
-xaccum(ir, x) = x
+# xaccum(ir, x) = x
 xaccum(ir, xs...) = push!(ir, xcall(Zygote, :accum, xs...))
 
 function adjoint(pr::Primal)

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -38,7 +38,7 @@ end
     dxv = view(dx, inds...)
     dxv .= accum.(dxv, _droplike(dy, dxv))
   end
-  return (_project(x, dx), map(_->nothing, inds)...)
+  return (dx, map(_->nothing, inds)...)
 end
 
 """

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -38,7 +38,7 @@ end
     dxv = view(dx, inds...)
     dxv .= accum.(dxv, _droplike(dy, dxv))
   end
-  return (dx, map(_->nothing, inds)...)
+  return (dx, map(_ -> nothing, inds)...)
 end
 
 """

--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -45,19 +45,20 @@ function Base.reducedim_init(::typeof(identity), ::typeof(accum), A::AbstractArr
   Base.reducedim_initarray(A, region, nothing, Union{Nothing,eltype(A)})
 end
 
+trim(x, Δ) = reshape(Δ, ntuple(i -> size(Δ, i), Val(ndims(x))))
+trim(x::Tuple, Δ) = NTuple{length(x)}(Δ)
+
 function unbroadcast(x::AbstractArray, x̄)
   N = ndims(x̄)
-  if length(x) == length(x̄)
-    _project(x, x̄)  # ProjectTo handles reshape, offsets, structured matrices, row vectors
-  else
-    dims = ntuple(d -> size(x, d) == 1 ? d : ndims(x̄)+1, ndims(x̄))
-    _project(x, accum_sum(x̄; dims = dims))
-  end
+  size(x) == size(x̄) ? x̄ :
+  length(x) == length(x̄) ? trim(x, x̄) :
+    trim(x, accum_sum(x̄, dims = ntuple(i -> size(x, i) == 1 ? i : ndims(x̄)+1, Val(ndims(x̄)))))
 end
+
 unbroadcast(x::Number, x̄) = accum_sum(x̄)
 unbroadcast(x::Tuple{<:Any}, x̄) = (accum_sum(x̄),)
-unbroadcast(x::Base.RefValue, x̄) = (x=accum_sum(x̄),)
-unbroadcast(x::Tuple, x̄) =  NTuple{length(x)}(length(x) == length(x̄) ? x̄ : accum_sum(x̄; dims=2:ndims(x̄))) # case length(x) > 1
+unbroadcast(x::Base.RefValue, x̄) = (x = accum_sum(x̄),)
+unbroadcast(x::Tuple, x̄) = trim(x, length(x) == length(x̄) ? x̄ : accum_sum(x̄; dims = 2:ndims(x̄))) # case length(x) > 1
 
 unbroadcast(x::AbstractArray, x̄::Nothing) = nothing
 

--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -13,7 +13,7 @@ end
 
 accum() = nothing
 accum(x) = x
-accum(x::AbstractArray{<:Complex}) = real(x)
+# accum(x::AbstractArray{<:Complex}) = real(x)
 
 accum(x, y) =
   x === nothing ? y :
@@ -28,9 +28,9 @@ function accum(x::T, ys::AbstractArray...) where {T <: AbstractArray}
   accum.(convert.(T, (x, ys...))...)
 end
 
-function accum(x::AbstractArray, ys::AbstractArray{<:Complex}...)
-  accum.(real(x), real.(ys)...)
-end
+# function accum(x::AbstractArray, ys::AbstractArray{<:Complex}...)
+#   accum.(real(x), real.(ys)...)
+# end
 @generated function accum(x::NamedTuple, y::NamedTuple)
   # assumes that y has no keys apart from those also in x
   fieldnames(y) ⊆ fieldnames(x) || throw(ArgumentError("$y keys must be a subset of $x keys"))

--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -13,6 +13,7 @@ end
 
 accum() = nothing
 accum(x) = x
+accum(x::AbstractArray{<:Complex}) = real(x)
 
 accum(x, y) =
   x === nothing ? y :
@@ -22,8 +23,14 @@ accum(x, y) =
 accum(x, y, zs...) = accum(accum(x, y), zs...)
 
 accum(x::Tuple, ys::Tuple...) = accum.(x, ys...)
-accum(x::AbstractArray, ys::AbstractArray...) = accum.(x, ys...)
+# use promotion rules for T, S...; x needs to be the widest type
+function accum(x::T, ys::AbstractArray...) where {T <: AbstractArray}
+  accum.(convert.(T, (x, ys...))...)
+end
 
+function accum(x::AbstractArray, ys::AbstractArray{<:Complex}...)
+  accum.(real(x), real.(ys)...)
+end
 @generated function accum(x::NamedTuple, y::NamedTuple)
   # assumes that y has no keys apart from those also in x
   fieldnames(y) ⊆ fieldnames(x) || throw(ArgumentError("$y keys must be a subset of $x keys"))


### PR DESCRIPTION
This PR revives working with RecursiveArrayTools (ref https://github.com/SciML/DiffEqSensitivity.jl/pull/493), and as discussed with @ChrisRackauckas , AD systems shouldn't be projecting internally, so we can reinstate RAT/ DiffEqSensitivity.

It is not known ahead of time where in the call stack a custom adjoint may be used or a custom type, we should allow for custom adjoints to manipulate code as they see fit.

Another change is that we allow complex gradients. These work most of the time, and the times they don't can be considered for bug fixes. I have a some methods which do technically do the same thing as `_project` in the accumulation stage rather than adding copies with every invocation of an adjoint.