### PR TITLE
Make chunk threshold configurable

### DIFF
--- a/src/lib/forward.jl
+++ b/src/lib/forward.jl
@@ -131,7 +131,7 @@ end
 forwarddiff(f, x; chunk_threshold = ForwardDiff.DEFAULT_CHUNK_THRESHOLD) = f(x)
 
 @adjoint function forwarddiff(f, x; chunk_threshold = ForwardDiff.DEFAULT_CHUNK_THRESHOLD)
-    y, J = forward_jacobian(f, x; chunk_threshold)
+    y, J = forward_jacobian(f, x; chunk_threshold = chunk_threshold)
     return y, ȳ -> (nothing, reshape_scalar(x, J * vec_scalar(ȳ)))
 end
 

--- a/src/lib/forward.jl
+++ b/src/lib/forward.jl
@@ -131,11 +131,11 @@ end
 forwarddiff(f, x; chunk_threshold = ForwardDiff.DEFAULT_CHUNK_THRESHOLD) = f(x)
 
 @adjoint function forwarddiff(f, x; chunk_threshold = ForwardDiff.DEFAULT_CHUNK_THRESHOLD)
-    y, J = forward_jacobian(f, x; chunk_threshold = chunk_threshold)
-    return y, ȳ -> (nothing, reshape_scalar(x, J * vec_scalar(ȳ)))
+  y, J = forward_jacobian(f, x; chunk_threshold = chunk_threshold)
+  return y, ȳ -> (nothing, reshape_scalar(x, J * vec_scalar(ȳ)))
 end
 
-# Use this to allow second derivatives -- this is forward-over-forward, 
+# Use this to allow second derivatives -- this is forward-over-forward,
 # see  https://github.com/FluxML/Zygote.jl/issues/769  for a forward-over-reverse proposal
 @adjoint ForwardDiff.gradient(f, x) = pullback(forwarddiff, x -> ForwardDiff.gradient(f, x), x)
 @adjoint ForwardDiff.jacobian(f, x) = pullback(forwarddiff, x -> ForwardDiff.jacobian(f, x), x)

--- a/test/features.jl
+++ b/test/features.jl
@@ -379,7 +379,7 @@ end == (10,)
   for chunk_threshold in 1:10:100
     x = [1:100;]
     @test gradient(x) do x
-      Zygote.forwarddiff(x -> x' * x, x; chunk_threshold)
+      Zygote.forwarddiff(x -> x' * x, x; chunk_threshold = chunk_threshold)
     end == (2 * x,)
   end
 end

--- a/test/features.jl
+++ b/test/features.jl
@@ -375,6 +375,16 @@ end == (1,)
   forwarddiff(x -> x^2, x)
 end == (10,)
 
+@testset "Gradient chunking" begin
+  for chunk_threshold in 1:10:100
+    x = [1:100;]
+    @test gradient(x) do x
+      Zygote.forwarddiff(x -> x' * x, x; chunk_threshold)
+    end == (2 * x,)
+  end
+end
+
+
 @test gradient(1) do x
   if true
   elseif true


### PR DESCRIPTION
This exposes the chunk threshold as an option of `Zygote.forwarddiff`.