### PR TITLE
Run doctests only once

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,7 +8,7 @@ using Documenter, Zygote
 
 makedocs(
   sitename="Zygote",
-  doctest = true,
+  doctest = false,
   pages = [
         "Home" => "index.md",
         "Custom Adjoints" => "adjoints.md",


### PR DESCRIPTION
Closes #1199 

The doctests right now run twice, as described in the issue.

This PR - 

- switches off the doctests while building the docs (the doctests still run in a CI step independently).
- reduces the CI time!