### PR TITLE
Add warnings to ForwardDiff functions

### DIFF
--- a/src/lib/forward.jl
+++ b/src/lib/forward.jl
@@ -137,8 +137,28 @@ end
 
 # Use this to allow second derivatives -- this is forward-over-forward,
 # see  https://github.com/FluxML/Zygote.jl/issues/769  for a forward-over-reverse proposal
-@adjoint ForwardDiff.gradient(f, x) = pullback(forwarddiff, x -> ForwardDiff.gradient(f, x), x)
-@adjoint ForwardDiff.jacobian(f, x) = pullback(forwarddiff, x -> ForwardDiff.jacobian(f, x), x)
+@adjoint function ForwardDiff.gradient(f, x)
+  F = typeof(f)
+  Base.issingletontype(F) || @warn """`ForwardDiff.gradient(f, x)` within Zygote cannot track gradients with respect to `f`
+  typeof(f) = $F is not a singleton type""" # maxlog=1 _id=hash(F)
+  pullback(forwarddiff, x -> ForwardDiff.gradient(f, x), x)
+end
 
-@adjoint ForwardDiff.derivative(f, x) = pullback(forwarddiff, x -> ForwardDiff.derivative(f, x), x)
-@adjoint ForwardDiff.hessian(f, x) = pullback(forwarddiff, x -> ForwardDiff.hessian(f, x), x)
+@adjoint function ForwardDiff.jacobian(f::F, x) where F
+  Base.issingletontype(F) || @warn """`ForwardDiff.jacobian(f, x)` within Zygote cannot track gradients with respect to `f`
+  typeof(f) = $F is not a singleton type""" # maxlog=1 _id=hash(F)
+  pullback(forwarddiff, x -> ForwardDiff.jacobian(f, x), x)
+end
+
+@adjoint function ForwardDiff.derivative(f::F, x) where F
+  Base.issingletontype(F) || @warn """`ForwardDiff.derivative(f, x)` within Zygote cannot track gradients with respect to `f`
+  typeof(f) = $F is not a singleton type""" maxlog=1 _id=hash(F)
+  pullback(forwarddiff, x -> ForwardDiff.derivative(f, x), x)
+end
+
+@adjoint function ForwardDiff.hessian(f::F, x) where F
+  Base.issingletontype(F) || @warn """`ForwardDiff.hessian(f, x)` within Zygote cannot track gradients with respect to `f`
+  typeof(f) = $F is not a singleton type""" maxlog=1 _id=hash(F)
+  pullback(forwarddiff, x -> ForwardDiff.hessian(f, x), x)
+end
+

--- a/src/lib/forward.jl
+++ b/src/lib/forward.jl
@@ -139,26 +139,30 @@ end
 # see  https://github.com/FluxML/Zygote.jl/issues/769  for a forward-over-reverse proposal
 @adjoint function ForwardDiff.gradient(f, x)
   F = typeof(f)
-  Base.issingletontype(F) || @warn """`ForwardDiff.gradient(f, x)` within Zygote cannot track gradients with respect to `f`
-  typeof(f) = $F is not a singleton type""" # maxlog=1 _id=hash(F)
+  Base.issingletontype(F) || @warn """`ForwardDiff.gradient(f, x)` within Zygote cannot track gradients with respect to `f`,
+  and `f` appears to be a closure, or a struct with fields (according to `issingletontype(typeof(f))`).
+  typeof(f) = $F""" maxlog=1 _id=hash(F)
   pullback(forwarddiff, x -> ForwardDiff.gradient(f, x), x)
 end
 
 @adjoint function ForwardDiff.jacobian(f::F, x) where F
-  Base.issingletontype(F) || @warn """`ForwardDiff.jacobian(f, x)` within Zygote cannot track gradients with respect to `f`
-  typeof(f) = $F is not a singleton type""" # maxlog=1 _id=hash(F)
+  Base.issingletontype(F) || @warn """`ForwardDiff.jacobian(f, x)` within Zygote cannot track gradients with respect to `f`,
+  and `f` appears to be a closure, or a struct with fields (according to `issingletontype(typeof(f))`).
+  typeof(f) = $F""" maxlog=1 _id=hash(F)
   pullback(forwarddiff, x -> ForwardDiff.jacobian(f, x), x)
 end
 
 @adjoint function ForwardDiff.derivative(f::F, x) where F
-  Base.issingletontype(F) || @warn """`ForwardDiff.derivative(f, x)` within Zygote cannot track gradients with respect to `f`
-  typeof(f) = $F is not a singleton type""" maxlog=1 _id=hash(F)
+  Base.issingletontype(F) || @warn """`ForwardDiff.derivative(f, x)` within Zygote cannot track gradients with respect to `f`,
+  and `f` appears to be a closure, or a struct with fields (according to `issingletontype(typeof(f))`).
+  typeof(f) = $F""" maxlog=1 _id=hash(F)
   pullback(forwarddiff, x -> ForwardDiff.derivative(f, x), x)
 end
 
 @adjoint function ForwardDiff.hessian(f::F, x) where F
-  Base.issingletontype(F) || @warn """`ForwardDiff.hessian(f, x)` within Zygote cannot track gradients with respect to `f`
-  typeof(f) = $F is not a singleton type""" maxlog=1 _id=hash(F)
+  Base.issingletontype(F) || @warn """`ForwardDiff.hessian(f, x)` within Zygote cannot track gradients with respect to `f`,
+  and `f` appears to be a closure, or a struct with fields (according to `issingletontype(typeof(f))`).
+  typeof(f) = $F""" maxlog=1 _id=hash(F)
   pullback(forwarddiff, x -> ForwardDiff.hessian(f, x), x)
 end
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -133,4 +133,13 @@ using ForwardDiff
   g3(x) = sum(abs2,ForwardDiff.jacobian(f,x))
   out,back = Zygote.pullback(g3,[2.0,3.2])
   @test back(1.0)[1] == ForwardDiff.gradient(g3,[2.0,3.2])
+  
+  # From https://github.com/FluxML/Zygote.jl/issues/1218
+  f1218(x::AbstractVector,y::AbstractVector) = sum(x)*sum(y)
+  gradf1218(x,y) = ForwardDiff.gradient(x->f1218(x,y), x)[1]
+  x = [0.1]
+  y = rand(5)
+  @test ForwardDiff.gradient(y->gradf1218(x,y), y) == ones(5)
+  # this returns (nothing,) -- now prints a warning
+  @test_broken Zygote.gradient(y->gradf1218(x,y), y) == ones(5)
 end


### PR DESCRIPTION
This tries to print a warning on any use of `ForwardDiff.gradient` etc. likely to give a wrong answer. Xref discussion in #1218

I don't know of any functions which give wrong results without triggering this. It's easy to invent examples which trigger it without giving wrong results, but whether they happen in the wild I'm not sure. It we were more sure about this, they could be made errors.