### PR TITLE
Remove `show` for `Type{<:Pullback}`

### DIFF
--- a/src/compiler/show.jl
+++ b/src/compiler/show.jl
@@ -10,4 +10,3 @@ end
 
 Base.show(io::IO, j::Pullback{S}) where S = print(io, "∂($(funcname(S.parameters[1])))")
 
-Base.show(io::IO, P::Type{<:Pullback{S}}) where S<:Tuple = print(io, "typeof(∂($(funcname(@isdefined(S) ? S.parameters[1] : nothing))))")


### PR DESCRIPTION
Alternative to #1354 by removing a `show` method for `Type{<:Pullback}`. I see an even more drastic improvement than reported in #1354:

## master branch

```julia
julia> using SnoopCompile

julia> invalidations = @snoopr using Zygote;

julia> length(uinvalidated(invalidations))
1542

julia> trees = invalidation_trees(invalidations);

julia> trees[end].backedges[end]
MethodInstance for show(::IOBuffer, ::Type) at depth 0 with 1246 children
```

```julia
julia> @time using Zygote
  1.327357 seconds (4.23 M allocations: 299.507 MiB, 4.29% gc time, 19.41% compilation time: 85% of which was recompilation)
```

## this PR

```julia
julia> using SnoopCompile

julia> invalidations = @snoopr using Zygote;

julia> length(uinvalidated(invalidations))
446

julia> trees = invalidation_trees(invalidations);

julia> trees[end].backedges[end]
MethodInstance for promote_rule(::Type{Int64}, ::Type) at depth 0 with 222 children
```

```julia
julia> @time using Zygote
  1.250796 seconds (4.11 M allocations: 293.619 MiB, 1.36% gc time, 18.60% compilation time: 84% of which was recompilation)
```