### PR TITLE
Make `wrap_chainrules_input` understand `mutable struct`s

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Zygote"
 uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
-version = "0.6.27"
+version = "0.6.28"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
@@ -24,7 +24,7 @@ ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 [compat]
 AbstractFFTs = "0.5, 1.0"
 ChainRules = "1.5"
-ChainRulesCore = "1.6"
+ChainRulesCore = "1.9"
 ChainRulesTestUtils = "1"
 DiffRules = "1.0"
 FillArrays = "0.8, 0.9, 0.10, 0.11, 0.12"

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -128,6 +128,8 @@ Convert `x` from the format Zygote uses internally to differentials types ChainR
   xp = map(wrap_chainrules_input, xs)
   ChainRules.Tangent{Any, typeof(xp)}(xp)
 end
+# For mutable types, including x=Ref(1), Zygote makes Ref{Any}(::NamedTuple)
+@inline wrap_chainrules_input(x::Ref) = wrap_chainrules_input(x[])
 
 """
   _project(x, dx)


### PR DESCRIPTION
For the gradient of a mutable struct, Zygote will make `Base.RefValue{Any}((value = 7.0,))` instead of just a NamedTuple. This was not handled at all by the code for converting to ChainRules types, causing Zygote's types to appear in unexpected places.

This PR makes `wrap_chainrules_input` send them to the same `Tangent` used for immutable `struct`s. This means that `wrap_chainrules_output` back to Zygote's types will create an ordinary NamedTuple, without the Ref. This doesn't seem to cause problems in the examples I could think of.

The simplest mutable struct is `Ref`, for which there appear to be no tests at all, apart from its use in broadcasting. Except one mutation test, which still works.