### PR TITLE
Always call reverse in `map`

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -165,12 +165,14 @@ end
 # needed for stateful functions.
 # See https://github.com/FluxML/Flux.jl/issues/1209
 # Should be generalized to abstract array, but reverse takes a dims keyword there
+
+# That lead to https://github.com/FluxML/Zygote.jl/issues/1374
+# ... and post-1.6 dims is not required to reverse arrays.
 _tryreverse(m, backs, Δ) = backs, Δ
-function _tryreverse(m::typeof(map), backs, Δ::Union{AbstractVector, Tuple})
-  return reverse(backs), reverse(Δ)
-end
+_tryreverse(m::typeof(map), backs, Δ) = reverse(backs), reverse(Δ)
+
 _tryreverse(m, x) = x
-_tryreverse(m::typeof(map), x::Union{AbstractVector, Tuple}) = reverse(x)
+_tryreverse(m::typeof(map), x) = reverse(x)
 
 # With mismatched lengths, map stops early. With mismatched shapes, it makes a vector.
 # So we keep axes(x) to restore gradient dx to its full length & correct shape.

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -161,13 +161,9 @@ function unzip(tuples)
   _unzip(tuples, Val(N))
 end
 
-# Reverse iteration order when ∇map is applied to vector,
-# needed for stateful functions.
-# See https://github.com/FluxML/Flux.jl/issues/1209
-# Should be generalized to abstract array, but reverse takes a dims keyword there
-
-# That lead to https://github.com/FluxML/Zygote.jl/issues/1374
-# ... and post-1.6 dims is not required to reverse arrays.
+# Reverse iteration order in ∇map, for stateful functions.
+# This is also used by comprehensions, which do guarantee iteration order.
+# Not done for pmap, presumably because all is lost if you are relying on its order.
 _tryreverse(m, backs, Δ) = backs, Δ
 _tryreverse(m::typeof(map), backs, Δ) = reverse(backs), reverse(Δ)
 


### PR DESCRIPTION
Fixes #1374 by removing the special case that `_tryreverse` only reverses vectors & tuples.

Possibly it will now fail on other types. That's better than silently failing to reverse them.