### PR TITLE
Correct spelling mistake

### DIFF
--- a/docs/src/adjoints.md
+++ b/docs/src/adjoints.md
@@ -2,7 +2,7 @@
 
 !!! note "Prefer to use ChainRulesCore to define custom adjoints"
     Zygote supports the use of [ChainRulesCore](http://www.juliadiff.org/ChainRulesCore.jl/stable/) to define custom sensitivities.
-    It is prefered to define the custom sensitivities using `ChainRulesCore.rrule` as they will work for many AD systems, not just Zygote.
+    It is preferred to define the custom sensitivities using `ChainRulesCore.rrule` as they will work for many AD systems, not just Zygote.
     These sensitivities can be added in your own package, or for Base/StdLib functions they can be added to [ChainRules.jl](https://github.com/JuliaDiff/ChainRules.jl/).
     To define custom sensitivities using ChainRulesCore, define a `ChainRulesCore.rrule(f, args...; kwargs...)`. Head to [ChainRules project's documentation](https://www.juliadiff.org/ChainRulesCore.jl/stable/) for more information.
     **If you are defining your custom adjoints using ChainRulesCore then you do not need to read this page**, and can consider it as documenting a legacy feature.


### PR DESCRIPTION
Correct spelling mistake