### PR TITLE
getindex for CuArray to fix repeated indices error

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -39,21 +39,6 @@ end
   return (_project(x, dx), map(_->nothing, inds)...)
 end
 
-using CUDA
-import NNlib
-
-∇getindex(x::CuArray, inds::Tuple{AbstractArray{<:Integer}}) = dy -> begin
-  dx = _zero(x, eltype(dy))
-  inds1_cpu = Array(inds[1])
-  if allunique(inds1_cpu)
-    dxv = view(dx, inds[1])
-    dxv .= accum.(dxv, _droplike(dy, dxv))
-  else
-    NNlib.scatter!(+, dx, dy, inds1_cpu)
-  end
-  return (_project(x, dx), map(_->nothing, inds)...)
-end
-
 """
     OneElement(val, ind, axes) <: AbstractArray
 

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -44,7 +44,13 @@ import NNlib
 
 ∇getindex(x::CuArray, inds::Tuple{AbstractArray{<:Integer}}) = dy -> begin
   dx = _zero(x, eltype(dy))
-  NNlib.scatter!(+, dx, dy, inds[1])
+  inds1_cpu = Array(inds[1])
+  if allunique(inds1_cpu)
+    dxv = view(dx, inds[1])
+    dxv .= accum.(dxv, _droplike(dy, dxv))
+  else
+    NNlib.scatter!(+, dx, dy, inds1_cpu)
+  end
   return (_project(x, dx), map(_->nothing, inds)...)
 end
 

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -39,6 +39,15 @@ end
   return (_project(x, dx), map(_->nothing, inds)...)
 end
 
+using CUDA
+import NNlib
+
+∇getindex(x::CuArray, inds::Tuple{AbstractArray{<:Integer}}) = dy -> begin
+  dx = _zero(x, eltype(dy))
+  NNlib.scatter!(+, dx, dy, inds[1])
+  return (_project(x, dx), map(_->nothing, inds)...)
+end
+
 """
     OneElement(val, ind, axes) <: AbstractArray
 

--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -286,11 +286,10 @@ using GPUArraysCore  # replaces @require CUDA block, weird indenting to preserve
 
   pull_block_vert(sz, Δ::AbstractGPUArray, A::Number) = @allowscalar Δ[sz]
 
-  ∇getindex(x::CUDA.CuArray, inds::Tuple{AbstractArray{<:Integer}}) = dy -> begin
+  ∇getindex(x::T, inds::Tuple{AbstractArray{<:Integer}}) where {T <: AbstractGPUArray} = dy -> begin
     inds1_cpu = Array(inds[1])
     dx = zeros(eltype(dy), length(x))
     dxv = view(dx, inds1_cpu)
     dxv .= accum.(dxv, _droplike(Array(dy), dxv))
-    return _project(x, CUDA.CuArray(dx)), nothing
+    return _project(x, T(dx)), nothing
   end
-end

--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -288,16 +288,9 @@ using GPUArraysCore  # replaces @require CUDA block, weird indenting to preserve
 
   ∇getindex(x::CUDA.CuArray, inds::Tuple{AbstractArray{<:Integer}}) = dy -> begin
     inds1_cpu = Array(inds[1])
-    if allunique(inds1_cpu)
-      dx = _zero(x, eltype(dy))
-      dxv = view(dx, inds[1])
-      dxv .= accum.(dxv, _droplike(dy, dxv))
-      return _project(x, dx), nothing
-    else
-      dx = zeros(eltype(dy), length(x))
-      dxv = view(dx, inds1_cpu)
-      dxv .= accum.(dxv, _droplike(Array(dy), dxv))
-      return _project(x, CUDA.CuArray(dx)), nothing
-    end
+    dx = zeros(eltype(dy), length(x))
+    dxv = view(dx, inds1_cpu)
+    dxv .= accum.(dxv, _droplike(Array(dy), dxv))
+    return _project(x, CUDA.CuArray(dx)), nothing
   end
 end

--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -286,3 +286,17 @@ using GPUArraysCore  # replaces @require CUDA block, weird indenting to preserve
 
   pull_block_vert(sz, Δ::AbstractGPUArray, A::Number) = @allowscalar Δ[sz]
 
+  import NNlib
+  
+  ∇getindex(x::CUDA.CuArray, inds::Tuple{AbstractArray{<:Integer}}) = dy -> begin
+    dx = _zero(x, eltype(dy))
+    inds1_cpu = Array(inds[1])
+    if allunique(inds1_cpu)
+      dxv = view(dx, inds[1])
+      dxv .= accum.(dxv, _droplike(dy, dxv))
+    else
+      NNlib.scatter!(+, dx, dy, inds1_cpu)
+    end
+    return (_project(x, dx), map(_->nothing, inds)...)
+  end
+end

--- a/test/cuda.jl
+++ b/test/cuda.jl
@@ -140,3 +140,9 @@ end
   @test_skip gradient((x,y) -> sum(vcat(x,y)), 1f0, r, 2f0, r)[2] isa CUDA.CuArray{Float32}
 end
 
+@testset "repeated indexing" begin
+  f(a) = sum(view(a, [1, 1, 2]))
+  a = CUDA.CuArray([1.0f0, 1.0f0, 1.0f0])
+  @test f(a) == 3.0f0
+  @test Array(gradient(f, a)[1]) == [2.0f0, 1.0f0, 0.0f0]
+end


### PR DESCRIPTION
I spent quite a while working out where my gradients were wrong, until eventually tracking it down to the GPU repeated index issue that is mentioned in multiple places:
- https://github.com/FluxML/Zygote.jl/issues/600
- https://github.com/FluxML/Zygote.jl/issues/821
- https://github.com/JuliaGPU/CUDA.jl/issues/89
- https://github.com/JuliaGPU/CUDA.jl/issues/1019
- https://github.com/JuliaLang/julia/pull/31407

Based on a solution suggested at https://discourse.julialang.org/t/increment-elements-of-array-by-index/49694 I added a hack to get the correct gradients, which can be found in this PR. It uses `scatter!` from [NNlib](https://github.com/FluxML/NNlib.jl) to accumulate values over multiple indices. It is considerably slower than the current version, which on the GPU gives silently incorrect and even stochastic gradients. However it is faster than moving the array off the GPU to do this step.

This isn't currently suitable for merging since it adds dependencies and isn't tested beyond the simple case. It might be useful as a starting point for a discussion on how to get this important issue fixed, though, and also might be useful as a hack to others.