### PR TITLE
use Base.Experimental macros to reduce load time 

### DIFF
--- a/src/Zygote.jl
+++ b/src/Zygote.jl
@@ -1,5 +1,13 @@
 module Zygote
 
+# This reduces time to first gradient, by 4x in the Flux example in Zygote#1126
+if isdefined(Base, :Experimental) && isdefined(Base.Experimental, Symbol("@optlevel"))
+  @eval Base.Experimental.@optlevel 1  # Julia 1.5
+end
+if isdefined(Base, :Experimental) && isdefined(Base.Experimental, Symbol("@max_methods"))
+  @eval Base.Experimental.@max_methods 1  # Julia 1.8, JuliaLang#43370
+end
+
 using LinearAlgebra, Statistics
 using LinearAlgebra: copytri!, AbstractTriangular
 


### PR DESCRIPTION
Aims to reduce startup time, xref https://github.com/FluxML/Zygote.jl/issues/1126 . Needs more benchmarking, to see if this slows down other things.

Here's one way to get awful results:
```
julia> @btime gradient((x,y) -> sum(sqrt.(x./2 .+ y) .- y' .+ 10 .* x.^2), $(rand(100)), $(rand(100)));
  min 6.625 μs, mean 19.931 μs (22 allocations, 167.00 KiB)   # 0.6.33
  min 43.125 μs, mean 56.539 μs (24 allocations, 167.02 KiB)  # PR
  min 131.416 μs, mean 142.481 μs (27 allocations, 167.06 KiB)  # julia -O1, and Zygote 0.6.33
```
I suspect for this to be useful, you would have to partition the package into sub-modules, only some of which are `-O1`. It seems quite messy to do that.