### PR TITLE
Insert `_project` into `getproperty`'s gradient, and then improve `z2d` etc. to restore stability

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -20,6 +20,7 @@ jobs:
         package:
           - {user: FluxML, repo: Flux.jl, group: All}
           - {user: FluxML, repo: NNlib.jl, group: All}
+          - {user: TuringLang, repo: DynamicPPL.jl, group: All}
           - {user: SciML, repo: DiffEqFlux.jl, group: Layers}
           - {user: SciML, repo: NeuralPDE.jl, group: NNPDE}
     steps:

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -21,7 +21,7 @@ jobs:
           - {user: FluxML, repo: Flux.jl, group: All}
           - {user: FluxML, repo: NNlib.jl, group: All}
           - {user: TuringLang, repo: DynamicPPL.jl, group: All}
-          - {user: TuringLang, repo: DistributionsAD.jl, group: All} # group Zygote?
+          - {user: TuringLang, repo: DistributionsAD.jl, group: Zygote}
           - {user: SciML, repo: DiffEqFlux.jl, group: Layers}
           - {user: SciML, repo: NeuralPDE.jl, group: NNPDE}
     steps:

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -21,6 +21,7 @@ jobs:
           - {user: FluxML, repo: Flux.jl, group: All}
           - {user: FluxML, repo: NNlib.jl, group: All}
           - {user: TuringLang, repo: DynamicPPL.jl, group: All}
+          - {user: TuringLang, repo: DistributionsAD.jl, group: All} # group Zygote?
           - {user: SciML, repo: DiffEqFlux.jl, group: Layers}
           - {user: SciML, repo: NeuralPDE.jl, group: NNPDE}
     steps:

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Zygote"
 uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
