### PR TITLE
Improved type stability with explicit params

### DIFF
--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -4,6 +4,9 @@ using Core: Typeof
 import Base: copy!, IdSet
 import Base.Broadcast: broadcasted, materialize!
 
+# Internal container used to track accumulated gradients of mutable types (including params).
+# Type param I ∈ (true, false) indicates whether implicit params are in use.
+# By default, this should be false unless pullback(f, ::Params) is called.
 mutable struct Context{I} <: AContext
   cache::Union{IdDict{Any,Any},Nothing}
 end
@@ -47,11 +50,11 @@ function pullback(cx::Context, f, args...)
     Incorrect argument order for pullback, please use:
 
       pullback(f, __context__::Context, args)
-    
+
     instead of:
 
       pullback(__context__::Context, f, args)
-    
+
     This is usually caused by a call to pullback in a higher-order @adjoint.
     The above warning will become an error in Zygote 0.7.
     """

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -310,7 +310,7 @@ end
 
 @adjoint function sum(f, xs::AbstractArray{<:AbstractArray}; kws...)
   @assert !haskey(kws, :init) # TODO add init support (julia 1.6)
-  return pullback(__context__, (f, xs) -> sum(f.(xs); kws...), f, xs)
+  return pullback((f, xs) -> sum(f.(xs); kws...), __context__, f, xs)
 end
 
 @adjoint function sum(xs::AbstractArray{Bool}; dims = :)
@@ -318,7 +318,7 @@ end
 end
 
 function _pullback(cx::AContext, ::typeof(prod), f, xs::AbstractArray)
-  y, back = pullback(cx, ((f, xs) -> prod(f.(xs))), f, xs)
+  y, back = pullback((f, xs) -> prod(f.(xs)), cx, f, xs)
   y, ȳ -> (nothing, back(ȳ)...)
 end
 

--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -21,7 +21,7 @@ accum(x, y) =
 
 accum(x, y, zs...) = accum(accum(x, y), zs...)
 
-accum(x::Tuple, ys::Tuple...) = accum.(x, ys...)
+accum(x::Tuple, ys::Tuple...) = map(accum, x, ys...)
 accum(x::AbstractArray, ys::AbstractArray...) = accum.(x, ys...)
 
 @generated function accum(x::NamedTuple, y::NamedTuple)
@@ -48,6 +48,7 @@ end
 
 @adjoint Base.typeassert(x, T) = Base.typeassert(x, T), Δ -> (Δ, nothing)
 
+accum_param(::Context{false}, _, Δ) = Δ
 @generated function accum_param(cx::Context, x, Δ)
   isbitstype(x) && return :(Δ)
   quote


### PR DESCRIPTION
We can disable accumulating (implicit) parameters to the gradient cache in explicit mode. This can dramatically improve type stability because `accum_param` will return a `Union{Nothing, [grad type]}` otherwise.

One impact of this PR is that taking gradients of functions with both implicit and explicit parameters (i.e. calling `pullback` twice) may involve some additional compilation. However, given that we're trying to move users off of using implicit params anyhow, I see it as a small price to pay for being friendlier to the compiler.

Benchmarking TTFG on the MWE in https://github.com/FluxML/Zygote.jl/issues/1126, modified to use explicit params:
```julia-repl
julia> @time loss_grad(model, lr_images)
 85.027100 seconds (61.36 M allocations: 3.216 GiB, 1.17% gc time, 99.98% compilation time) # 0.6.40
 59.024238 seconds (60.72 M allocations: 3.174 GiB, 1.69% gc time, 99.98% compilation time) # this PR
```

Closes #1243.