### PR TITLE
number adjoints to rrules

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Zygote"
 uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
-version = "0.6.42"
+version = "0.6.43"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/lib/number.jl
+++ b/src/lib/number.jl
@@ -1,29 +1,60 @@
-@adjoint Base.literal_pow(::typeof(^), x::Number, ::Val{p}) where {p} =
-  Base.literal_pow(^,x,Val(p)),
-  Δ -> (nothing, Δ * conj(p * Base.literal_pow(^,x,Val(p-1))), nothing)
-
-@adjoint Base.convert(T::Type{<:Real}, x::Real) = convert(T, x), ȳ -> (nothing, ȳ)
-@adjoint (T::Type{<:Real})(x::Real) = T(x), ȳ -> (nothing, ȳ)
-
-for T in Base.uniontypes(Core.BuiltinInts)
-    @adjoint (::Type{T})(x::Core.BuiltinInts) = T(x), Δ -> (Δ,)
+function ChainRulesCore.rrule(
+    ::ZygoteRuleConfig, ::typeof(Base.literal_pow), ::typeof(^), x::Number, ::Val{p}
+) where {p}
+    function literal_pow_pullback(Δ)
+        dx = Δ * conj(p * Base.literal_pow(^,x,Val(p-1)))
+        return (NoTangent(), NoTangent(), dx, NoTangent())
+    end
+    return Base.literal_pow(^,x,Val(p)), literal_pow_pullback
 end
 
-@adjoint Base.:+(xs::Number...) = +(xs...), Δ -> map(_ -> Δ, xs)
+function ChainRulesCore.rrule(::ZygoteRuleConfig, T::Type{<:Real}, x::Real)
+    Real_pullback(Δ) = (NoTangent(), Δ)
+    return T(x), Real_pullback
+end
 