-version = "0.6.29"
+version = "0.6.30"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -159,16 +159,13 @@ _project(x::AbstractArray, dx::Tuple) = _project(x, reshape(collect(dx), axes(x)
 
 # Piracy:
 # wrap_chainrules_input doesn't handle array of Union{Int,Nothing}
-(::ChainRulesCore.ProjectTo)(::Nothing) = ChainRulesCore.NoTangent()
-
-# CRC likes Tangent{<:Complex}, but Zygote makes Tangent{Any}
-# (project::ProjectTo{<:Complex})(dx::Tangent) = project(Complex(dx.re, dx.im))
+# (::ChainRulesCore.ProjectTo)(::Nothing) = ChainRulesCore.NoTangent()
 
 # CRC likes Tangent{AbstractArray}, but Zygote makes Tangent{Any}
 # in particular this would hit https://github.com/JuliaDiff/ChainRulesCore.jl/blob/2ec2549b73b22bc08f554dae864fb650cfb9c3d7/src/projection.jl#L139
 # if we were not losing track of the Primal in the Tangent
 # This type piracy is just giving up that safety check.
-(project::ProjectTo{AbstractArray})(dx::Tangent) = dx
+# (project::ProjectTo{AbstractArray})(dx::Tangent) = dx
 
 """
   ZBack{F}(back) <: Function

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -244,7 +244,8 @@ zygote2differential(t::Tuple, primal::Tuple) = map(z2d, t, primal)
 zygote2differential(t::Tuple, primal) = (@warn "primal should be a tuple, not $primal"; return t)
 
 z2d(::Nothing, ::Any) = NoTangent()
-z2d(dx, ::Any) = dx  # numbers, Dict, etc.
+z2d(dx, ::Any) = dx
+z2d(dx::NamedTuple, primal::Dict) = dx  # uses a NamedTuple but not for fields!
 z2d(dx::AbstractArray{<:Number}, primal::AbstractArray) = dx
 z2d(dx::AbstractArray{<:AbstractArray}, primal::AbstractArray) = dx
 z2d(dx::AbstractArray, primal::AbstractArray) = z2d.(dx, primal)

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -133,11 +133,13 @@ Convert `x` from the format Zygote uses internally to differentials types ChainR
 end
 # For mutable types, including x=Ref(1), Zygote makes Ref{Any}(::NamedTuple)
 @inline wrap_chainrules_input(x::Ref) = wrap_chainrules_input(x[])
+# For arrays, whitelist the safe ones, but always look inside Any[]:
+@inline wrap_chainrules_input(dxs::AbstractArray{<:Number}) = dxs
+@inline wrap_chainrules_input(dxs::AbstractArray{<:AbstractArray{<:Number}}) = dxs
+@inline wrap_chainrules_input(dxs::AbstractArray) = map(wrap_chainrules_input, xs)
 # Could `reinterpret` instead of broadcasting here -- TODO
-@inline wrap_chainrules_input(xs::AbstractArray{<:Ref}) = wrap_chainrules_input.(xs)
-@inline wrap_chainrules_input(xs::AbstractArray{<:Union{Nothing, <:Ref}}) = wrap_chainrules_input.(xs) # no test invented for this
-@inline wrap_chainrules_input(xs::AbstractArray{<:NamedTuple}) = wrap_chainrules_input.(xs)
-@inline wrap_chainrules_input(xs::AbstractArray{<:Union{Nothing, <:NamedTuple}}) = wrap_chainrules_input.(xs)
+# One easy case:
+# @inline wrap_chainrules_input(xs::Base.ReinterpretArray{<:NamedTuple, <:Tangent}) = parent(@show xs)
 
 """
   _project(x, dx)

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -156,11 +156,12 @@ end
 @inline wrap_chainrules_input(dxs::AbstractArray{<:Number}) = dxs
 @inline wrap_chainrules_input(dxs::AbstractArray{<:AbstractArray{<:Number}}) = dxs
 @inline wrap_chainrules_input(dxs::AbstractArray) = map(wrap_chainrules_input, dxs)
-# Could `reinterpret` instead here...
-# One easy case, but can this go wrong?
-# @inline wrap_chainrules_input(xs::Base.ReinterpretArray{<:NamedTuple, <:Tangent}) = parent(@show xs)
 
 #=
+# Could `reinterpret` instead here? See issue 1112. 
+# One easy case, might be this:
+@inline wrap_chainrules_input(xs::Base.ReinterpretArray{<:NamedTuple, <:Tangent}) = parent(xs)
+
 # This is for `z2d` reinterpret below:
 wrap_chainrules_input(::Type{Nothing}) = NoTangent
 wrap_chainrules_input(::Type{NamedTuple{L,T}}) where {L,T} = NamedTuple{L,wrap_chainrules_input(T)}

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -115,8 +115,9 @@ for T_outer in (:Tuple, :NamedTuple)
     ChainRulesCore.backing(xp)  # this is accessing ChainRulesCore internals, but it is prob safe enough, and it is fastest
   end
 end
-# Could `reinterpret` instead of broadcasting here -- TODO
-@inline wrap_chainrules_output(xs::AbstractArray{<:ChainRules.Tangent}) = wrap_chainrules_output.(xs)
+wrap_chainrules_output(dxs::AbstractArray{<:Number}) = dxs
+wrap_chainrules_output(dxs::AbstractArray{<:AbstractArray{<:Number}}) = dxs
+wrap_chainrules_output(dxs::AbstractArray) = map(wrap_chainrules_output, dxs)
 
 """
     wrap_chainrules_input(x)

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -143,6 +143,7 @@ Convert `dx` from the format Zygote uses internally to differentials types Chain
 """
 @inline wrap_chainrules_input(dx) = dx
 @inline wrap_chainrules_input(::Nothing) = ChainRules.ZeroTangent()
+@inline wrap_chainrules_input(::Tuple{Vararg{Nothing}}) = ChainRules.ZeroTangent()
 @inline wrap_chainrules_input(::AbstractArray{Nothing}) = ChainRules.ZeroTangent()
 @inline function wrap_chainrules_input(dxs::Union{Tuple, NamedTuple})
   xp = map(wrap_chainrules_input, dxs)

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -120,19 +120,20 @@ wrap_chainrules_output(dxs::AbstractArray{<:AbstractArray{<:Number}}) = dxs
 wrap_chainrules_output(dxs::AbstractArray) = map(wrap_chainrules_output, dxs)
 
 """
-    wrap_chainrules_input(x)
+    wrap_chainrules_input(dx)
 
-Convert `x` from the format Zygote uses internally to differentials types ChainRules uses.
+Convert `dx` from the format Zygote uses internally to differentials types ChainRules uses.
 """
-@inline wrap_chainrules_input(x) = x
+@inline wrap_chainrules_input(dx) = dx
 @inline wrap_chainrules_input(::Nothing) = ChainRules.ZeroTangent()
 @inline wrap_chainrules_input(::AbstractArray{Nothing}) = ChainRules.ZeroTangent()
-@inline function wrap_chainrules_input(xs::Union{Tuple, NamedTuple})
-  xp = map(wrap_chainrules_input, xs)
-  ChainRules.Tangent{Any, typeof(xp)}(xp)
+@inline function wrap_chainrules_input(dxs::Union{Tuple, NamedTuple})
+  xp = map(wrap_chainrules_input, dxs)
+  # This produces Tangent{Any} since it does not get to see the primal, `x`.
+  ChainRulesCore.Tangent{Any, typeof(xp)}(xp)
 end
 # For mutable types, including x=Ref(1), Zygote makes Ref{Any}(::NamedTuple)
-@inline wrap_chainrules_input(x::Ref) = wrap_chainrules_input(x[])
+@inline wrap_chainrules_input(dx::Ref) = wrap_chainrules_input(dx[])
 # For arrays, whitelist the safe ones, but always look inside Any[]:
 @inline wrap_chainrules_input(dxs::AbstractArray{<:Number}) = dxs
 @inline wrap_chainrules_input(dxs::AbstractArray{<:AbstractArray{<:Number}}) = dxs

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -146,9 +146,8 @@ Also handles some Zygote-specific corrections, such as `x::Array, dx::Tuple`.
 Safe to apply to arbitrary input.
 """
 @inline function _project(x, dx)
-  # Note that this use of `wrap_chainrules_input` has the primal `x`, so could
-  # avoid making `Tangent{Any}`, perhaps via `zygote2differential` -- TODO.
-  wrap_chainrules_output(ProjectTo(x)(wrap_chainrules_input(dx)))
+  # wrap_chainrules_output(ProjectTo(x)(wrap_chainrules_input(dx)))
+  wrap_chainrules_output(ProjectTo(x)(zygote2differential(dx, x)))
 end
 
 # Restore splatted arrays
@@ -159,7 +158,7 @@ _project(x::AbstractArray, dx::Tuple) = _project(x, reshape(collect(dx), axes(x)
 (::ChainRulesCore.ProjectTo)(::Nothing) = ChainRulesCore.NoTangent()
 
 # CRC likes Tangent{<:Complex}, but Zygote makes Tangent{Any}
-(project::ProjectTo{<:Complex})(dx::Tangent) = project(Complex(dx.re, dx.im))
+# (project::ProjectTo{<:Complex})(dx::Tangent) = project(Complex(dx.re, dx.im))
 
 # CRC likes Tangent{AbstractArray}, but Zygote makes Tangent{Any}
 # in particular this would hit https://github.com/JuliaDiff/ChainRulesCore.jl/blob/2ec2549b73b22bc08f554dae864fb650cfb9c3d7/src/projection.jl#L139

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -136,7 +136,7 @@ end
 # For arrays, whitelist the safe ones, but always look inside Any[]:
 @inline wrap_chainrules_input(dxs::AbstractArray{<:Number}) = dxs
 @inline wrap_chainrules_input(dxs::AbstractArray{<:AbstractArray{<:Number}}) = dxs
-@inline wrap_chainrules_input(dxs::AbstractArray) = map(wrap_chainrules_input, xs)
+@inline wrap_chainrules_input(dxs::AbstractArray) = map(wrap_chainrules_input, dxs)
 # Could `reinterpret` instead of broadcasting here -- TODO
 # One easy case:
 # @inline wrap_chainrules_input(xs::Base.ReinterpretArray{<:NamedTuple, <:Tangent}) = parent(@show xs)

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -272,7 +272,14 @@ end
 z2d(dx::NamedTuple{L,S}, primal::AbstractDict) where {L,S<:Tuple{Vararg{Union{Number,Nothing}}}} = dx
 @generated function z2d(delta::NamedTuple{L,S}, primal::T) where {L,S<:Tuple{Vararg{Union{Number,Nothing}}}, T}
   fnames = fieldnames(T)
-  deltas = map(n -> Base.sym_in(n, L) ? :(delta.$n) : nothing, fnames)
+  deltas = map(fnames) do n
+    i = findfirst(isequal(n), L)
+    if i == nothing || S.parameters[i] == Nothing
+      :(NoTangent())
+    else
+      :(delta.$n)
+    end
+  end
   return quote
     backing = NamedTuple{$fnames}(($(deltas...),))
     Tangent{$T, typeof(backing)}(backing)

--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -227,7 +227,8 @@ end
   function back(Δ)
     accum_param(__context__, val, Δ) === nothing && return
     if isimmutable(x)
-      ((; nt_nothing(x)..., pair(Val(f), Δ, x)...), nothing)
+      dx = (; nt_nothing(x)..., pair(Val(f), Δ, x)...)
+      (_project(x, dx), nothing)
     else
       dx = grad_mut(__context__, x)
       dx[] = (; dx[]..., pair(Val(f), accum(getfield(dx[], f), Δ))...)

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -353,6 +353,8 @@ end
 @testset "zygote2differential inference" begin
     @test @inferred(Zygote.z2d(1.0, 2.0)) isa Real
     @test @inferred(Zygote.z2d([1,2,3], [4,5,6])) isa Vector
-    @test @inferred(Zygote.z2d((1, 2.0, 3+4im), (5, 6.0, 7+8im))) isa Tangent{<:Tuple}
+    if VERSION > v"1.7-"
+        @test @inferred(Zygote.z2d((1, 2.0, 3+4im), (5, 6.0, 7+8im))) isa Tangent{<:Tuple}
+    end
     @test @inferred(Zygote.z2d((re=1,), 3.0+im)) isa Tangent{ComplexF64}
 end

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -350,11 +350,9 @@ end
     end == (4.0,)
 end
 
-@testset "zygote2differential inference" begin
+VERSION > v"1.7-" && @testset "zygote2differential inference" begin
     @test @inferred(Zygote.z2d(1.0, 2.0)) isa Real
     @test @inferred(Zygote.z2d([1,2,3], [4,5,6])) isa Vector
-    if VERSION > v"1.7-"
-        @test @inferred(Zygote.z2d((1, 2.0, 3+4im), (5, 6.0, 7+8im))) isa Tangent{<:Tuple}
-    end
+    @test @inferred(Zygote.z2d((1, 2.0, 3+4im), (5, 6.0, 7+8im))) isa Tangent{<:Tuple}
     @test @inferred(Zygote.z2d((re=1,), 3.0+im)) isa Tangent{ComplexF64}
 end

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -360,7 +360,7 @@ end
     @test @inferred(Zygote.z2d((re=1, im=nothing), 3.0+im)) isa Tangent{ComplexF64}
 
     # To test the generic case, we need a struct within a struct. 
-    nested = Tangent{Base.RefValue{ComplexF64}}(x = Tangent{ComplexF64}(re = 1, im = nothing),)
+    nested = Tangent{Base.RefValue{ComplexF64}}(; x=Tangent{ComplexF64}(; re=1, im=NoTangent()),)
     if VERSION > v"1.7-"
         @test @inferred(Zygote.z2d((; x=(; re=1)), Ref(3.0+im))) == nested
     else

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -359,11 +359,17 @@ end
     @test @inferred(Zygote.z2d((re=1,), 3.0+im)) isa Tangent{ComplexF64}
     @test @inferred(Zygote.z2d((re=1, im=nothing), 3.0+im)) isa Tangent{ComplexF64}
 
+    # collapse nothings
+    @test @inferred(Zygote.z2d((nothing,), (1,))) === NoTangent()
+    @test @inferred(Zygote.z2d((nothing, nothing), (1,2))) === NoTangent()
+
     # To test the generic case, we need a struct within a struct. 
     nested = Tangent{Base.RefValue{ComplexF64}}(; x=Tangent{ComplexF64}(; re=1, im=NoTangent()),)
     if VERSION > v"1.7-"
         @test @inferred(Zygote.z2d((; x=(; re=1)), Ref(3.0+im))) == nested
+        @test @inferred(Zygote.z2d((; x=(; re=nothing)), Ref(3.0+im))) === NoTangent()
     else
         @test Zygote.z2d((; x=(; re=1)), Ref(3.0+im)) == nested
+        @test Zygote.z2d((; x=(; re=nothing)), Ref(3.0+im)) === NoTangent()
     end
 end

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -350,7 +350,7 @@ end
     end == (4.0,)
 end
 
-VERSION > v"1.7-" && @testset "zygote2differential inference" begin
+@testset "zygote2differential inference" begin
     @test @inferred(Zygote.z2d(1.0, 2.0)) isa Real
     @test @inferred(Zygote.z2d([1,2,3], [4,5,6])) isa Vector
     @test @inferred(Zygote.z2d((1, 2.0, 3+4im), (5, 6.0, 7+8im))) isa Tangent{<:Tuple}

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -349,3 +349,10 @@ end
       @fastmath x^2.0
     end == (4.0,)
 end
+
+@testset "zygote2differential inference" begin
+    @test @inferred(Zygote.z2d(1.0, 2.0)) isa Real
+    @test @inferred(Zygote.z2d([1,2,3], [4,5,6])) isa Vector
+    @test @inferred(Zygote.z2d((1, 2.0, 3+4im), (5, 6.0, 7+8im))) isa Tangent{<:Tuple}
+    @test @inferred(Zygote.z2d((re=1,), 3.0+im)) isa Tangent{ComplexF64}
+end

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -163,7 +163,9 @@ end
     y, back = @inferred pullback(x -> x.m, g)
     @test y == getfield(g, :m)
     # This type instability is due to the handling of non-bitstypes in `accum_param`
-    @test Base.return_types(back, Tuple{Vector{Float64}}) == Any[Union{Tuple{Nothing}, typeof(((m = [1.0, 0.0, 0.0], P = nothing),))}]
+    if VERSION > v"1.7-"
+      @test Base.return_types(back, Tuple{Vector{Float64}}) == Any[Union{Tuple{Nothing}, typeof(((m = [1.0, 0.0, 0.0], P = nothing),))}]
+    end
     @test back([1., 0, 0]) == ((m = [1.0, 0.0, 0.0], P = nothing),)
 
     Base.getproperty(g::Gaussian, s::Symbol) = 2getfield(g, s)

--- a/test/features.jl
+++ b/test/features.jl
@@ -422,6 +422,9 @@ end
 
   @test gradient((x,y,z) -> sum((x,y,z)[1:2]), 7, 8.8, 9.9) == (1.0, 1.0, nothing)
   @test gradient((x,y,z) -> sum((x,y,z)[[1,2,1]]), 1,2,3) == (2, 1, nothing)
+
+  @test gradient(xs -> sum(x -> x[2], xs), [(1,2,3), (4,5,6)]) == ([(nothing, 1.0, nothing), (nothing, 1.0, nothing)],)
+  @test gradient(xs -> sum(x -> prod(x[2:3]), xs), [(1,2,3), (4,5,6)]) == ([(nothing, 3.0, 2.0), (nothing, 6.0, 5.0)],)
 end
 
 @testset "@timed" begin

--- a/test/features.jl
+++ b/test/features.jl
@@ -468,6 +468,17 @@ end
   @test gradient(x -> sum(sum, Ref(x) .* [1,2,3]), [4,5]) == ([6.0, 6.0],)
 end
 
+@testset "NamedTuples" begin
+  @test gradient(x -> x.a, (a=1, b=2)) == ((a = 1, b = nothing),)
+  @test gradient(x -> x[1].a, [(a=1, b=2)]) == ([(a = 1, b = nothing)],)
+  @test gradient(x -> x[1].a, [(a=1, b=2), (a=3, b=4)]) == ([(a = 1, b = nothing), nothing],)
+
+  # Mix with Ref
+  @test gradient(x -> x[].a, Ref((a=1, b=2))) == ((x = (a = 1, b = nothing),),)
+  @test gradient(x -> x[1][].a, [Ref((a=1, b=2)), Ref((a=3, b=4))]) == ([(x = (a = 1, b = nothing),), nothing],)
+  @test gradient(x -> x[1].a, [(a=1, b=2), "three"]) == ([(a = 1, b = nothing), nothing],)
+end
+
 function type_test()
    Complex{<:Real}
 end

--- a/test/features.jl
+++ b/test/features.jl
@@ -705,11 +705,8 @@ end
 
   # second order
   @test gradient(x -> sum(gradient(y -> sum(y.^2), x)[1]), [1, 2])[1] ≈ [2, 2]
-
-  # Need an adjoint for constructor Zygote.ZBack{ChainRules.var"#sin_pullback#1133"{Float64}}. 
-  #     Gradient is of type Tangent{Zygote.ZBack{ChainRules.var"#sin_pullback#1133"{Float64}}, NamedTuple{(:back,), Tuple{Tangent{ChainRules.var"#sin_pullback#1133"{Float64}, NamedTuple{(:cosx,), Tuple{Float64}}}}}}
-  # @test gradient(x -> sum(gradient(y -> sum(sin.(y)), x)[1]), [1, 2])[1] ≈ [-0.8414709848078965, -0.9092974268256817]
-  # @test gradient(x -> sum(abs, gradient(y -> sum(log.(2 .* exp.(y)) .^ 2), x)[1]), [1, 2])[1] ≈ [2,2]
+  @test gradient(x -> sum(gradient(y -> sum(sin.(y)), x)[1]), [1, 2])[1] ≈ [-0.8414709848078965, -0.9092974268256817]
+  @test gradient(x -> sum(abs, gradient(y -> sum(log.(2 .* exp.(y)) .^ 2), x)[1]), [1, 2])[1] ≈ [2,2]
 
   # getproperty, Tangents, etc
   @test gradient(xs -> sum((x->x.im^2).(xs)), [1+2im,3])[1] == [4im, 0]

--- a/test/features.jl
+++ b/test/features.jl
@@ -694,8 +694,8 @@ end
 
   # second order
   @test gradient(x -> sum(gradient(y -> sum(y.^2), x)[1]), [1, 2])[1] ≈ [2, 2]
-  @test_broken gradient(x -> sum(gradient(y -> sum(sin.(y)), x)[1]), [1, 2])[1] ≈ [-0.8414709848078965, -0.9092974268256817]
-  @test_broken gradient(x -> sum(abs, gradient(y -> sum(log.(2 .* exp.(y)) .^ 2), x)[1]), [1, 2])[1] ≈ [2,2]
+  @test gradient(x -> sum(gradient(y -> sum(sin.(y)), x)[1]), [1, 2])[1] ≈ [-0.8414709848078965, -0.9092974268256817]
+  @test gradient(x -> sum(abs, gradient(y -> sum(log.(2 .* exp.(y)) .^ 2), x)[1]), [1, 2])[1] ≈ [2,2]
 
   # getproperty, Tangents, etc
   @test gradient(xs -> sum((x->x.im^2).(xs)), [1+2im,3])[1] == [4im, 0]

--- a/test/features.jl
+++ b/test/features.jl
@@ -694,8 +694,8 @@ end
 
   # second order
   @test gradient(x -> sum(gradient(y -> sum(y.^2), x)[1]), [1, 2])[1] ≈ [2, 2]
-  @test gradient(x -> sum(gradient(y -> sum(sin.(y)), x)[1]), [1, 2])[1] ≈ [-0.8414709848078965, -0.9092974268256817]
-  @test gradient(x -> sum(abs, gradient(y -> sum(log.(2 .* exp.(y)) .^ 2), x)[1]), [1, 2])[1] ≈ [2,2]
+  @test_broken gradient(x -> sum(gradient(y -> sum(sin.(y)), x)[1]), [1, 2])[1] ≈ [-0.8414709848078965, -0.9092974268256817]
+  @test_broken gradient(x -> sum(abs, gradient(y -> sum(log.(2 .* exp.(y)) .^ 2), x)[1]), [1, 2])[1] ≈ [2,2]
 
   # getproperty, Tangents, etc
   @test gradient(xs -> sum((x->x.im^2).(xs)), [1+2im,3])[1] == [4im, 0]

--- a/test/features.jl
+++ b/test/features.jl
@@ -694,8 +694,11 @@ end
 
   # second order
   @test gradient(x -> sum(gradient(y -> sum(y.^2), x)[1]), [1, 2])[1] ≈ [2, 2]
-  @test gradient(x -> sum(gradient(y -> sum(sin.(y)), x)[1]), [1, 2])[1] ≈ [-0.8414709848078965, -0.9092974268256817]
-  @test gradient(x -> sum(abs, gradient(y -> sum(log.(2 .* exp.(y)) .^ 2), x)[1]), [1, 2])[1] ≈ [2,2]
+
+  # Need an adjoint for constructor Zygote.ZBack{ChainRules.var"#sin_pullback#1133"{Float64}}. 
+  #     Gradient is of type Tangent{Zygote.ZBack{ChainRules.var"#sin_pullback#1133"{Float64}}, NamedTuple{(:back,), Tuple{Tangent{ChainRules.var"#sin_pullback#1133"{Float64}, NamedTuple{(:cosx,), Tuple{Float64}}}}}}
+  # @test gradient(x -> sum(gradient(y -> sum(sin.(y)), x)[1]), [1, 2])[1] ≈ [-0.8414709848078965, -0.9092974268256817]
+  # @test gradient(x -> sum(abs, gradient(y -> sum(log.(2 .* exp.(y)) .^ 2), x)[1]), [1, 2])[1] ≈ [2,2]
 
   # getproperty, Tangents, etc
   @test gradient(xs -> sum((x->x.im^2).(xs)), [1+2im,3])[1] == [4im, 0]

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -1878,6 +1878,18 @@ end
 a = rand(3)
 @test Zygote.gradient(x->sum(x .+ rand.()), a) == (ones(3),)
 
+@testset "Zygote 660" begin
+  # https://github.com/FluxML/Zygote.jl/pull/660
+  function example(x,N)
+      ax = axes(x)
+      extraAxe = ax[2+N:end]
+      filledLoc = fill(1, N)
+      return x[:, filledLoc..., extraAxe...]
+  end
+  y, back = pullback(example, randn(5,3,4,3), 2)
+  @test back(zero(y).=1) isa Tuple{Array{Float64,4}, Nothing}
+end
+
 @testset "CRC issue 440" begin
   # https://github.com/JuliaDiff/ChainRulesCore.jl/issues/440
   f(x,y) = sum(sum, [[x[i],y[i]] for i=1:length(x)])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,61 +5,61 @@ using CUDA: has_cuda
 
 @testset "all" begin  # Overall testset ensures it keeps running after failure
 
-if has_cuda()
-  @testset "CUDA tests" begin
-    include("cuda.jl")
+  if has_cuda()
+    @testset "CUDA tests" begin
+      include("cuda.jl")
+    end
+    @info "CUDA tests have run"
+  else
+    @warn "CUDA not found - Skipping CUDA Tests"
   end
-  @info "CUDA tests have run"
-else
-  @warn "CUDA not found - Skipping CUDA Tests"
-end
 
-@testset "Interface" begin
-  include("interface.jl")
-end
+  @testset "Interface" begin
+    include("interface.jl")
+  end
 
-@testset "Tools" begin
-  include("tools.jl")
-end
+  @testset "Tools" begin
+    include("tools.jl")
+  end
 
-@testset "Utils" begin
-  include("utils.jl")
-end
+  @testset "Utils" begin
+    include("utils.jl")
+  end
 
-@testset "lib" begin
-  include("lib/number.jl")
-  include("lib/lib.jl")
-  include("lib/array.jl")
-end
+  @testset "lib" begin
+    include("lib/number.jl")
+    include("lib/lib.jl")
+    include("lib/array.jl")
+  end
 
-@testset "Features" begin
-  include("features.jl")
-  @info "features.jl done"
-end
+  @testset "Features" begin
+    include("features.jl")
+    @info "features.jl done"
+  end
 
-@testset "Forward" begin
-  include("forward/forward.jl")
-end
+  @testset "Forward" begin
+    include("forward/forward.jl")
+  end
 
-@testset "Data Structures" begin
-  include("structures.jl")
-end
+  @testset "Data Structures" begin
+    include("structures.jl")
+  end
 
-@testset "ChainRules" begin
-  include("chainrules.jl")
-  @info "chainrules.jl done"
-end
+  @testset "ChainRules" begin
+    include("chainrules.jl")
+    @info "chainrules.jl done"
+  end
 
-@testset "Gradients" begin
-  include("gradcheck.jl")
-end
+  @testset "Gradients" begin
+    include("gradcheck.jl")
+  end
 
-@testset "Complex" begin
-  include("complex.jl")
-end
+  @testset "Complex" begin
+    include("complex.jl")
+  end
 
-@testset "Compiler" begin
-  include("compiler.jl")
-end
+  @testset "Compiler" begin
+    include("compiler.jl")
+  end
 
 end # @testset "all"


### PR DESCRIPTION
The goal here is to avoid things like this:
```julia
julia> pullback(x -> abs2(x.im * ((1-im) * x).re), 4+5im)[2](1.0)
# Zygote v0.6.0:
((re = 450.0 + 450.0im, im = 810.0),)
# Zygote v0.6.28:
ERROR: MethodError: no method matching Complex(::ComplexF64, ::ZeroTangent)
# this PR:
(450.0 + 1260.0im,)
```
While projection was intended as a mechanism to encode & enforce mathematical properties like real vs complex, I think it's also a good way to encode (when desired) a preference for the "natural gradient" of a complex number, instead of a NamedTuple, because this can participate in other stages of the calculation. One example of this found in the wild was fixed in https://github.com/JuliaDiff/ChainRules.jl/pull/509, a made-up example in the same spirit is:
```julia
julia> gradient(x -> sqrt(sum(parent(x .^ 2))), Diagonal([1,2,3]))[1]
# latest tagged:
ERROR: ArgumentError: broadcasting over dictionaries and `NamedTuple`s is reserved
# this PR + CRC#446:
3×3 Diagonal{Float64, Vector{Float64}}:
 0.267261   ⋅         ⋅ 
  ⋅        0.534522   ⋅ 
  ⋅         ⋅        0.801784
```
I'm a little concerned this may affect what #909 just fixed. Maybe CI will tell us, but cc @simeonschaub ?