### PR TITLE
Remove adjoints for `LowerTriangular` and `UpperTriangular`

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -462,8 +462,6 @@ end
 # LinAlg Matrix Types
 # ===================
 
-@adjoint LinearAlgebra.LowerTriangular(A) = LowerTriangular(A), Δ->(LowerTriangular(Δ),)
-@adjoint LinearAlgebra.UpperTriangular(A) = UpperTriangular(A), Δ->(UpperTriangular(Δ),)
 @adjoint LinearAlgebra.UnitLowerTriangular(A) = UnitLowerTriangular(A), Δ->(UnitLowerTriangular(Δ)-I,)
 @adjoint LinearAlgebra.UnitUpperTriangular(A) = UnitUpperTriangular(A), Δ->(UnitUpperTriangular(Δ)-I,)
 


### PR DESCRIPTION
There are two reasons for this PR:
- These are defined in ChainRules
- Tests are broken on nightly (and apparently also on Julia 1.8-rc1, as [observed upstream](https://github.com/JuliaGaussianProcesses/ApproximateGPs.jl/issues/135)) that point [to a problem in the backward pass for `UpperTriangular`](https://github.com/FluxML/Zygote.jl/runs/7124557589?check_suite_focus=true#step:6:1516), so I'd like to check if it helps to remove the rules from Zygote

There are more definitions that probably could be removed in favour of ChainRules but I wanted to keep the PR simple.
