### PR TITLE
Fix `specialize_method` for 1.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Zygote"
 uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
-version = "0.6.30"
+version = "0.6.31"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/lib/literal_getproperty.jl
+++ b/src/lib/literal_getproperty.jl
@@ -29,7 +29,11 @@ function reflect(@nospecialize(sigtypes::Tuple), world::UInt = typemax(UInt))
     end
     method_index === 0 && return nothing
     type_signature, raw_static_params, method = _methods[method_index]
-    method_instance = Core.Compiler.specialize_method(method, type_signature, raw_static_params, false)
+    if VERSION < v"1.8-"
+        method_instance = Core.Compiler.specialize_method(method, type_signature, raw_static_params, false)
+    else
+        method_instance = Core.Compiler.specialize_method(method, type_signature, raw_static_params; preexisting=false)
+    end
     method_signature = method.sig
     static_params = Any[raw_static_params...]
     return method_instance, method_signature, static_params


### PR DESCRIPTION
Fixes this (from tests):
```
julia> using Zygote

julia> hessian(sin, pi/2)
-1.0

julia> Zygote.hessian_reverse(sin, pi/2)
ERROR: MethodError: no method matching specialize_method(::Method, ::Type{Tuple{typeof(ZygoteRules._pullback), Zygote.Context, typeof(ZygoteRules.literal_getfield), Zygote.ZBack{ChainRules.var"#sin_pullback#1143"{Float64}}, Val{:back}}}, ::Core.SimpleVector, ::Bool)
Closest candidates are:
  specialize_method(::Method, ::Any, ::Core.SimpleVector; preexisting, compilesig) at ~/.julia/dev/julia/usr/share/julia/base/compiler/utilities.jl:187

(jl_hNiwcz) pkg> st
Status `/private/var/folders/yq/4p2zwd614y59gszh7y9ypyhh0000gn/T/jl_hNiwcz/Project.toml`
  [7869d1d1] IRTools v0.4.4
  [e88e6eb3] Zygote v0.6.30

julia> VERSION
v"1.8.0-DEV.1002"
```
Locally, one test still fails:
```
test_rrule: sum on Float64,Float64,Float64: Error During Test at /Users/me/.julia/packages/ChainRulesTestUtils/f5cNH/src/testers.jl:191
  Got exception outside of a @test
  return type Tuple{NoTangent, Tangent{Tuple{Float64, Float64, Float64}, Tuple{Float64, Float64, Float64}}} does not match inferred return type Tuple{NoTangent, Any}
  Stacktrace:
    [1] error(s::String)
      @ Base ./error.jl:33
    [2] _test_inferred(f::Any, args::Any; kwargs::Base.Pairs{Symbol, V, Tuple{Vararg{Symbol, N}}, NamedTuple{names, T}} where {V, N, names, T<:Tuple{Vararg{Any, N}}})

  ChainRules                                                             |  199      1       1    201
    ChainRules integration                                               |   45                    45
    ChainRulesCore.rrule_via_ad                                          |  144      1       1    146
      basic                                                              |   17              1     18
      kwargs                                                             |    7                     7
      struct                                                             |   17                    17
      tuples/namedtuples                                                 |   43      1             44
        test_rrule: my_tuple on Float64,Float64,Float64                  |   11                    11
        test_rrule: my_namedtuple on Float64,Float64,Float64             |   11                    11
        test_rrule: my_namedtuple on Float64,Float64,Float64,Float64     |   12                    12
        test_rrule: sum on Float64,Float64,Float64                       |    1      1              
```