### PR TITLE
Rewrap Dict Tangents for ChainRules

### DIFF
--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -344,4 +344,8 @@ z2d(dx::NamedTuple{L,S}, primal::AbstractDict) where {L,S<:Tuple{Vararg{Union{Nu
   end
 end
 
+function z2d(dx::AbstractDict, primal::T) where T<:Dict
+      return Tangent{T}(Dict(kk => z2d(dvv, primal[kk]) for (kk, dvv) in dx))
+end
+
 z2d(dx::Ref, primal) = z2d(dx[], primal)  # mutable structs


### PR DESCRIPTION
Can someone link me to the issues about this?

This path isn't well explored in ChainRules, but it is defined.
https://github.com/JuliaDiff/ChainRulesCore.jl/blob/fbb4936204cb1d857c2dd41eac4bd7bf497771b2/src/tangent_types/tangent.jl#L56-L58

This is the code Zygote uses for accumulating,
https://github.com/FluxML/Zygote.jl/blob/c335d6d1e52f6201e8e7c9bf5002193d01eca06b/src/lib/base.jl#L26-L29
which actually looks like it is different to what ChainRulesCore will do?
https://github.com/JuliaDiff/ChainRulesCore.jl/blob/fbb4936204cb1d857c2dd41eac4bd7bf497771b2/src/tangent_types/tangent.jl#L334

TODO:

- [ ] tests