### PR TITLE
Elide stack generation outside of looping control flow

### DIFF
--- a/src/compiler/interface2.jl
+++ b/src/compiler/interface2.jl
@@ -33,10 +33,10 @@ end
   meta, forw, _ = g
   argnames!(meta, Symbol("#self#"), :ctx, :f, :args)
   forw = varargs!(meta, forw, 3)
-  # IRTools.verify(forw)
+  # verify(forw)
   forw = slots!(pis!(inlineable!(forw)))
   # be ready to swap to using chainrule if one is declared
-  cr_edge != nothing && edge!(meta, cr_edge)
+  cr_edge !== nothing && edge!(meta, cr_edge)
   return update!(meta.code, forw)
 end
 
@@ -53,7 +53,7 @@ end
   end
   meta, _, back = g
   argnames!(meta, Symbol("#self#"), :Δ)
-  # IRTools.verify(back)
+  # verify(back)
   back = slots!(inlineable!(back))
   return update!(meta.code, back)
 end

--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -68,6 +68,12 @@ function accum_global(cx::Context, ref, x̄)
   return
 end
 
+# Needed for nested AD
+function _pullback(::typeof(accum_global), cx::Context, ref, x̄)
+  accum_global_pullback(_) = nothing
+  return accum_global(cx, ref, x̄), accum_global_pullback
+end
+
 unwrap(x) = x
 
 @adjoint unwrap(x) = unwrap(x), x̄ -> (accum_param(__context__, x, x̄),)

--- a/test/features.jl
+++ b/test/features.jl
@@ -396,7 +396,7 @@ end == (2,)
 global_param = 3
 
 @testset "Global Params" begin
-  cx = Zygote.Context()
+  cx = Zygote.Context{true}(nothing) # only makes sense with implicit params
   y, back = Zygote._pullback(cx, x -> x*global_param, 2)
   @test y == 6
   @test back(1) == (nothing, 3)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Zygote, Test
 using Zygote: gradient, ZygoteRuleConfig
 using CUDA
 using CUDA: has_cuda
+using LinearAlgebra
 
 @testset "all" begin  # Overall testset ensures it keeps running after failure
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,4 +1,3 @@
-using LinearAlgebra
 using ForwardDiff
 using Zygote: hessian_dual, hessian_reverse
 


### PR DESCRIPTION
This PR ports @Keno's work on https://github.com/FluxML/Zygote.jl/pull/78 to 2022 Zygote.

Because IRTools and base Julia have slightly different IR representations, some tweaks were necessary for the core algorithm:
1. Instead of inserting phi nodes, we need to add block arguments. This is a bit more tedious because it requires updating multiple blocks.
2. On the bright side, we don't need to calculate an iterated dominance frontier for each block. Whether any savings from that are wiped away from calling `IRTools.dominators` I'm not sure.
3. Blocks are iterated over in reverse order. This allows us to iteratively narrow down the number of unaccounted alpha vars. Although `forward_stacks!` now theoretically runs in `O(blocks * alphas)` instead of `O(max(blocks, alphas))` now, in practice the vast majority of alphas will be eliminated very quickly (if not in the first loop iteration).

## Performance Comparison
```julia
using Zygote, BenchmarkTools

function qux(a, b, x) # Simple control flow
   aa = a ? sin(x) : cos(x)
   bb = b ? sech(aa) : tanh(aa)
   return bb
end

foldminus(xs) = Base.afoldl(-, xs...) # afoldl is very branch-heavy

xs = ntuple(identity, 16)
```
```julia-repl
julia> @time gradient(qux, true, false, 1.0);
  0.146199 seconds (60.84 k allocations: 3.519 MiB, 99.73% compilation time) # 0.6.37
  0.135723 seconds (52.94 k allocations: 3.086 MiB, 99.86% compilation time) # This PR

julia> @btime gradient(qux, true, false, 1.0);
  3.378 μs (46 allocations: 1.31 KiB)
  3.044 μs (35 allocations: 720 bytes)

julia> @time gradient(foldminus, xs);
  4.785566 seconds (11.53 M allocations: 616.818 MiB, 2.59% gc time, 99.97% compilation time)
  4.428252 seconds (11.97 M allocations: 660.290 MiB, 3.03% gc time, 99.97% compilation time)

julia> @btime gradient(foldminus, $xs);
  111.256 μs (506 allocations: 20.30 KiB)
  151.316 ns (8 allocations: 848 bytes)
```
The `afoldl` example is particularly interesting because of how that function is [defined](https://github.com/JuliaLang/julia/blob/v1.7.2/base/operators.jl#L608-L647). Despite the presence of a loop at the end, not requiring stacks for the block of conditionals is significantly faster. This could have immediate downstream impact for code like https://github.com/FluxML/Flux.jl/pull/1809#discussion_r777762381.

## Next Steps
The Zygote test suite passes locally for me, so if CI + downstream is green then I think this should be a drop-in replacement for the current compiler code path. Per the comments, more optimizations may be possible for aspects such as calculating self-reachability. After looking through a bunch of IRTools code, there's probably a lot of low hanging fruit to optimize there as well.