### PR TITLE
Unify and simplify adjoints for `pairwise(::Euclidean, ...)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Zygote"
 uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
-version = "0.6.48"
+version = "0.6.49"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/lib/distances.jl
+++ b/src/lib/distances.jl
@@ -69,8 +69,8 @@ _sqrt_if_positive(d, δ) = d > δ ? sqrt(d) : zero(d)
 @adjoint function pairwise(dist::Euclidean, X::AbstractMatrix, Y::AbstractMatrix; dims=2)
   # Modify the forwards-pass slightly to ensure stability on the reverse.
   function _pairwise_euclidean(sqdist::SqEuclidean, X, Y)
-    δ = eps(promote_type(eltype(X), eltype(Y)))^2
     D2 = pairwise(sqdist, X, Y; dims=dims)
+    δ = eps(eltype(D2))
     return _sqrt_if_positive.(D2, δ)
   end
   return pullback(_pairwise_euclidean, SqEuclidean(dist.thresh), X, Y)
@@ -79,8 +79,8 @@ end
 @adjoint function pairwise(dist::Euclidean, X::AbstractMatrix; dims=2)
   # Modify the forwards-pass slightly to ensure stability on the reverse.
   function _pairwise_euclidean(sqdist::SqEuclidean, X)
-    δ = eps(eltype(X))^2
     D2 = pairwise(sqdist, X; dims=dims)
+    δ = eps(eltype(D2))
     return _sqrt_if_positive.(D2, δ)
   end
   return pullback(_pairwise_euclidean, SqEuclidean(dist.thresh), X)

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -1197,10 +1197,21 @@ end
         Δ = randn(P, P)
         X = repeat(randn(rng, D), 1, P)
 
+        # Single input matrix
         Δ_fd = FiniteDifferences.j′vp(
           FiniteDifferences.central_fdm(5, 1), X -> pairwise(metric, X; dims=2), Δ, X
         )
         _, pb = Zygote.pullback(X -> pairwise(metric, X; dims=2), X)
+
+        # This is impressively inaccurate, but at least it doesn't produce a NaN.
+        @test first(Δ_fd) ≈ first(pb(Δ)) atol=1e-3 rtol=1e-3
+
+        # Two input matrices
+        Y = copy(X)
+        Δ_fd = FiniteDifferences.j′vp(
+          FiniteDifferences.central_fdm(5, 1), X -> pairwise(metric, X, Y; dims=2), Δ, X
+        )
+        _, pb = Zygote.pullback(X -> pairwise(metric, X, Y; dims=2), X)
 
         # This is impressively inaccurate, but at least it doesn't produce a NaN.
         @test first(Δ_fd) ≈ first(pb(Δ)) atol=1e-3 rtol=1e-3


### PR DESCRIPTION
Implements the suggestions in https://github.com/FluxML/Zygote.jl/pull/1307#discussion_r976398636 and unifies both `pairwise` adjoints.