### PR TITLE
Remove `cat` adjoint in favour of ChainRules

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Zygote"
 uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
-version = "0.6.38"
+version = "0.6.39"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -116,19 +116,6 @@ pull_block_horz(sz, Δ, A::AbstractMatrix) = Δ[:, sz-size(A, 2)+1:sz]
 end
 @adjoint hcat(xs::Number...) = hcat(xs...), Δ -> (Δ...,)
 
-@adjoint function cat(Xs...; dims)
-  cat(Xs...; dims = dims), Δ -> begin
-    start = ntuple(_ -> 0, ndims(Δ))
-    catdims = Base.dims2cat(dims)
-    dXs = map(Xs) do x
-      move = ntuple(d -> (d<=length(catdims) && catdims[d]) ? size(x,d) : 0, ndims(Δ))
-      x_in_Δ = ntuple(d -> (d<=length(catdims) && catdims[d]) ? (start[d]+1:start[d]+move[d]) : Colon(), ndims(Δ))
-      start = start .+ move
-      dx = Δ[x_in_Δ...]
-    end
-  end
-end
-
 @adjoint function repeat(xs; inner=ntuple(_->1, ndims(xs)), outer=ntuple(_->1, ndims(xs)))
   repeat(xs, inner = inner, outer = outer), function (Δ)
     Δ′ = zero(xs)


### PR DESCRIPTION
Now that this has been effectively superseded by https://github.com/JuliaDiff/ChainRules.jl/blob/v1.28.2/src/rulesets/Base/array.jl#L345, we can ease some of our maintenance burden. I've kept the tests around for now.