### PR TITLE
Implement `copy` and `merge!` for `Grads`

### DIFF
--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -299,15 +299,17 @@ function copy!(x::AbstractVector,  gs::Grads)
   x
 end
 
-function Base.merge!(gs_dst::Grads, gs_src::Grads)
+function Base.merge!(gs_dst::Grads, gs_srcs::Grads...)
+  for gs_src in gs_srcs
     union!(gs_dst.params, gs_src.params)
     merge!(gs_dst.grads, gs_src.grads)
-    gs_dst
+  end
+  gs_dst
 end
 
 function Base.copy(gs::Grads)
-    gs_new = Grads(IdDict(), gs.params)
-    merge!(gs_new, gs)
+  gs_new = Grads(IdDict(), gs.params)
+  merge!(gs_new, gs)
 end
 
 broadcasted(f, gs::Grads, gss::ADictOrGrads...) = map(f, gs, gss...)


### PR DESCRIPTION
Following a discussion on the autodiff Slack channel, this implements `copy` and `copy!` methods for `Grads` which can be handy when evaluating pullbacks of implicit-style gradients at different sensitivities.