### PR TITLE
Handle nothing grads for `Pairs.data`

### DIFF
--- a/src/lib/base.jl
+++ b/src/lib/base.jl
@@ -162,7 +162,7 @@ function _pullback(cx::AContext, ::typeof(literal_getindex),
                    ps::Iterators.Pairs{<:Any,<:Any,<:Any,<:NamedTuple}, ::Val{K}) where K
   val, gf_back = _pullback(cx, literal_getfield, NamedTuple(ps), Val(K))
   function kwargs_literal_getindex_pullback(Δ)
-    dps = (data = gf_back(Δ)[2], itr = nothing)
+    dps = (data = gradindex(gf_back(Δ), 2), itr = nothing)
     return (nothing, dps, nothing)
   end
   return val, kwargs_literal_getindex_pullback

--- a/test/features.jl
+++ b/test/features.jl
@@ -594,7 +594,7 @@ end
 
   # for when no kwargs have grads backpropogated
   no_kwarg_grad(x; kwargs...) = x[kwargs[:i]]
-  @test gradient(x -> no_kwarg_grad(x; i=1), [1]) == (1,)
+  @test gradient(x -> no_kwarg_grad(x; i=1), [1]) == ([1],)
 end
 
 @testset "Iterators" begin

--- a/test/features.jl
+++ b/test/features.jl
@@ -591,6 +591,10 @@ end
   h(somedata) = g(; somedata...)
   @test gradient(h, (; x=3.0, y=4.0, z=2.3)) == ((x = 2.3, y = nothing, z = 3.0),)
   @test gradient(h, Dict(:x=>3.0, :y=>4.0, :z=>2.3)) == ((y = nothing, z = 3.0, x = 2.3),)
+
+  # for when no kwargs have grads backpropogated
+  no_kwarg_grad(x; kwargs...) = x[kwargs[:i]]
+  @test gradient(x -> no_kwarg_grad(x; i=1), [1]) == (1,)
 end
 
 @testset "Iterators" begin


### PR DESCRIPTION
MWE:
```julia
no_kwarg_grad(x; kwargs...) = x[kwargs[:i]]
gradient(x -> no_kwarg_grad(x; i=1), [1]) # MethodError: no method matching getindex(::Nothing, ::Int64) on master
```
@ChrisRackauckas it also appears that whatever [SciMLSensitivity downstream tests](https://github.com/FluxML/Zygote.jl/blob/master/.github/workflows/Downstream.yml#L25) are running are inadequate to catch stuff like this. In fact, I'm not sure if any _are_ running given that file still reads DiffEqFlux. What should we replace that line with?