### PR TITLE
Cholesky type stability

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Zygote"
 uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
-version = "0.6.30"
+version = "0.6.31"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -753,7 +753,7 @@ end
   C::Cholesky{T, <:StridedMatrix{T}} where {T<:Real}, ::Val{:L}
 )
   return literal_getproperty(C, Val(:L)), function(Δ)
-    Δ_factors = C.uplo == 'L' ? tril!(collect(Δ)) : triu(collect(Δ'))
+    Δ_factors = C.uplo == 'L' ? tril!(collect(Δ)) : triu!(collect(Δ'))
     return ((uplo=nothing, info=nothing, factors=Δ_factors),)
   end
 end

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -741,20 +741,24 @@ end
     return ((uplo=nothing, info=nothing, factors=nothing),)
   end
 end
-@adjoint function literal_getproperty(C::Cholesky, ::Val{:U})
+@adjoint function literal_getproperty(
+  C::Cholesky{T, <:StridedMatrix{T}} where {T<:Real}, ::Val{:U}
+)
   return literal_getproperty(C, Val(:U)), function(Δ)
-    Δ_factors = C.uplo == 'U' ? UpperTriangular(Δ) : LowerTriangular(copy(Δ'))
+    Δ_factors = C.uplo == 'U' ? triu!(collect(Δ)) : tril!(collect(Δ'))
     return ((uplo=nothing, info=nothing, factors=Δ_factors),)
   end
 end
-@adjoint function literal_getproperty(C::Cholesky, ::Val{:L})
+@adjoint function literal_getproperty(
+  C::Cholesky{T, <:StridedMatrix{T}} where {T<:Real}, ::Val{:L}
+)
   return literal_getproperty(C, Val(:L)), function(Δ)
-    Δ_factors = C.uplo == 'L' ? LowerTriangular(Δ) : UpperTriangular(copy(Δ'))
+    Δ_factors = C.uplo == 'L' ? tril!(collect(Δ)) : triu(collect(Δ'))
     return ((uplo=nothing, info=nothing, factors=Δ_factors),)
   end
 end
 
-@adjoint function logdet(C::Cholesky)
+@adjoint function logdet(C::Cholesky{T, <:StridedMatrix{T}} where {T<:Real})
   return logdet(C), function(Δ)
     return ((uplo=nothing, info=nothing, factors=Diagonal(2 .* Δ ./ diag(C.factors))),)
   end

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -758,7 +758,7 @@ end
   end
 end
 
-@adjoint function logdet(C::Cholesky{T, <:StridedMatrix{T}} where {T<:Real})
+@adjoint function logdet(C::Cholesky)
   return logdet(C), function(Δ)
     return ((uplo=nothing, info=nothing, factors=Diagonal(2 .* Δ ./ diag(C.factors))),)
   end

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -801,6 +801,17 @@ end
     @test gradtest(A->logdet(cholesky(A' * A + I)), A)
     @test gradtest(B->cholesky(Symmetric(B)).U, A * A' + I)
     @test gradtest(B->logdet(cholesky(Symmetric(B))), A * A' + I)
+
+    @testset "inference" begin
+      out, pb = _pullback(Context(), C -> C.U, cholesky(Symmetric(A'A + I, :U)))
+      @inferred pb(out)
+      out, pb = _pullback(Context(), C -> C.U, cholesky(Symmetric(A'A + I, :L)))
+      @inferred pb(out)
+      out, pb = _pullback(Context(), C -> C.L, cholesky(Symmetric(A'A + I, :U)))
+      @inferred pb(out)
+      out, pb = _pullback(Context(), C -> C.L, cholesky(Symmetric(A'A + I, :L)))
+      @inferred pb(out)
+    end
   end
   @testset "cholesky - scalar" begin
     rng = MersenneTwister(123456)

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -803,13 +803,13 @@ end
     @test gradtest(B->logdet(cholesky(Symmetric(B))), A * A' + I)
 
     @testset "inference" begin
-      out, pb = _pullback(Context(), C -> C.U, cholesky(Symmetric(A'A + I, :U)))
+      out, pb = pullback(C -> C.U, cholesky(Symmetric(A'A + I, :U)))
       @inferred pb(out)
-      out, pb = _pullback(Context(), C -> C.U, cholesky(Symmetric(A'A + I, :L)))
+      out, pb = pullback(C -> C.U, cholesky(Symmetric(A'A + I, :L)))
       @inferred pb(out)
-      out, pb = _pullback(Context(), C -> C.L, cholesky(Symmetric(A'A + I, :U)))
+      out, pb = pullback(C -> C.L, cholesky(Symmetric(A'A + I, :U)))
       @inferred pb(out)
-      out, pb = _pullback(Context(), C -> C.L, cholesky(Symmetric(A'A + I, :L)))
+      out, pb = pullback(C -> C.L, cholesky(Symmetric(A'A + I, :L)))
       @inferred pb(out)
     end
   end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Zygote, Test
-using Zygote: gradient, ZygoteRuleConfig
+using Zygote: gradient, ZygoteRuleConfig, _pullback, Context
 using CUDA
 using CUDA: has_cuda
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Zygote, Test
-using Zygote: gradient, ZygoteRuleConfig, _pullback, Context
+using Zygote: gradient, ZygoteRuleConfig
 using CUDA
 using CUDA: has_cuda
 


### PR DESCRIPTION
The methods for `literal_getproperty` on the Cholesky factorisation are type-unstable. This instability stems from the value of `uplo` not being known at compile time as it's dynamic.

The only way that I can see around this is to ensure that we arrive at the same type for the `factors` field regardless whether `uplo` is `:L` or `:U`.

I'm not 100% happy with using `collect` -- it feels like it'll be a bad option for things like `CuArray`s, to which this rule does in principle apply I believe. @oxinabox @mcabbott @DhairyaLGandhi @devmotion any thoughts on another way of achieving the same thing?

Note: this should not prevent us moving forward with #1114 as this doesn't interfere with the rrule for `cholesky` itself.