### PR TITLE
Remove unnecessary generated functions

### DIFF
--- a/src/tools/builtins.jl
+++ b/src/tools/builtins.jl
@@ -3,7 +3,7 @@ macro __new__(T, args...)
 end
 
 macro __splatnew__(T, args)
-  esc(Expr(:new, T, args))
+  esc(Expr(:splatnew, T, args))
 end
 
 @inline __new__(T, args...) = @__splatnew__(T, args)

--- a/src/tools/builtins.jl
+++ b/src/tools/builtins.jl
@@ -1,16 +1,13 @@
-@generated function __new__(T, args...)
-  quote
-    Base.@_inline_meta
-    $(Expr(:new, :T, [:(args[$i]) for i = 1:length(args)]...))
-  end
+macro __new__(T, args...)
+  esc(Expr(:new, T, args...))
 end
 
-@generated function __splatnew__(T, args)
-  quote
-    Base.@_inline_meta
-    $(Expr(:splatnew, :T, :args))
-  end
+macro __splatnew__(T, args)
+  esc(Expr(:new, T, args))
 end
+
+@inline __new__(T, args...) = @__splatnew__(T, args)
+@inline __splatnew__(T, args) = @__splatnew__(T, args)
 
 literal_getindex(x, ::Val{i}) where i = getindex(x, i)
 literal_indexed_iterate(x, ::Val{i}) where i = Base.indexed_iterate(x, i)


### PR DESCRIPTION
I could be wrong here, but I suspect that it's completely unnecessary for `__new__` and `__splatnew__` to be `@generated` functions, and their presence likely has a negative impact on the compiler heuristics as they apply to Zygote, since it has to compile a generated function for every combination of types and arguments. 

I've replaced them with just regular functions that use macros instead. I suspect these functions could even be marked `@nospecialize` since all they're meant to do is forward their arguments to the macro and then julia's builtin `:new` and `:splatnew` can handle the rest. 