### PR TITLE
getproperty performance workaround

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -15,7 +15,9 @@ makedocs(
         "Complex Differentiation" => "complex.md",
         "Profiling" => "profiling.md",
         "Internals" => "internals.md",
-        "Glossary" => "glossary.md"],
+        "Glossary" => "glossary.md",
+        "Performance Tips" => "performance_tips.md",
+  ],
   format = Documenter.HTML(prettyurls = haskey(ENV, "CI"), analytics = "UA-36890222-9"))
 
 deploydocs(

--- a/docs/src/performance_tips.md
+++ b/docs/src/performance_tips.md
@@ -1,0 +1,22 @@
+# Performance Tips
+
+## getproperty
+
+Zygote has known performance problems with `getproperty`.
+In particular, if you try to differentiate something like
+```julia
+struct Foo
+    x::Float64
+end
+
+Zygote.gradient(x -> x.x, Foo(5.0))
+```
+you will wind that it is not type-stable, despite the function being differentiated being
+type-stable.
+
+See the docstring for the function `pullback_for_default_literal_getproperty` in
+[ZygoteRules.jl](https://github.com/FluxML/ZygoteRules.jl) for instructions on how to
+work around this problem.
+
+[This PR](https://github.com/FluxML/Zygote.jl/pull/909) may make this workaround redundant
+at some point.

--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -237,16 +237,22 @@ end
   unwrap(val), back
 end
 
+function pullback_for_default_literal_getproperty(cx::AContext, x, ::Val{f}) where {f}
+  return _pullback(cx, literal_getfield, x, Val{f}())
+end
+
 _pullback(cx::AContext, ::typeof(getfield), x, field_name::Symbol) =
   _pullback(cx, literal_getfield, x, Val(field_name))
 
-function _pullback(cx::AContext, ::typeof(literal_getproperty), x::NamedTuple,
-                   ::Val{property_name}) where {property_name}
-  return _pullback(cx, literal_getfield, x, Val(property_name))
+function _pullback(
+  cx::AContext, ::typeof(literal_getproperty), x::NamedTuple, ::Val{property_name}
+) where {property_name}
+  return pullback_for_default_literal_getproperty(cx, x, Val{property_name}())
 end
+
 function _pullback(cx::AContext, ::typeof(literal_getindex), x::NamedTuple,
                    ::Val{key}) where {key}
-  return _pullback(cx, literal_getfield, x, Val(key))
+  return pullback_for_default_literal_getproperty(cx, x, Val{key}())
 end
 
 function _pullback(cx::AContext, ::typeof(literal_getproperty), x::Tuple,

--- a/test/getproperty_performance_workaround.jl
+++ b/test/getproperty_performance_workaround.jl
@@ -1,0 +1,21 @@
+struct YourType
+    x::Float64
+end
+
+# Copy + paste suggestion from ZygoteRules docstring.
+using ZygoteRules
+using ZygoteRules: AContext, literal_getproperty, pullback_for_default_literal_getproperty
+
+function ZygoteRules._pullback(
+  cx::AContext, ::typeof(literal_getproperty), x::YourType, ::Val{f}
+) where {f}
+    return pullback_for_default_literal_getproperty(cx, x, Val{f}())
+end
+
+@testset "getproperty_performance_workaround" begin
+    x = YourType(5.0)
+    @inferred (x -> x.x)(x)
+    @inferred Zygote._pullback(Zygote.Context(), x -> x.x, x)
+    out, pb = Zygote._pullback(Zygote.Context(), x -> x.x, x)
+    @inferred pb(4.0)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -56,3 +56,7 @@ end
 @testset "Compiler" begin
   include("compiler.jl")
 end
+
+@testset "getproperty_performance_workaround" begin
+  include("getproperty_performance_workaround.jl")
+end


### PR DESCRIPTION
Counterpart to https://github.com/FluxML/ZygoteRules.jl/pull/21

Works around the issue discussed in https://github.com/FluxML/Zygote.jl/pull/909, which may at some point be properly addressed. Until that point, having an "official" work-around seems like a reasonable idea to me.

Also starts a performance tips part of the docs.