### PR TITLE
`@adjoint broadcasted` for unary minus

### DIFF
--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -80,6 +80,8 @@ unbroadcast(x::AbstractArray, x̄::Nothing) = nothing
 
 @adjoint broadcasted(::typeof(-), x::Numeric, y::Numeric) = x .- y,
   Δ -> (nothing, unbroadcast(x, Δ), _minus(unbroadcast(y, Δ)))
+@adjoint broadcasted(::typeof(-), x::Numeric) = .-x,
+  Δ -> (nothing, _minus(Δ))
 _minus(Δ) = -Δ
 _minus(::Nothing) = nothing
 


### PR DESCRIPTION
The absence of this rule means that the one from ChainRules gets called, which is lazier. 

Closes  https://github.com/FluxML/NNlib.jl/issues/432