### PR TITLE
Make tests pass on 1.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Zygote"
 uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
-version = "0.6.31"
+version = "0.6.32"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
@@ -29,7 +29,7 @@ ChainRulesTestUtils = "1"
 DiffRules = "1.0"
 FillArrays = "0.8, 0.9, 0.10, 0.11, 0.12"
 ForwardDiff = "0.10"
-IRTools = "0.4"
+IRTools = "0.4.4"
 MacroTools = "0.5"
 NaNMath = "0.3"
 Requires = "1.1"

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -267,14 +267,8 @@ end
 
 @testset "ChainRulesCore.rrule_via_ad" begin
     @testset "basic" begin
-        # broken because Zygoye compresses `(NoTangent(), NoTangent())` into just NoTangent()
-        # which ChainRulesTestUtils does not think is valid:
-        @test_broken(rrule_via_ad(ZygoteRuleConfig(), round, 2.2) isa Tuple{NoTangent,NoTangent})
-        # Later: That makes no sense, would always be broken. If you call the pullback,
-        # then right now Zygote agrees with the rrule, but gives 0.0 not NoTangent:
+        # Not marked as tests since perhaps ZeroTangent would be better.
         rrule_via_ad(ZygoteRuleConfig(), round, 2.2)[2](1) == (NoTangent(), 0.0)
-        rrule(round, 2.2)[2](1) == (NoTangent(), 0.0)
-        # Not marked as tests since perhaps NoTangent would be better.
         # But test_rrule is happy:
         test_rrule(ZygoteRuleConfig(), round, 2.2; rrule_f=rrule_via_ad)
 

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -1,4 +1,6 @@
 using ChainRulesCore, ChainRulesTestUtils, Zygote
+using Zygote: ZygoteRuleConfig
+
 @testset "ChainRules integration" begin
     @testset "ChainRules basics" begin
         cr_inner_demo_rrule_hitcount = Ref(0)
@@ -268,10 +270,15 @@ end
         # broken because Zygoye compresses `(NoTangent(), NoTangent())` into just NoTangent()
         # which ChainRulesTestUtils does not think is valid:
         @test_broken(rrule_via_ad(ZygoteRuleConfig(), round, 2.2) isa Tuple{NoTangent,NoTangent})
-        # uncomment below when/if above is fixed
-        # test_rrule(ZygoteRuleConfig(), round, 2.2; rrule_f=rrule_via_ad)
+        # Later: That makes no sense, would always be broken. If you call the pullback,
+        # then right now Zygote agrees with the rrule, but gives 0.0 not NoTangent:
+        rrule_via_ad(ZygoteRuleConfig(), round, 2.2)[2](1) == (NoTangent(), 0.0)
+        rrule(round, 2.2)[2](1) == (NoTangent(), 0.0)
+        # Not marked as tests since perhaps NoTangent would be better.
+        # But test_rrule is happy:
+        test_rrule(ZygoteRuleConfig(), round, 2.2; rrule_f=rrule_via_ad)
 
-        test_rrule(ZygoteRuleConfig(), vcat, rand(3), rand(4); rrule_f=rrule_via_ad, check_inferred=false)
+        test_rrule(ZygoteRuleConfig(), vcat, rand(3), rand(4); rrule_f=rrule_via_ad)
         test_rrule(ZygoteRuleConfig(), getindex, rand(5), 3; rrule_f=rrule_via_ad)
     end
 
@@ -313,10 +320,13 @@ end
         test_rrule(
             ZygoteRuleConfig(), my_namedtuple, 1., (2.0, 2.4), 3.; rrule_f=rrule_via_ad
         )
-        test_rrule(ZygoteRuleConfig(), sum, (1.0, 2.0, 3.0); rrule_f=rrule_via_ad)
+        test_rrule(
+            ZygoteRuleConfig(), sum, (1.0, 2.0, 3.0); rrule_f=rrule_via_ad, check_inferred=false
+        )
         test_rrule(
             ZygoteRuleConfig(), sum, (a=1.0, b=2.0); rrule_f=rrule_via_ad, check_inferred=false
         )
+        # There is at present no rrule for sum(::Tuple), so those are testing zygote directly.
     end
 
     @testset "arrays" begin
@@ -348,6 +358,10 @@ end
     @test gradient(2.0) do x
       @fastmath x^2.0
     end == (4.0,)
+
+    @test gradient(2) do x
+      @fastmath log(x)
+    end == (1/2,)
 end
 
 @testset "zygote2differential inference" begin


### PR DESCRIPTION
Previously, `sum(::Tuple)` had `check_inferred=false` but NamedTuple did not. Now both do. That was the one failing test.

But some other tests marked `check_inferred=false` no longer need that. So perhaps it's a wash.

Closes #1066 