### PR TITLE
Fix link in error message

### DIFF
--- a/docs/src/limitations.md
+++ b/docs/src/limitations.md
@@ -33,7 +33,7 @@ the elements of arrays in-place (e.g. setting values with x .= ...)
 Possible fixes:
 - avoid mutating operations (preferred)
 - or read the documentation and solutions for this error
-  https://fluxml.ai/Zygote.jl/dev/limitations.html#Array-mutation
+  https://fluxml.ai/Zygote.jl/latest/limitations
 
 Stacktrace:
   ...
@@ -94,7 +94,7 @@ julia> gradient(rand(3)) do x
        end
 ERROR: Compiling Tuple{typeof(tryme), Vector{Float64}}: try/catch is not supported.
 Refer to the Zygote documentation for fixes.
-https://fluxml.ai/Zygote.jl/dev/limitations.html#try-catch-statements-1
+https://fluxml.ai/Zygote.jl/latest/limitations
 
 Stacktrace:
   ...
@@ -116,7 +116,7 @@ julia> jclock(2)
 julia> gradient(jclock, rand())
 ERROR: Can't differentiate foreigncall expression
 You might want to check the Zygote limitations documentation.
-https://fluxml.ai/Zygote.jl/dev/limitations.html
+https://fluxml.ai/Zygote.jl/latest/limitations
 
 Stacktrace:
   ...

--- a/src/compiler/reverse.jl
+++ b/src/compiler/reverse.jl
@@ -120,7 +120,7 @@ function instrument(ir::IR)
     elseif isexpr(ex, :enter, :leave)
       error("""try/catch is not supported.
             Refer to the Zygote documentation for fixes.
-            https://fluxml.ai/Zygote.jl/dev/limitations.html#Try-catch-statements-1
+            https://fluxml.ai/Zygote.jl/latest/limitations
             """)
     elseif isexpr(ex, :(=))
       @assert ex.args[1] isa GlobalRef
@@ -283,7 +283,7 @@ function adjoint(pr::Primal)
         push!(rb, stmt(xcall(Base, :error, """
                              Can't differentiate $(ex.head) expression.
                              You might want to check the Zygote limitations documentation.
-                             https://fluxml.ai/Zygote.jl/dev/limitations.html
+                             https://fluxml.ai/Zygote.jl/latest/limitations
                              """),
                        line = b[v].line))
       else # A literal value

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -75,7 +75,7 @@ the elements of arrays in place (e.g. setting values with x .= ...)
 Possible fixes:
 - avoid mutating operations (preferred)
 - or read the documentation and solutions for this error
-  https://fluxml.ai/Zygote.jl/dev/limitations.html#Array-mutation-1
+  https://fluxml.ai/Zygote.jl/latest/limitations
 """)
 
 @adjoint! setindex!(xs::AbstractArray, x...) = setindex!(xs, x...),


### PR DESCRIPTION
The link in the error message doesn't work now https://fluxml.ai/Zygote.jl/dev/limitations.html#Array-mutation-1
should be https://fluxml.ai/Zygote.jl/latest/limitations#Array-mutation-1 instead

[Edit: Closes #1260]