### PR TITLE
Add rule for Dict iteration

### DIFF
--- a/test/lib/base.jl
+++ b/test/lib/base.jl
@@ -10,4 +10,36 @@
 
         @test result1 == result2
     end
+
+    @testset "Dict iteration" begin
+        # https://github.com/FluxML/Zygote.jl/issues/1065
+        function sumkv(d)
+            s = zero(d["c"])
+            for (k, v) in d
+                s += v
+                k == :b && (s += v)
+            end
+            return sum(s)
+        end
+
+        function sumvals(d)
+            s = zero(d["c"])
+            for v in values(d)
+                s += v
+            end
+            return sum(s)
+        end
+
+        d_num = Dict(:a => 3, :b => 4, "c" => 5)
+        d_arr = Dict(:a => [3], :b => [4], "c" => [5])
+        ps = d_arr |> values |> collect |> Params
+
+        @test gradient(sumkv, d_num)[1] == Dict(:a => 1, :b => 2, "c" => 1)
+        grads = gradient(() -> sumkv(d_arr), ps)
+        @test (grads[d_arr[:a]], grads[d_arr[:b]], grads[d_arr["c"]]) == ([1], [2], [1])
+
+        @test gradient(sumvals, d_num)[1] == Dict(:a => 1, :b => 1, "c" => 1)
+        grads = gradient(() -> sumvals(d_arr), ps)
+        @test (grads[d_arr[:a]], grads[d_arr[:b]], grads[d_arr["c"]]) == ([1], [1], [1])
+    end
 end


### PR DESCRIPTION
Fixes the first example in https://github.com/FluxML/Zygote.jl/issues/1065. N.B. that `_pullback` is used over `@adjoint` because we're trying to get rid of it, and over `rrule` because support for Dict tangents in CR is still spotty (+ we don't have to be nearly as general).