### PR TITLE
Downstream test for Molly.jl

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -24,6 +24,7 @@ jobs:
           - {user: TuringLang, repo: DistributionsAD.jl, group: Zygote}
           - {user: SciML, repo: DiffEqFlux.jl, group: Layers}
           - {user: SciML, repo: NeuralPDE.jl, group: NNPDE}
+          - {user: JuliaMolSim, repo: Molly.jl, group: Zygote}
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1


### PR DESCRIPTION
A while ago I talked with @DhairyaLGandhi about including downstream tests for differentiable simulation in Molly.jl. This PR adds those downstream tests, using the `group` flag to only run the relevant tests. The CPU-only tests take about 10 mins.

I am still figuring out the best tolerance levels for the tests so there may be intermittent failures. Also, Molly makes use of Zygote's broadcast internals so failures may be acceptable.