### PR TITLE
Support 0-dimensional array indexing

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -28,7 +28,9 @@ end
 @adjoint view(x::AbstractArray, inds...) = view(x, inds...), ∇getindex(x, inds)
 
 ∇getindex(x::AbstractArray{T,N}, inds) where {T,N} = dy -> begin
-  if inds isa NTuple{N,Int} && T <: Number
+  if N == 0
+    dx = dy
+  elseif inds isa NTuple{N,Int} && T <: Number
     dx = OneElement(dy, inds, axes(x))
   elseif inds isa NTuple{<:Any, Integer}
     dx = _zero(x, typeof(dy))

--- a/test/lib/array.jl
+++ b/test/lib/array.jl
@@ -6,3 +6,9 @@ using Zygote: ZygoteRuleConfig
 
 test_rrule(ZygoteRuleConfig(), x->sum(sin, Diagonal(x)), ones(2); rrule_f=rrule_via_ad, check_inferred=false)
 test_rrule(ZygoteRuleConfig(), x->sum(sin, Diagonal(x)), rand(3); rrule_f=rrule_via_ad, check_inferred=false)
+
+@testset "Zero Dimensional Array Indexing" begin
+    x = Array{Float64,0}(undef)
+    x[1] = 0.7
+    @test Zygote.gradient(x->x[1],x)[1][1] == 1.0
+end


### PR DESCRIPTION
MWE:

```julia
x = Array{Float64,0}(undef)
x[1] = 0.7
axes(x) # ()
dx = Zygote.OneElement(1.0, x, axes(x)) # fails
Zygote.gradient(x->x[1],x) # fails
```

It's somewhat of an edge case found in https://github.com/SciML/DiffEqSensitivity.jl/pull/498