### PR TITLE
Address invalidations caused by overloading `Base.show()`

### DIFF
--- a/src/compiler/show.jl
+++ b/src/compiler/show.jl
@@ -8,6 +8,6 @@ function funcname(T)
     end
 end
 
-Base.show(io::IO, j::Pullback{S}) where S = print(io, "∂($(funcname(S.parameters[1])))")
+Base.show(io::IO, mime::MIME"text/plain", j::Pullback{S}) where {S} = print(io, "∂($(funcname(S.parameters[1])))")
 
-Base.show(io::IO, P::Type{<:Pullback{S}}) where S<:Tuple = print(io, "typeof(∂($(funcname(@isdefined(S) ? S.parameters[1] : nothing))))")
+Base.show(io::IO, mime::MIME"text/plain", P::Type{<:Pullback{S}}) where {S<:Tuple} = print(io, "typeof(∂($(funcname(@isdefined(S) ? S.parameters[1] : nothing))))")

--- a/src/compiler/show.jl
+++ b/src/compiler/show.jl
@@ -1,11 +1,11 @@
-funcname(::Type{Type{T}}) where T = string(T)
+funcname(::Type{Type{T}}) where {T} = string(T)
 
 function funcname(T)
-  if isdefined(T, :instance)
-    string(T.instance)
-  else
-    "λ"
-  end
+    if isdefined(T, :instance)
+        string(T.instance)
+    else
+        "λ"
+    end
 end
 
 Base.show(io::IO, j::Pullback{S}) where S = print(io, "∂($(funcname(S.parameters[1])))")


### PR DESCRIPTION
While hunting down causes of large compilation times for a package I am developing, I found that
the largest number of invalidations were caused by two lines in Zygote.jl

(note: all timings are with Julia v1.8.5 and Zygote v0.6.54)

Specifically (in `show.jl`), these

```julia
Base.show(io::IO, j::Pullback{S}) where {S} = print(io, "∂($(funcname(S.parameters[1])))")
Base.show(io::IO, P::Type{<:Pullback{S}}) where {S<:Tuple} = print(io, "typeof(∂($(funcname(@isdefined(S) ? S.parameters[1] : nothing))))")
```

need a mime type defined, e.g.

```julia
Base.show(io::IO, mime::MIME"text/plain", j::Pullback{S})
```

Here are comparisons before and after the change:

```julia
# Initial `using` time for reference
# julia> @time using Zygote
#   1.880127 seconds (4.92 M allocations: 333.361 MiB, 6.91% gc time, 32.06% compilation time: 93% of which was recompilation)


# Following the guide at
# https://timholy.github.io/SnoopCompile.jl/dev/snoopr/#invalidations

using SnoopCompileCore

invalidations = @snoopr using Zygote

using SnoopCompile

@info length(uinvalidated(invalidations))
# [ Info: 1528

# Listed last are invalidations with the most children
# The suggestion is to focus on these
trees = invalidation_trees(invalidations)
methinvs = trees[end]

root = methinvs.backedges[end]
# MethodInstance for show(::IOBuffer, ::Type) at depth 0 with 924 children


# After adding mime type
# julia> @time using Zygote
#   1.483492 seconds (4.20 M allocations: 296.987 MiB, 1.23% gc time, 20.56% compilation time: 86% of which was recompilation)

# @info length(uinvalidated(invalidations))
# [ Info: 640

# root = methinvs.backedges[end]
# MethodInstance for promote_rule(::Type{Int64}, ::Type) at depth 0 with 481 children
```