### PR TITLE
Use CR adjoint for `logdet(::Cholesky)`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.3' # Replace this with the minimum Julia version that your package supports.
+          - '1.6' # Replace this with the minimum Julia version that your package supports.
           - '1'   # automatically expands to the latest stable 1.x release of Julia
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 
 [compat]
 AbstractFFTs = "0.5, 1.0"
-ChainRules = "1.31"
+ChainRules = "1.33"
 ChainRulesCore = "1.9"
 ChainRulesTestUtils = "1"
 DiffRules = "1.0"

--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 
 [compat]
 AbstractFFTs = "0.5, 1.0"
-ChainRules = "1.5"
+ChainRules = "1.31"
 ChainRulesCore = "1.9"
 ChainRulesTestUtils = "1"
 DiffRules = "1.0"
@@ -37,7 +37,7 @@ Requires = "1.1"
 SpecialFunctions = "1.6, 2"
 StatsFuns = "0.9.8"
 ZygoteRules = "0.2.1"
-julia = "1.3"
+julia = "1.6"
 
 [extras]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -741,12 +741,6 @@ end
   end
 end
 
-@adjoint function logdet(C::Cholesky)
-  return logdet(C), function(Δ)
-    return ((uplo=nothing, info=nothing, factors=Diagonal(2 .* Δ ./ diag(C.factors))),)
-  end
-end
-
 @adjoint function Matrix(S::UniformScaling, i::Integer, j::Integer)
   return Matrix(S, i, j), Δ -> ((λ=tr(Δ),), nothing, nothing)
 end


### PR DESCRIPTION
Once https://github.com/JuliaDiff/ChainRules.jl/pull/613 is merged, the Zygote adjoint for `logdet(::Cholesky)` can be removed. (FYI the CR PR also adds a rule for `det(::Cholesky)` and hence fixes some existing issues since no such rule exists in Zygote.)

Unfortunately, using this CR rule requires updating the Julia compat entry from 1.3 to 1.6. According to the [RegistryCI docs](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/#New-versions-of-existing-packages) a patch release may not narrow the compat range for Julia. Hence you might want to postpone this PR until the next breaking release of Zygote.