### PR TITLE
Make LogExpFunctions a proper dependency and clean adjoints

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Zygote"
 uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
-version = "0.6.40"
+version = "0.6.41"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
@@ -13,6 +13,7 @@ ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 IRTools = "7869d1d1-7146-5819-86e3-90919afe41df"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 NaNMath = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -31,11 +32,11 @@ DiffRules = "1.0"
 FillArrays = "0.8, 0.9, 0.10, 0.11, 0.12, 0.13"
 ForwardDiff = "0.10"
 IRTools = "0.4.4"
+LogExpFunctions = "0.3.1"
 MacroTools = "0.5"
 NaNMath = "0.3, 1"
 Requires = "1.1"
 SpecialFunctions = "1.6, 2"
-StatsFuns = "0.9.8"
 ZygoteRules = "0.2.1"
 julia = "1.3"
 
@@ -45,9 +46,7 @@ ChainRulesTestUtils = "cdddcdb0-9152-4a09-a978-84456f9df70a"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
-LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
-StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ChainRulesTestUtils", "CUDA", "Distances", "FFTW", "FiniteDifferences", "LogExpFunctions", "Test"]
+test = ["ChainRulesTestUtils", "CUDA", "Distances", "FFTW", "FiniteDifferences", "Test"]

--- a/src/Zygote.jl
+++ b/src/Zygote.jl
@@ -41,8 +41,8 @@ include("lib/broadcast.jl")
 include("lib/forward.jl")
 include("lib/utils.jl")
 include("lib/range.jl")
+include("lib/logexpfunctions.jl")
 @init @require Distances="b4f34e82-e78d-54a5-968a-f98e89d6e8f7" include("lib/distances.jl")
-@init @require LogExpFunctions="2ab3a3ac-af41-5b50-aa03-7779005ae688" include("lib/logexpfunctions.jl")
 
 # we need to define this late, so that the genfuncs see lib.jl
 # Move using statements out of this file to help with sysimage building


### PR DESCRIPTION
This PR makes LogExpFunctions a proper dependency and cleans its adjoints (ie, removes everything that is implemented identically or better in LogExpFunctions with ChainRules).

There's no need to hide LogExpFunctions behind a Requires block since it's already an indirect dependency of Zygote via ForwardDiff, DiffRules, and SpecialFunctions.

The remaining adjoints are for broadcasting arrays and/or reuse the primal and hence are potentially more efficient than the CR definitions in LogExpFunctions. I don't think the first ones will be added to LogExpFunctions in the near future (for most scalar functions, e.g. also in ChainRules, no special broadcast rules are implemented and one focus of LogExpFunctions is to keep it lightweight with reasonably low code complexity) but the other optimizations could be added to LogExpFunctions at some point.