### PR TITLE
`ntuple` for `_restore` regardless of length

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -184,7 +184,7 @@ _tryreverse(m::typeof(map), x::Union{AbstractVector, Tuple}) = reverse(x)
 _tryaxes(x) = axes(x)
 _tryaxes(x::Tuple) = Val(length(x))
 _restore(dx, ax::Tuple) = axes(dx) == ax ? dx : reshape(vcat(dx, falses(prod(length, ax) - length(dx))), ax)
-_restore(dx, ::Val{N}) where {N} = length(dx) < N ? ntuple(i -> get(dx,i,nothing), N) : NTuple{N}(dx)
+_restore(dx, ::Val{N}) where {N} = ntuple(i -> get(dx,i,nothing), N)
 
 # Sometimes a pullback doesn't return a Tuple, but rather returns only a
 # single nothing to say "all arguments have zero cotangent". This function is needed to

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -1961,3 +1961,19 @@ end
   @test g1[1].A isa Number
   @test size(g1[2]) == size(V)
 end
+
+@testset "Zygote #1162" begin
+  function zygote1162(as, bs)
+      results = [f1162(a, b) for (a, b) in zip(as, bs)]
+      return results[2][1] + results[2][2]
+  end
+  function f1162(a, b)
+      return [a^2, b^2]
+  end
+
+  as = (1.0, 2.0, 3.0)
+  bs = (4.0, 5.0, 6.0)
+
+  g = Zygote.gradient(zygote1162, as, bs)
+  @test g == ((nothing, 2*as[2], nothing), (nothing, 2*bs[2], nothing))
+end

--- a/test/lib/array.jl
+++ b/test/lib/array.jl
@@ -6,7 +6,3 @@ using Zygote: ZygoteRuleConfig
 
 test_rrule(ZygoteRuleConfig(), x->sum(sin, Diagonal(x)), ones(2); rrule_f=rrule_via_ad, check_inferred=false)
 test_rrule(ZygoteRuleConfig(), x->sum(sin, Diagonal(x)), rand(3); rrule_f=rrule_via_ad, check_inferred=false)
-
-# issue 44179
-
-@test Zygote._restore([nothing, 1, nothing], Val(3)) == (nothing, 1, nothing)

--- a/test/lib/array.jl
+++ b/test/lib/array.jl
@@ -6,3 +6,7 @@ using Zygote: ZygoteRuleConfig
 
 test_rrule(ZygoteRuleConfig(), x->sum(sin, Diagonal(x)), ones(2); rrule_f=rrule_via_ad, check_inferred=false)
 test_rrule(ZygoteRuleConfig(), x->sum(sin, Diagonal(x)), rand(3); rrule_f=rrule_via_ad, check_inferred=false)
+
+# issue 44179
+
+@test Zygote._restore([nothing, 1, nothing], Val(3)) == (nothing, 1, nothing)


### PR DESCRIPTION
This is a fix for #1162 by removing the ternary check in `_restore` to see if the length of `dx` is less than the length of the tuple and always using `ntuple` instead of `NTuple{N}`. 

As far as I can tell the behavior of `_restore` should be unchanged, since if `length(dx) < N` the code path is the same, whereas if `length(dx) >= N` we still retrieve the first `N` elements of `dx`. 