### PR TITLE
Make value returned by `copy!` consistent

### DIFF
--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -288,7 +288,7 @@ function copy!(gs::Grads, x::AbstractVector)
     gs[p] .= reshape(x[i+1:i+length(p)], size(p))
     i += length(p)
   end
-  x
+  gs
 end
 
 function copy!(x::AbstractVector,  gs::Grads)

--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -235,7 +235,7 @@ function copy!(x::AbstractVector, ps::Params)
     x[i+1:i+length(p)] .= vec(p)
     i += length(p)
   end
-  ps
+  x
 end
 
 """


### PR DESCRIPTION
Hello,

following the discussion from #1135, I have spotted two instances, where the `copy!` function returns the second argument instead of the first.

I personally think that the function should always return the first argument in order for the behavior to be consistent.

Further, even though this behavior is not enforced in the Julia documentation, the line
```copy!(dst, src) -> dst```
in the [documentation](https://docs.julialang.org/en/v1/base/arrays/#Base.copy!) can lead users to a false conclusion that the first argument is always returned.

Best regards,
Dominik 