### PR TITLE
Opt out of CR broadcasting

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Zygote"
 uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
-version = "0.6.41"
+version = "0.6.42"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -19,8 +19,6 @@ function has_chain_rrule(T)
   config_T, arg_Ts = Iterators.peel(T.parameters)
   configured_rrule_m = meta(Tuple{typeof(rrule), config_T, arg_Ts...})
   
-  isnothing(configured_rrule_m) && return false, nothing  # too crude, surely
-  
   if _is_rrule_redispatcher(configured_rrule_m.method)
     # The config is not being used:
     # it is being redispatched without config, so we need the method it redispatches to

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -18,6 +18,9 @@ such that if a suitable rule is defined later, the generated function will recom
 function has_chain_rrule(T)
   config_T, arg_Ts = Iterators.peel(T.parameters)
   configured_rrule_m = meta(Tuple{typeof(rrule), config_T, arg_Ts...})
+  
+  isnothing(configured_rrule_m) && return false, nothing  # too crude, surely
+  
   if _is_rrule_redispatcher(configured_rrule_m.method)
     # The config is not being used:
     # it is being redispatched without config, so we need the method it redispatches to

--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -164,6 +164,12 @@ end
 # https://github.com/FluxML/Zygote.jl/pull/1001 tries to use broadcast_forward (using Dual numbers)
 # whenever possible, this was previously used only for CuArrays. It is usually much faster.
 
+# https://github.com/JuliaDiff/ChainRules.jl/pull/644 implements broadcasting.
+# Its generic rule would be applied before the one defined here, with AbstractArrayStyle
+# @adjoint function broadcasted(::AbstractArrayStyle, f::F, args...) where {F}
+# but does not pass all Zygote's tests. So disable it:
+ChainRulesCore.@opt_out rrule(cfg::ZygoteRuleConfig, ::typeof(Broadcast.broadcasted), f::F, args::Vararg{Any,N}) where {F,N}
+
 @generated inclen(::NTuple{N,Any}) where N = Val(N+1)
 
 # Avoid hitting special cases for `Adjoint` etc.
@@ -283,36 +289,4 @@ using GPUArraysCore  # replaces @require CUDA block, weird indenting to preserve
   end
 
   pull_block_vert(sz, Δ::AbstractGPUArray, A::Number) = @allowscalar Δ[sz]
-
-# ChainRules opt-out
-# =================
-
-# https://github.com/JuliaDiff/ChainRules.jl/pull/644 implements broadcasting.
-# Its generic rule would be applied before the one defined above, with AbstractArrayStyle:
-#   @adjoint function broadcasted(::AbstractArrayStyle, f::F, args...) where {F}
-# but does not pass all Zygote's tests. So disable it:
-ChainRulesCore.@opt_out rrule(cfg::ZygoteRuleConfig, ::typeof(Broadcast.broadcasted), f::F, args::Vararg{Any,N}) where {F,N}
-# That expands to 
-#  rrule(cfg::ZygoteRuleConfig, ::typeof(broadcasted), f::F, args::Vararg{Any, N}) where {F, N}) = nothing
-# which is now ambiguous with many other rrules defined there. So we need more opt-outs:
-
-const _NumericOrBroadcast = Union{Number, AbstractArray{<:Number}, NTuple{<:Any,Number}, Broadcast.Broadcasted}
-
-ChainRulesCore.@opt_out rrule(cfg::ZygoteRuleConfig, ::typeof(broadcasted), ::typeof(+), xs::_NumericOrBroadcast...)
-ChainRulesCore.@opt_out rrule(cfg::ZygoteRuleConfig, ::typeof(broadcasted), ::typeof(-), x::_NumericOrBroadcast, y::_NumericOrBroadcast)
-ChainRulesCore.@opt_out rrule(cfg::ZygoteRuleConfig, ::typeof(broadcasted), ::typeof(-), x::_NumericOrBroadcast)
-ChainRulesCore.@opt_out rrule(cfg::ZygoteRuleConfig, ::typeof(broadcasted), ::typeof(*), x::_NumericOrBroadcast, y::_NumericOrBroadcast)
-ChainRulesCore.@opt_out rrule(cfg::ZygoteRuleConfig, ::typeof(broadcasted), ::typeof(Base.literal_pow), ::typeof(^), x::_NumericOrBroadcast, ::Val{2})
-ChainRulesCore.@opt_out rrule(cfg::ZygoteRuleConfig, ::typeof(broadcasted), ::typeof(/), x::_NumericOrBroadcast, y::Number)
-ChainRulesCore.@opt_out rrule(cfg::ZygoteRuleConfig, ::typeof(broadcasted), ::typeof(identity), x::_NumericOrBroadcast)
-ChainRulesCore.@opt_out rrule(cfg::ZygoteRuleConfig, ::typeof(broadcasted), ::Type{T}, x::_NumericOrBroadcast) where {T<:Number}
-ChainRulesCore.@opt_out rrule(cfg::ZygoteRuleConfig, ::typeof(broadcasted), ::typeof(float), x::_NumericOrBroadcast)
-ChainRulesCore.@opt_out rrule(cfg::ZygoteRuleConfig, ::typeof(broadcasted), ::typeof(conj), x::_NumericOrBroadcast)
-ChainRulesCore.@opt_out rrule(cfg::ZygoteRuleConfig, ::typeof(broadcasted), ::typeof(adjoint), x::_NumericOrBroadcast)
-ChainRulesCore.@opt_out rrule(cfg::ZygoteRuleConfig, ::typeof(broadcasted), ::typeof(conj), x::AbstractArray{<:Real})
-ChainRulesCore.@opt_out rrule(cfg::ZygoteRuleConfig, ::typeof(broadcasted), ::typeof(adjoint), x::AbstractArray{<:Real})
-ChainRulesCore.@opt_out rrule(cfg::ZygoteRuleConfig, ::typeof(broadcasted), ::typeof(real), x::_NumericOrBroadcast)
-ChainRulesCore.@opt_out rrule(cfg::ZygoteRuleConfig, ::typeof(broadcasted), ::typeof(real), x::AbstractArray{<:Real})
-ChainRulesCore.@opt_out rrule(cfg::ZygoteRuleConfig, ::typeof(broadcasted), ::typeof(imag), x::_NumericOrBroadcast)
-ChainRulesCore.@opt_out rrule(cfg::ZygoteRuleConfig, ::typeof(broadcasted), ::typeof(complex), x::_NumericOrBroadcast)
 


### PR DESCRIPTION
This adds an `@opt_out` so as not to use the broadcasting rule defined in https://github.com/JuliaDiff/ChainRules.jl/pull/644.

Without this, the `rrule` for `broadcasted(f, args...)` is applied before the `@adjoint` rule for `broadcasted(:: AbstractArrayStyle , f, args...)`. And then many tests here fail.

To stop the new `rrule` being used on older Zygote versions, I think they will need an upper bound on CR added to the registry. 