### PR TITLE
ScaledPlan backwards rule

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -814,7 +814,21 @@ end
 @adjoint function \(P::AbstractFFTs.Plan, xs)
   return P \ xs, function(Δ)
     N = prod(size(Δ)[[P.region...]])
-    return (nothing, (P * Δ)/N)
+    return (nothing, (P * Δ) / N)
+  end
+end
+
+@adjoint function *(P::AbstractFFTs.ScaledPlan, xs)
+  return P * xs, function(Δ)
+    N = prod(size(xs)[[P.p.region...]])
+    return (nothing, N * P.scale^2 * (P \ Δ))
+  end
+end
+
+@adjoint function \(P::AbstractFFTs.ScaledPlan, xs)
+  return P \ xs, function(Δ)
+    N = prod(size(xs)[[P.p.region...]])
+    return (nothing, (P * Δ) / (N * P.scale^2))
   end
 end
 


### PR DESCRIPTION
The current adjoint for FFT plans in Zygote doesn't handle `ScaledPlan`s. See for example:

https://github.com/JuliaMath/FFTW.jl/issues/182
https://github.com/SciML/OperatorLearning.jl/issues/11

This issue mostly arises because the inverse plan of e.g. an FFT makes use of `ScaledPlan`. This rule adds a `ScaledPlan` rule, and adds more comprehensive tests which explicitly test every possible forward and inverse plan (and therefore test for the `ScaledPlan` issue that was not being handled previously).

Also, it seems like backwards rules for `fft`s are being moved into `AbstractFFTs.jl` using ChainRules. However, there are no backwards rules there for FFT plans yet, see https://github.com/JuliaMath/AbstractFFTs.jl/issues/63. (The same issue holding that back -- that the type of an FFT plan does not convey enough information for the backwards rule for real FFTs -- leads to a few errored tests in Zygote, which are manually skipped in `gradcheck.jl`). But until that happens, it seems like the rules in Zygote are the only ones that handle FFT plans to at least some extent, so this patch should be helpful until plans are properly handled in `AbstractFFTs.jl`.