-@adjoint a // b = (a // b, c̄ -> (c̄ * 1//b, - c̄ * a // b // b))
+for T in Base.uniontypes(Core.BuiltinInts)
+    @eval function ChainRulesCore.rrule(::ZygoteRuleConfig, ::Type{$T}, x::Core.BuiltinInts)
+        IntX_pullback(Δ) = (NoTangent(), Δ)
+        return $T(x), IntX_pullback
+    end
+end
+
+function ChainRulesCore.rrule(::ZygoteRuleConfig, ::typeof(+), xs::Number...)
+    plus_pullback(Δ) = (NoTangent(), map(_ -> Δ, xs)...)
+    return +(xs...), plus_pullback
+end
+
+function ChainRulesCore.rrule(::ZygoteRuleConfig, ::typeof(//), a, b)
+    divide_pullback(r̄) = (NoTangent(), r̄ * 1//b, - r̄ * a // b // b)
+    return a // b, divide_pullback
+end
 
 # Complex Numbers
 
-@adjoint (T::Type{<:Complex})(re, im) = T(re, im), c̄ -> (nothing, real(c̄), imag(c̄))
+function ChainRulesCore.rrule(::ZygoteRuleConfig, T::Type{<:Complex}, r, i)
+    Complex_pullback(c̄) = (NoTangent(), real(c̄), imag(c̄))
+    return T(r, i), Complex_pullback
+end
 
 # we define these here because ChainRules.jl only defines them for x::Union{Real,Complex}
 
-@adjoint abs2(x::Number) = abs2(x), Δ -> (real(Δ)*(x + x),)
-@adjoint real(x::Number) = real(x), r̄ -> (real(r̄),)
-@adjoint conj(x::Number) = conj(x), r̄ -> (conj(r̄),)
-@adjoint imag(x::Number) = imag(x), ī -> (real(ī)*im,)
+function ChainRulesCore.rrule(::ZygoteRuleConfig, ::typeof(abs2), x::Number)
+    abs2_pullback(Δ) = (NoTangent(), real(Δ)*(x + x))
+    return abs2(x), abs2_pullback
+end
 
-# for real x, ChainRules pulls back a zero real adjoint, whereas we treat x
-# as embedded in the complex numbers and pull back a pure imaginary adjoint
-@adjoint imag(x::Real) = zero(x), ī -> (real(ī)*im,)
+function ChainRulesCore.rrule(::ZygoteRuleConfig, ::typeof(real), x::Number)
+    real_pullback(r̄) = (NoTangent(), real(r̄))
+    return real(x), real_pullback
+end
+
+function ChainRulesCore.rrule(::ZygoteRuleConfig, ::typeof(conj), x::Number)
+    conj_pullback(c̄) = (NoTangent(), conj(c̄))
+    return conj(x), conj_pullback
+end
+
+function ChainRulesCore.rrule(::ZygoteRuleConfig, ::typeof(imag), x::Number)
+    imag_pullback(ī) = (NoTangent(), real(ī)*im)
+    return imag(x), imag_pullback
+end

--- a/src/lib/number.jl
+++ b/src/lib/number.jl
@@ -61,6 +61,8 @@ function ChainRulesCore.rrule(::ZygoteRuleConfig, ::typeof(conj), x::Number)
     return conj(x), conj_pullback
 end
 
+# for real x, ChainRules pulls back a zero real adjoint, whereas we treat x
+# as embedded in the complex numbers and pull back a pure imaginary adjoint
 function ChainRulesCore.rrule(::ZygoteRuleConfig, ::typeof(imag), x::Number)
     imag_pullback(ī) = (NoTangent(), real(ī)*im)
     return imag(x), imag_pullback

--- a/src/lib/number.jl
+++ b/src/lib/number.jl
@@ -1,4 +1,11 @@
 function ChainRulesCore.rrule(
+    ::ZygoteRuleConfig, ::typeof(convert), T::Type{<:Real}, x::Real
+)
+    convert_pullback(Δ) = (NoTangent(), NoTangent(), Δ)
+    return convert(T, x), convert_pullback
+end
+
+function ChainRulesCore.rrule(
     ::ZygoteRuleConfig, ::typeof(Base.literal_pow), ::typeof(^), x::Number, ::Val{p}
 ) where {p}
     function literal_pow_pullback(Δ)

--- a/test/lib/number.jl
+++ b/test/lib/number.jl
@@ -1,7 +1,44 @@
-@testset "nograds" begin
-  @test gradient(floor, 1) === (0.0,)
-  @test gradient(ceil, 1) === (0.0,)
-  @test gradient(round, 1) === (0.0,)
-  @test gradient(hash, 1) === nothing
-  @test gradient(div, 1, 2) === nothing
-end #testset
+@testset "number.jl" begin
+  @testset "nograds" begin
+    @test gradient(floor, 1) === (0.0,)
+    @test gradient(ceil, 1) === (0.0,)
+    @test gradient(round, 1) === (0.0,)
+    @test gradient(hash, 1) === nothing
+    @test gradient(div, 1, 2) === nothing
+  end
+
+  @testset "basics" begin
+    @test gradient(Base.literal_pow, ^, 3//2, Val(-5))[2] isa Rational
+
+    @test gradient(convert, Rational, 3.14) == (nothing, 1.0)
+    @test gradient(convert, Rational, 2.3) == (nothing, 1.0)
+    @test gradient(convert, UInt64, 2) == (nothing, 1.0)
+    @test gradient(convert, BigFloat, π) == (nothing, 1.0)
+
+    @test gradient(Rational, 2) == (1//1,)
+
+    @test gradient(Bool, 1) == (1.0,)
+    @test gradient(Int32, 2) == (1.0,)
+    @test gradient(UInt16, 2) == (1.0,)
+
+    @test gradient(+, 2.0, 3, 4.0, 5.0) == (1.0, 1.0, 1.0, 1.0)
+
+    @test gradient(//, 3, 2) == (1//2, -3//4)
+  end
+
+  @testset "Complex numbers" begin
+    @test gradient(imag, 3.0) == (0.0,)
+    @test gradient(imag, 3.0 + 3.0im) == (0.0 + 1.0im,)
+
+    @test gradient(conj, 3.0) == (1.0,)
+    @test gradient(real ∘ conj, 3.0 + 1im) == (1.0 + 0im,)
+
+    @test gradient(real, 3.0) == (1.0,)
+    @test gradient(real, 3.0 + 1im) == (1.0 + 0im,)
+
+    @test gradient(abs2, 3.0) == (2*3.0,)
+    @test gradient(abs2, 3.0+2im) == (2*3.0 + 2*2.0im,)
+
+    @test gradient(real ∘ Complex, 3.0, 2.0) == (1.0, 0.0)
+  end
+end


### PR DESCRIPTION
Translates the `@adjoint`s in number.jl to `rrule`s. Helps with #1209 

```julia
using Zygote, BenchmarkTools

@btime gradient(Base.literal_pow, ^, 3//2, Val(-5));
@btime gradient(convert, Rational, 3.14);
@btime gradient(convert, Rational, 2.3);
@btime gradient(convert, UInt64, 2);
@btime gradient(convert, BigFloat, π);
@btime gradient(Rational, 2);
@btime gradient(Bool, 1);
@btime gradient(Int32, 2);
@btime gradient(UInt16, 2);
@btime gradient(+, 2.0, 3, 4.0, 5.0);
@btime gradient(//, 3, 2);
@btime gradient(imag, 3.0);
@btime gradient(imag, 3.0 + 3.0im);
@btime gradient(conj, 3.0);
@btime gradient(x -> real(conj(x)), 3.0 + 1im);
@btime gradient(real, 3.0);
@btime gradient(real, 3.0 + 1im);
@btime gradient(abs2, 3.0);
@btime gradient(abs2, 3.0+2im);
@btime gradient((r, i) -> real(Complex(r, i)), 3.0, 2.0);
```

Speed comparison (first one main, second one this PR)
```julia
julia> @btime gradient(Base.literal_pow, ^, 3//2, Val(-5));
  237.297 ns (0 allocations: 0 bytes)
  237.116 ns (0 allocations: 0 bytes)

julia> @btime gradient(convert, Rational, 3.14);
  261.813 ns (0 allocations: 0 bytes)
  258.479 ns (0 allocations: 0 bytes)

julia> @btime gradient(convert, Rational, 2.3);
  267.302 ns (0 allocations: 0 bytes)
  268.514 ns (0 allocations: 0 bytes)

julia> @btime gradient(convert, UInt64, 2);
  1.560 ns (0 allocations: 0 bytes)
  1.608 ns (0 allocations: 0 bytes)

julia> @btime gradient(convert, BigFloat, π);
  912.306 ns (14 allocations: 400 bytes)
  970.850 ns (14 allocations: 400 bytes)

julia> @btime gradient(Rational, 2);
  0.044 ns (0 allocations: 0 bytes)
  0.044 ns (0 allocations: 0 bytes)

julia> @btime gradient(Bool, 1);
  1.561 ns (0 allocations: 0 bytes)
  1.560 ns (0 allocations: 0 bytes)

julia> @btime gradient(Int32, 2);
  1.612 ns (0 allocations: 0 bytes)
  1.662 ns (0 allocations: 0 bytes)

julia> @btime gradient(UInt16, 2);
  1.715 ns (0 allocations: 0 bytes)
  1.608 ns (0 allocations: 0 bytes)

julia> @btime gradient(+, 2.0, 3, 4.0, 5.0);
  0.043 ns (0 allocations: 0 bytes)
  0.043 ns (0 allocations: 0 bytes)

julia> @btime gradient(//, 3, 2);
  59.099 ns (0 allocations: 0 bytes)
  58.116 ns (0 allocations: 0 bytes)

julia> @btime gradient(imag, 3.0);
  0.044 ns (0 allocations: 0 bytes)
  0.044 ns (0 allocations: 0 bytes)

julia> @btime gradient(imag, 3.0 + 3.0im);
  0.044 ns (0 allocations: 0 bytes)
  0.044 ns (0 allocations: 0 bytes)

julia> @btime gradient(conj, 3.0);
  0.044 ns (0 allocations: 0 bytes)
  0.044 ns (0 allocations: 0 bytes)

julia> @btime gradient(x -> real(conj(x)), 3.0 + 1im);
  6.281 ns (0 allocations: 0 bytes)
  6.282 ns (0 allocations: 0 bytes)

julia> @btime gradient(real, 3.0);
  0.044 ns (0 allocations: 0 bytes)
  0.043 ns (0 allocations: 0 bytes)

julia> @btime gradient(real, 3.0 + 1im);
  0.044 ns (0 allocations: 0 bytes)
  0.045 ns (0 allocations: 0 bytes)

julia> @btime gradient(abs2, 3.0);
  0.043 ns (0 allocations: 0 bytes)
  0.044 ns (0 allocations: 0 bytes)

julia> @btime gradient(abs2, 3.0+2im);
  0.044 ns (0 allocations: 0 bytes)
  0.044 ns (0 allocations: 0 bytes)

julia> @btime gradient((r, i) -> real(Complex(r, i)), 3.0, 2.0);
  6.281 ns (0 allocations: 0 bytes)
  7.615 ns (0 allocations: 0 bytes)
```

