### PR TITLE
MethodError if configured rrule is ambiguous

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Zygote"
 uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
-version = "0.6.54"
+version = "0.6.55"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -278,11 +278,20 @@ using Zygote: ZygoteRuleConfig
 
     # https://github.com/FluxML/Zygote.jl/issues/1234
     @testset "rrule lookup ambiguities" begin
-      f_ambig(x, y) = x + y
-      ChainRulesCore.rrule(::typeof(f_ambig), x::Int, y) = x + y, _ -> (0, 0)
-      ChainRulesCore.rrule(::typeof(f_ambig), x, y::Int) = x + y, _ -> (0, 0)
+      @testset "unconfigured" begin
+        f_ambig(x, y) = x + y
+        ChainRulesCore.rrule(::typeof(f_ambig), x::Int, y) = x + y, _ -> (0, 0)
+        ChainRulesCore.rrule(::typeof(f_ambig), x, y::Int) = x + y, _ -> (0, 0)
 
-      @test_throws MethodError pullback(f_ambig, 1, 2)
+        @test_throws MethodError pullback(f_ambig, 1, 2)
+      end
+      @testset "configured" begin
+        h_ambig(x, y) = x + y
+        ChainRulesCore.rrule(::ZygoteRuleConfig, ::typeof(h_ambig), x, y) = x + y, _ -> (0, 0)
+        ChainRulesCore.rrule(::RuleConfig, ::typeof(h_ambig), x::Int, y::Int) = x + y, _ -> (0, 0)
+
+        @test_throws MethodError pullback(h_ambig, 1, 2)
+      end
     end
 end
 


### PR DESCRIPTION
This resolves https://github.com/FluxML/Zygote.jl/issues/1342
which is a special case of ambiguity where the ambiguity is for a configured rule and it's configured opt-out.
But it applies without an opt-out also.

This in particular implements [Sol0](https://github.com/FluxML/Zygote.jl/issues/1342#issuecomment-1363438666)
Which is to give an useful `MethodError`  rather than a confusing error about no field, as follows:

Before
```
julia> pullback(h_ambig, 1, 2)
ERROR: type Nothing has no field method
Stacktrace:
 [1] getproperty(x::Nothing, f::Symbol)
   @ Base ./Base.jl:33
 [2] has_chain_rrule(T::Type)
   @ Zygote ~/.julia/packages/Zygote/AS0Go/src/compiler/chainrules.jl:21
 [3] #s2941#1099
   @ ~/.julia/packages/Zygote/AS0Go/src/compiler/interface2.jl:20 [inlined]
 [4] var"#s2941#1099"(::Any, ctx::Any, f::Any, args::Any)
   @ Zygote ./none:0
 [5] (::Core.GeneratedFunctionStub)(::Any, ::Vararg{Any, N} where N)
   @ Core ./boot.jl:571
 [6] pullback(::Function, ::Zygote.Context{false}, ::Int64, ::Vararg{Int64, N} where N)
   @ Zygote ~/.julia/packages/Zygote/AS0Go/src/compiler/interface.jl:44
 [7] pullback(::Function, ::Int64, ::Int64)
   @ Zygote ~/.julia/packages/Zygote/AS0Go/src/compiler/interface.jl:42
 [8] top-level scope
   @ REPL[24]:1
```

Now:
```
julia> pullback(h_ambig, 1, 2)
ERROR: MethodError: rrule(::ZygoteRuleConfig{Zygote.Context{false}}, ::typeof(h_ambig), ::Int64, ::Int64) is ambiguous. Candidates:
  rrule(::RuleConfig, ::typeof(h_ambig), x::Int64, y::Int64) in Main at /home/oxinabox/JuliaEnvs/Zygote.jl/test/chainrules.jl:291
  rrule(::ZygoteRuleConfig, ::typeof(h_ambig), x, y) in Main at /home/oxinabox/JuliaEnvs/Zygote.jl/test/chainrules.jl:290
Possible fix, define
  rrule(::ZygoteRuleConfig, ::typeof(h_ambig), ::Int64, ::Int64)
Stacktrace:
 [1] chain_rrule
   @ ~/JuliaEnvs/Zygote.jl/src/compiler/chainrules.jl:223 [inlined]
 [2] macro expansion
   @ ~/JuliaEnvs/Zygote.jl/src/compiler/interface2.jl:0 [inlined]
 [3] _pullback(::Zygote.Context{false}, ::typeof(h_ambig), ::Int64, ::Int64)
   @ Zygote ~/JuliaEnvs/Zygote.jl/src/compiler/interface2.jl:9
 [4] pullback(::Function, ::Zygote.Context{false}, ::Int64, ::Vararg{Int64})
   @ Zygote ~/JuliaEnvs/Zygote.jl/src/compiler/interface.jl:44
 [5] pullback(::Function, ::Int64, ::Int64)
   @ Zygote ~/JuliaEnvs/Zygote.jl/src/compiler/interface.jl:42
 [6] top-level scope
   @ ~/JuliaEnvs/Zygote.jl/test/chainrules.jl:293
   ```

This behavior is consistent with our behavour for non-configured rules as implemented in https://github.com/FluxML/Zygote.jl/issues/1342

[Sol1](https://github.com/FluxML/Zygote.jl/issues/1342#issuecomment-1363438666) (to just ignore rules) would be easily implemented for both configured and unconfigured cases  by changing the final `if` to `is_ambig || match(...)` rather than `!is_ambig && match(...)
but should be a separate PR.

### PR Checklist

- [x] Tests are added
