### PR TITLE
Free CuArrays in the reverse pass

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -41,7 +41,7 @@ MacroTools = "0.5"
 NaNMath = "0.3, 1"
 Requires = "1.1"
 SpecialFunctions = "1.6, 2"
-ZygoteRules = "0.2.1"
+ZygoteRules = "0.2.3"
 julia = "1.6"
 
 [extras]

--- a/src/Zygote.jl
+++ b/src/Zygote.jl
@@ -4,7 +4,7 @@ using LinearAlgebra, Statistics
 using LinearAlgebra: copytri!, AbstractTriangular
 
 import ZygoteRules: @adjoint, @adjoint!, AContext, adjoint, _pullback, pullback,
-  literal_getproperty, literal_getfield
+  literal_getproperty, literal_getfield, maybe_final
 
 using ChainRulesCore
 using ChainRules: ChainRules, rrule, unthunk, canonicalize

--- a/src/Zygote.jl
+++ b/src/Zygote.jl
@@ -4,7 +4,7 @@ using LinearAlgebra, Statistics
 using LinearAlgebra: copytri!, AbstractTriangular
 
 import ZygoteRules: @adjoint, @adjoint!, AContext, adjoint, _pullback, pullback,
-  literal_getproperty, literal_getfield, maybe_final
+  literal_getproperty, literal_getfield, maybe_final, @adjoint_final
 
 using ChainRulesCore
 using ChainRules: ChainRules, rrule, unthunk, canonicalize

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -209,7 +209,7 @@ end
 @inline (s::ZBack{Nothing})(dy) = wrap_chainrules_output(s.back(wrap_chainrules_input(dy)))
 @inline function (s::ZBack)(dy)
   ∇s = wrap_chainrules_output(s.back(wrap_chainrules_input(dy)))
