### PR TITLE
Create PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+<!--
+Thanks for filing a PR! Please delete this comment and describe your change here.
+
+For bugfixes, please detail the bug and include a test case which your patch fixes.
+If you are adding a new feature, please clearly describe the design, its rationale, the possible alternatives considered.
+It is easiest to merge new features when there is clear precedent in other systems; we need to know we're taking
+the right direction since it can be hard to change later.
+
+If you are refactoring an existing, undocumented functionality (including internal functions), please try to document it.
+-->
+
+### PR Checklist
+
+- [ ] Tests are added
+- [ ] Documentation, if applicable


### PR DESCRIPTION
We've had one in Flux for ages, but if anything Zygote needs one more. Ideally it would be possible to do this org-wide, does anyone know if that's possible?