### PR TITLE
Make sure conda env dir is set on Buildkite CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,6 +4,8 @@ steps:
       - JuliaCI/julia#v1:
           version: "1.6"
       - JuliaCI/julia-test#v1: ~
+    command:
+      - mkdir -p "${JULIA_DEPOT_PATH}/conda/3/x86_64"
     agents:
       queue: "juliagpu"
       cuda: "*"
@@ -14,6 +16,8 @@ steps:
       - JuliaCI/julia#v1:
           version: "1"
       - JuliaCI/julia-test#v1: ~
+    command:
+      - mkdir -p "${JULIA_DEPOT_PATH}/conda/3/x86_64"
     agents:
       queue: "juliagpu"
       cuda: "*"


### PR DESCRIPTION
This should hopefully resolve issues such as https://buildkite.com/julialang/zygote-dot-jl/builds/1422#01868b24-5751-4c0c-a03e-59c4790a436c/302-483 and make GPU CI consistently green again.

### PR Checklist

- [N/A] Tests are added
- [N/A] Documentation, if applicable
