### PR TITLE
deprecate `dropgrad` and `ignore`

### DIFF
--- a/docs/src/utils.md
+++ b/docs/src/utils.md
@@ -20,7 +20,6 @@ Zygote.@showgrad
 Zygote.hook
 Zygote.Buffer
 Zygote.forwarddiff
-Zygote.ignore
 Zygote.checkpointed
 ```
 

--- a/docs/src/utils.md
+++ b/docs/src/utils.md
@@ -18,7 +18,6 @@ Zygote.withgradient
 Zygote.withjacobian
 Zygote.@showgrad
 Zygote.hook
-Zygote.dropgrad
 Zygote.Buffer
 Zygote.forwarddiff
 Zygote.ignore

--- a/docs/src/utils.md
+++ b/docs/src/utils.md
@@ -13,6 +13,10 @@ Zygote also provides a set of helpful utilities. These are all "user-level" tool
 in other words you could have written them easily yourself, but they live in
 Zygote for convenience.
 
+See `ChainRules.ignore_derivatives` if you want to exclude some of your code from the
+gradient calculation. This replaces previous Zygote-specific `ignore` and `dropgrad`
+functionality.
+
 ```@docs
 Zygote.withgradient
 Zygote.withjacobian

--- a/src/Zygote.jl
+++ b/src/Zygote.jl
@@ -18,6 +18,7 @@ export rrule_via_ad
 
 const Numeric{T<:Number} = Union{T, AbstractArray{<:T}}
 
+include("deprecated.jl")
 include("tools/buffer.jl")
 include("tools/builtins.jl")
 

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,0 +1,15 @@
+"""
+    dropgrad(x) -> x
+
+Drop the gradient of `x`.
+
+    julia> gradient(2, 3) do a, b
+         dropgrad(a)*b
+       end
+    (nothing, 2)
+"""
+function dropgrad end
+
+@adjoint dropgrad(x) = dropgrad(x), _ -> nothing
+
+Base.@deprecate dropgrad(x) ChainRulesCore.ignore_derivatives(x)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -13,3 +13,39 @@ function dropgrad end
 @adjoint dropgrad(x) = dropgrad(x), _ -> nothing
 
 Base.@deprecate dropgrad(x) ChainRulesCore.ignore_derivatives(x)
+
+
+"""
+    ignore() do
+      ...
+    end
+
+Tell Zygote to ignore a block of code. Everything inside the `do` block will run
+on the forward pass as normal, but Zygote won't try to differentiate it at all.
+This can be useful for e.g. code that does logging of the forward pass.
+
+Obviously, you run the risk of incorrect gradients if you use this incorrectly.
+"""
+function ignore end
+
+@adjoint ignore(f) = ignore(f), _ -> nothing
+
+Base.@deprecate ignore(f) ChainRulesCore.ignore_derivatives(f)
+
+"""
+    @ignore (...)
+
+Tell Zygote to ignore an expression. Equivalent to `ignore() do (...) end`.
+Example:
+
+```julia-repl
+julia> f(x) = (y = Zygote.@ignore x; x * y);
+julia> f'(1)
+1
+```
+"""
+macro ignore(ex)
+    return :(Zygote.ignore() do
+        $(esc(ex))
+    end)
+end

--- a/src/lib/utils.jl
+++ b/src/lib/utils.jl
@@ -1,36 +1,4 @@
 """
-    ignore() do
-      ...
-    end
-
-Tell Zygote to ignore a block of code. Everything inside the `do` block will run
-on the forward pass as normal, but Zygote won't try to differentiate it at all.
-This can be useful for e.g. code that does logging of the forward pass.
-
-Obviously, you run the risk of incorrect gradients if you use this incorrectly.
-"""
-ignore(f) = f()
-@adjoint ignore(f) = ignore(f), _ -> nothing
-
-"""
-    @ignore (...)
-
-Tell Zygote to ignore an expression. Equivalent to `ignore() do (...) end`.
-Example:
-
-```julia-repl
-julia> f(x) = (y = Zygote.@ignore x; x * y);
-julia> f'(1)
-1
-```
-"""
-macro ignore(ex)
-    return :(Zygote.ignore() do
-        $(esc(ex))
-    end)
-end
-
-"""
     hook(x̄ -> ..., x) -> x
 
 Gradient hooks. Allows you to apply an arbitrary function to the gradient for

--- a/src/lib/utils.jl
+++ b/src/lib/utils.jl
@@ -1,17 +1,4 @@
 """
-    dropgrad(x) -> x
-
-Drop the gradient of `x`.
-
-    julia> gradient(2, 3) do a, b
-         dropgrad(a)*b
-       end
-    (nothing, 2)
-"""
-dropgrad(x) = x
-@adjoint dropgrad(x) = dropgrad(x), _ -> nothing
-
-"""
     ignore() do
       ...
     end

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -1,0 +1,10 @@
+@test_deprecated dropgrad(1)
+@test_deprecated ignore(1)
+@test_deprecated Zygote.@ignore x=1
+
+@test gradient(x -> Zygote.ignore(() -> x*x), 1) == (nothing,)
+@test gradient(x -> Zygote.@ignore(x*x), 1) == (nothing,)
+@test gradient(1) do x
+  y = Zygote.@ignore x
+  x * y
+end == (1,)

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -1681,14 +1681,6 @@ end
   @test gradient(x -> findfirst(ismissing, x), [1, missing]) == (nothing,)
   @test gradient(x -> findlast(ismissing, x), [1, missing]) == (nothing,)
   @test gradient(x -> findall(ismissing, x)[1], [1, missing]) == (nothing,)
-
-
-  @test gradient(x -> Zygote.ignore(() -> x*x), 1) == (nothing,)
-  @test gradient(x -> Zygote.@ignore(x*x), 1) == (nothing,)
-  @test gradient(1) do x
-    y = Zygote.@ignore x
-    x * y
-  end == (1,)
 end
 
 @testset "fastmath" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,6 +14,10 @@ using CUDA: has_cuda
     @warn "CUDA not found - Skipping CUDA Tests"
   end
 
+  @testset "deprecated.jl" begin
+    include("deprecated.jl")
+  end
+
   @testset "Interface" begin
     include("interface.jl")
   end


### PR DESCRIPTION
Contributes to #1235 

I'll do `nograd` separately since it is used for a few adjoints that may need to be ported first.