### PR TITLE
Fix adjoint Iterators.product behavior with nothing

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -286,8 +286,11 @@ _ndims(x) = Base.IteratorSize(x) isa Base.HasShape ? _ndims(Base.IteratorSize(x)
   function back(dy::AbstractArray)
     d = 1
     ntuple(length(xs)) do n
-      first(dy)[n] === nothing && return nothing
       nd = _ndims(xs[n])
+      if first(dy)[n] === nothing
+        d += nd
+        return nothing
+      end
       dims = ntuple(i -> i<d ? i : i+nd, ndims(dy)-nd)
       d += nd
       init = zero.(first(dy)[n]) # allows for tuples, which accum can add:

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -287,12 +287,9 @@ _ndims(x) = Base.IteratorSize(x) isa Base.HasShape ? _ndims(Base.IteratorSize(x)
     d = 1
     ntuple(length(xs)) do n
       nd = _ndims(xs[n])
-      if first(dy)[n] === nothing
-        d += nd
-        return nothing
-      end
       dims = ntuple(i -> i<d ? i : i+nd, ndims(dy)-nd)
       d += nd
+      first(dy)[n] === nothing && return nothing
       init = zero.(first(dy)[n]) # allows for tuples, which accum can add:
       red = mapreduce(StaticGetter{n}(), accum, dy; dims=dims, init=init)
       return _project(xs[n], reshape(red, axes(xs[n])))

--- a/test/lib/array.jl
+++ b/test/lib/array.jl
@@ -1,8 +1,16 @@
 using ChainRulesTestUtils
 using LinearAlgebra
-using Zygote: ZygoteRuleConfig
+using Zygote: ZygoteRuleConfig, _pullback
 
 # issue 897
 
 test_rrule(ZygoteRuleConfig(), x->sum(sin, Diagonal(x)), ones(2); rrule_f=rrule_via_ad, check_inferred=false)
 test_rrule(ZygoteRuleConfig(), x->sum(sin, Diagonal(x)), rand(3); rrule_f=rrule_via_ad, check_inferred=false)
+
+@testset "adjoints of Iterators.product" begin
+    y, back = _pullback(Iterators.product, 1:5, 1:3, 1:2)
+    @test back(collect(y)) == (nothing, [6.0, 12.0, 18.0, 24.0, 30.0], [10.0, 20.0, 30.0], [15.0, 30.0])
+    @test back([(nothing, j, k) for i in 1:5, j in 1:3, k in 1:2]) == (nothing, nothing, [10.0, 20.0, 30.0], [15.0, 30.0])
+    @test back([(i, nothing, k) for i in 1:5, j in 1:3, k in 1:2]) == (nothing, [6.0, 12.0, 18.0, 24.0, 30.0], nothing, [15.0, 30.0])
+    @test back([(i, j, nothing) for i in 1:5, j in 1:3, k in 1:2]) == (nothing, [6.0, 12.0, 18.0, 24.0, 30.0], [10.0, 20.0, 30.0], nothing)
+end

--- a/test/lib/array.jl
+++ b/test/lib/array.jl
@@ -13,4 +13,8 @@ test_rrule(ZygoteRuleConfig(), x->sum(sin, Diagonal(x)), rand(3); rrule_f=rrule_
     @test back([(nothing, j, k) for i in 1:5, j in 1:3, k in 1:2]) == (nothing, nothing, [10.0, 20.0, 30.0], [15.0, 30.0])
     @test back([(i, nothing, k) for i in 1:5, j in 1:3, k in 1:2]) == (nothing, [6.0, 12.0, 18.0, 24.0, 30.0], nothing, [15.0, 30.0])
     @test back([(i, j, nothing) for i in 1:5, j in 1:3, k in 1:2]) == (nothing, [6.0, 12.0, 18.0, 24.0, 30.0], [10.0, 20.0, 30.0], nothing)
+
+    # This was wrong before https://github.com/FluxML/Zygote.jl/pull/1170
+    @test gradient(x -> sum([y[2] * y[3] for y in Iterators.product(x, x, x, x)]), [1,2,3,4])[1] ≈ [320, 320, 320, 320]
+    @test gradient(x -> sum(y[2] * y[3] for y in Iterators.product(x, x, x, x)), [1,2,3,4])[1] ≈ [320, 320, 320, 320]
 end


### PR DESCRIPTION
Hi,
This PR fixes the issue illustrated below where a `DimesionMismatch` occurs depending on the position of nothing arguments to the pullback of `Iterators.product`.
```julia
using Zygote

function aget()
    y, back = Zygote._pullback(Iterators.product, 1:5, 1:3, 1:2)
end

function atest0()
    y, back = aget()
    t0 = [(i, j, k) for i in 1:5, j in 1:3, k in 1:2]
    back(t0)
    # OK
end
function atest1()
    y, back = aget()
    t1 = [(nothing, j, k) for i in 1:5, j in 1:3, k in 1:2]
    back(t1)
    # ERROR: DimensionMismatch("new dimensions (3,) must be consistent with array size 5")
end
function atest2()
    y, back = aget()
    t2 = [(i, nothing, k) for i in 1:5, j in 1:3, k in 1:2]
    back(t2)
    # ERROR: DimensionMismatch("new dimensions (2,) must be consistent with array size 3")
end
function atest3()
    y, back = aget()
    t3 = [(i, j, nothing) for i in 1:5, j in 1:3, k in 1:2]
    back(t3)
    # OK
end
function atest4()
    y, back = aget()
    t4 = [(nothing, nothing, k) for i in 1:5, j in 1:3, k in 1:2]
    back(t4)
    # ERROR: DimensionMismatch("new dimensions (2,) must be consistent with array size 5")
end
function atest5()
    y, back = aget()
    t5 = [(nothing, j, nothing) for i in 1:5, j in 1:3, k in 1:2]
    back(t5)
    # ERROR: DimensionMismatch("new dimensions (3,) must be consistent with array size 5")
end
function atest6()
    y, back = aget()
    t6 = [(i, nothing, nothing) for i in 1:5, j in 1:3, k in 1:2]
    back(t6)
    # OK
end
function atest7()
    y, back = aget()
    t7 = [(nothing, nothing, nothing) for i in 1:5, j in 1:3, k in 1:2]
    back(t7)
    # OK
end
```
I hope this PR enforces the desired behavior of the pullback in this edge case, but I don't know enough about Zygote to understand where the `nothing` arguments are originating from (I noticed this bug while trying to differentiate some other code).
I can reference:
- https://github.com/FluxML/Zygote.jl/issues/421
- https://github.com/FluxML/Zygote.jl/pull/785

With this PR, the results of the tests defined above are:
```julia
julia> atest0()
(nothing, [6.0, 12.0, 18.0, 24.0, 30.0], [10.0, 20.0, 30.0], [15.0, 30.0])

julia> atest1()
(nothing, nothing, [10.0, 20.0, 30.0], [15.0, 30.0])

julia> atest2()
(nothing, [6.0, 12.0, 18.0, 24.0, 30.0], nothing, [15.0, 30.0])

julia> atest3()
(nothing, [6.0, 12.0, 18.0, 24.0, 30.0], [10.0, 20.0, 30.0], nothing)

julia> atest4()
(nothing, nothing, nothing, [15.0, 30.0])

julia> atest5()
(nothing, nothing, [10.0, 20.0, 30.0], nothing)

julia> atest6()
(nothing, [6.0, 12.0, 18.0, 24.0, 30.0], nothing, nothing)

julia> atest7()
(nothing, nothing, nothing, nothing)
```