-  maybe_final(y)
+  maybe_final(s.fwd)
   ∇s
 end
 

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -273,7 +273,7 @@ function ChainRulesCore.rrule_via_ad(config::ZygoteRuleConfig{C}, f_args...; kwa
     free = only_once(C) ? y : nothing
     function ad_pullback(Δ)
       ∇s = zygote2differential(pb(wrap_chainrules_output(Δ)), f_args)
-      maybe_final(@show free)
+      maybe_final(free)
       ∇s
     end
     return y, ad_pullback

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -3,6 +3,7 @@ struct ZygoteRuleConfig{CTX<:AContext} <: RuleConfig{Union{HasReverseMode,NoForw
 end
 ZygoteRuleConfig() = ZygoteRuleConfig(Context())
 
+@inline only_once(::Type{<:AContext}) = false  # can't directly use Context{true,true} as not defined yet
 
 _is_rrule_redispatcher(m::Method) = m.sig == Tuple{typeof(rrule), RuleConfig, Vararg}
 

--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -19,7 +19,7 @@ Context{I,O}() where {I,O} = Context{I,O}(nothing)
 
 cache(cx::Context) = cx.cache === nothing ? (cx.cache = IdDict()) : cx.cache
 
-@inline only_once(::Type{<:Context{true,true}}) = true
+@inline only_once(::Type{<:Context{<:Any,true}}) = true
 
 struct Pullback{S,T}
   t::T
@@ -113,7 +113,7 @@ Base.adjoint(f::Function) = x -> begin  # still piracy! avoids projection for le
 end
 
 # This is inserted into @adjoint_final by ZygoteRules
-@inline maybe_final(::Context{false,true}, x) = maybe_final(x)
+@inline maybe_final(::Context{<:Any,true}, x) = maybe_final(x)
 # The goal is to free CuArrays promptly. 
 @inline maybe_final(x::DenseArray) = finalize(x)
 
@@ -121,7 +121,7 @@ end
 # Can't differentiate foreigncall expression $(Expr(:foreigncall, :(:jl_finalize_th), Nothing
 # And if it in fact finalises, then other 2nd derivative tests fail. So do nothing:
 @adjoint maybe_final(x) = nothing, _ -> nothing
-@adjoint maybe_final(::Context{false,true}, x) = nothing, _ -> nothing
+@adjoint maybe_final(::Context, x) = nothing, _ -> nothing
 
 # Probably just for testing:
 maybe_final(x::Vector) = resize!(x, 0)

--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -112,7 +112,8 @@ Base.adjoint(f::Function) = x -> begin  # still piracy! avoids projection for le
   back(sensitivity(y))[1]
 end
 
-@inline maybe_final(cx, y) = nothing
+# This is inserted into @adjoint by ZygoteRules,
+# which has a 2-arg do-nothing method.
 @inline maybe_final(::Context{false,true}, x) = maybe_final(x)
 # The goal is to free CuArrays promptly. 
 @inline maybe_final(x::DenseArray) = finalize(x)

--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -112,6 +112,23 @@ Base.adjoint(f::Function) = x -> begin  # still piracy! avoids projection for le
   back(sensitivity(y))[1]
 end
 
+@inline maybe_final(cx, y) = nothing
+@inline maybe_final(::Context{false,true}, x) = maybe_final(x)
+# The goal is to free CuArrays promptly. 
+@inline maybe_final(x::DenseArray) = finalize(x)
+# Don't waste time on other things, e.g. @btime finalize(nothing) is about 40ns
+@inline maybe_final(x) = nothing
+
+# Without an @adjoint rule, some hessian tests fail:
+# Can't differentiate foreigncall expression $(Expr(:foreigncall, :(:jl_finalize_th), Nothing
+# And if it in fact finalises, then other 2nd derivative tests fail. So do nothing:
+@adjoint maybe_final(x) = nothing, _ -> nothing
+# @adjoint maybe_final(::Context{false,true}, x) = nothing, _ -> nothing
+
+# Probably just for testing:
+maybe_final(x::Vector) = resize!(x, 0)
+maybe_final(x::Array{<:AbstractFloat}) = fill!(x, NaN) 
+
 """
     withgradient(f, args...)
     withgradient(f, ::Params)

--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -112,19 +112,16 @@ Base.adjoint(f::Function) = x -> begin  # still piracy! avoids projection for le
   back(sensitivity(y))[1]
 end
 
-# This is inserted into @adjoint by ZygoteRules,
-# which has a 2-arg do-nothing method.
+# This is inserted into @adjoint_final by ZygoteRules
 @inline maybe_final(::Context{false,true}, x) = maybe_final(x)
 # The goal is to free CuArrays promptly. 
 @inline maybe_final(x::DenseArray) = finalize(x)
-# Don't waste time on other things, e.g. @btime finalize(nothing) is about 40ns
-@inline maybe_final(x) = nothing
 
-# Without an @adjoint rule, some hessian tests fail:
+# Without an @adjoint rule for this, some hessian tests fail:
 # Can't differentiate foreigncall expression $(Expr(:foreigncall, :(:jl_finalize_th), Nothing
 # And if it in fact finalises, then other 2nd derivative tests fail. So do nothing:
 @adjoint maybe_final(x) = nothing, _ -> nothing
-# @adjoint maybe_final(::Context{false,true}, x) = nothing, _ -> nothing
+@adjoint maybe_final(::Context{false,true}, x) = nothing, _ -> nothing
 
 # Probably just for testing:
 maybe_final(x::Vector) = resize!(x, 0)

--- a/src/compiler/interface2.jl
+++ b/src/compiler/interface2.jl
@@ -17,6 +17,8 @@ end
     chain_rrule_f = :chain_rrule
   end
 
+  # Here ZygoteRuleConfig{Zygote.Context{false, true}} is passed to chain_rrule
+
   hascr, cr_edge = has_chain_rrule(cr_T)
   hascr && return :($chain_rrule_f(ZygoteRuleConfig(ctx), f, args...))
 

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -191,7 +191,7 @@ for (mapfunc,∇mapfunc) in [(:map,:∇map),(:pmap,:∇pmap)]
     ys = map(first, ys_and_backs)
     arg_ax = map(_tryaxes, args)
     function map_back(Δ)
-      if Base.issingletontype(F) && length(args) == 1
+      ∇s = if Base.issingletontype(F) && length(args) == 1
         Δarg = $mapfunc(((_,pb), δ) -> last_or_nothing(pb(δ)), ys_and_backs, Δ) # No unzip needed
         (nothing, Δarg)
       elseif Base.issingletontype(F)
@@ -207,6 +207,8 @@ for (mapfunc,∇mapfunc) in [(:map,:∇map),(:pmap,:∇pmap)]
         Δargs = map(_restore, Δf_and_args[2:end], arg_ax)
         (Δf, Δargs...)
       end
+      maybe_final(cx, ys_and_backs)
+      ∇s
     end
     map_back(::Nothing) = nothing
     return ys, map_back

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -31,11 +31,11 @@ y, back = pullback(badly, 2)
 bt = try back(1) catch e stacktrace(catch_backtrace()) end
 
 @test trace_contains(bt, nothing, "compiler.jl", 20)
-if VERSION >= v"1.6-"
-  @test_broken trace_contains(bt, :badly, "compiler.jl", 24)
-else
+# if VERSION >= v"1.6-"
+#   @test_broken trace_contains(bt, :badly, "compiler.jl", 24)
+# else
   @test trace_contains(bt, :badly, "compiler.jl", 24)
-end
+# end
 
 # Type inference checks
 

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -270,8 +270,11 @@ end
   @test gradtest(dot, randn(rng, 10, 3), randn(rng, 10, 3))
 end
 
-@test gradtest(kron, rand(5), rand(3))
-@test gradtest(kron, rand(5), rand(3), rand(8))
+if VERSION < v"1.9-"  # kron(::Vector...) no longer reshapes, needs a rule:
+  # https://github.com/JuliaDiff/ChainRules.jl/issues/684
+  @test gradtest(kron, rand(5), rand(3))
+  @test gradtest(kron, rand(5), rand(3), rand(8))
+end
 @test gradtest(kron, rand(5,1), rand(3,1))
 @test gradtest(kron, rand(5,1), rand(3,1), rand(8,1))
 @test gradtest(kron, rand(5,2), rand(3,2), rand(8,2))


### PR DESCRIPTION
This adds:
* A flag to `Context` to indicate that the pullback will never be called twice -- set to true for `gradient`, false for `jacobian`
* Modifications to many rules, esp. for broadcasting, so that `y=f(x)` in the forward pass has `finalize(y)` in the reverse. This increases the largest size of Flux model which can run on a given GPU.

Applying such modifications everywhere led to many errors, some from rules like `y = x .+ false` which return `y === x` under Zygote. So they now require a separate macro `@adjoint_final`. 

At present this modification is applied to all CR `rrule`s. This is probably unsafe and we should revert  2524163c8a5bd4aab9101c964d6d8d0676b501e8 . Unclear how best to opt-in within ChainRules. Xref https://github.com/JuliaDiff/ChainRulesCore.jl/pull/592 about the idea of a flag, but not entirely sure that's the right approach. 

Explicit finalising won't work well with thunks. Which doesn't matter at all yet, but might after #966.

It also does not work with second derivatives, hence is disabled. Other uses of the context flag (like testing `only_once(cfg)` & then over-writing some array) probably also need to be disabled.

Needs https://github.com/FluxML/ZygoteRules.jl/pull/23 so CI will fail. Locally, one failure, one failure to fail:
```
Global Params: Error During Test at /Users/me/.julia/dev/Zygote/test/features.jl:399
  Got exception outside of a @test
  KeyError: key :(Main.global_param) not found
  Stacktrace:
    [1] getindex(d::IdDict{Any, Any}, key::Any)
      @ Base ./iddict.jl:108
    [2] macro expansion
      @ ~/.julia/dev/Zygote/test/features.jl:404 [inlined]

Compiler: Error During Test at /Users/me/.julia/dev/Zygote/test/compiler.jl:35
 Unexpected Pass
 Expression: trace_contains(bt, :badly, "compiler.jl", 24)
 Got correct result, please change to @test if no longer broken.
```