### PR TITLE
Allow ChainRules zero types internally

### DIFF
--- a/src/Zygote.jl
+++ b/src/Zygote.jl
@@ -3,7 +3,7 @@ module Zygote
 using LinearAlgebra, Statistics
 using LinearAlgebra: copytri!, AbstractTriangular
 
-import ZygoteRules: @adjoint, @adjoint!, AContext, adjoint, _pullback, pullback,
+import ZygoteRules: ZygoteRules, @adjoint, @adjoint!, AContext, adjoint, _pullback, pullback,
   literal_getproperty, literal_getfield, unthunk_tangent
 
 using ChainRulesCore

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -358,7 +358,8 @@ z2d(dx::Ref, primal) = z2d(dx[], primal)  # mutable structs
     differential2zygote(dx)
 
 Convert input `dx` from ChainRules differential types to the Zygote format.
-This is similar to `wrap_chainrules_output(dx)`, but converts zero types.
+This is similar to `wrap_chainrules_output(dx)`, but converts zero types,
+and recursively converts Tangents.
 """
 @inline differential2zygote(@nospecialize(x)) = x
 @inline differential2zygote(::AbstractZero) = nothing

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -150,6 +150,7 @@ Convert `dx` from the format Zygote uses internally to differentials types Chain
 @inline wrap_chainrules_input(::Nothing) = ChainRules.ZeroTangent()
 @inline wrap_chainrules_input(::Tuple{Vararg{Nothing}}) = ChainRules.ZeroTangent()
 @inline wrap_chainrules_input(::AbstractArray{Nothing}) = ChainRules.ZeroTangent()
+@inline wrap_chainrules_input(dxs::AbstractArray{T}) where {T<:AbstractZero} = first(dxs)
 @inline function wrap_chainrules_input(dxs::Union{Tuple, NamedTuple})
   xp = map(wrap_chainrules_input, dxs)
   # This produces Tangent{Any} since it does not get to see the primal, `x`.

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -150,6 +150,7 @@ Convert `dx` from the format Zygote uses internally to differentials types Chain
 @inline wrap_chainrules_input(::Nothing) = ChainRules.ZeroTangent()
 @inline wrap_chainrules_input(::Tuple{Vararg{Nothing}}) = ChainRules.ZeroTangent()
 @inline wrap_chainrules_input(::AbstractArray{Nothing}) = ChainRules.ZeroTangent()
+@inline wrap_chainrules_input(::AbstractArray{<:AbstractZero}) = ChainRules.ZeroTangent()
 @inline function wrap_chainrules_input(dxs::Union{Tuple, NamedTuple})
   xp = map(wrap_chainrules_input, dxs)
   # This produces Tangent{Any} since it does not get to see the primal, `x`.

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -150,7 +150,6 @@ Convert `dx` from the format Zygote uses internally to differentials types Chain
 @inline wrap_chainrules_input(::Nothing) = ChainRules.ZeroTangent()
 @inline wrap_chainrules_input(::Tuple{Vararg{Nothing}}) = ChainRules.ZeroTangent()
 @inline wrap_chainrules_input(::AbstractArray{Nothing}) = ChainRules.ZeroTangent()
-@inline wrap_chainrules_input(::AbstractArray{<:AbstractZero}) = ChainRules.ZeroTangent()
 @inline function wrap_chainrules_input(dxs::Union{Tuple, NamedTuple})
   xp = map(wrap_chainrules_input, dxs)
   # This produces Tangent{Any} since it does not get to see the primal, `x`.
@@ -382,6 +381,7 @@ end
 differential2zygote(dxs::AbstractArray{<:Number}) = dxs
 differential2zygote(dxs::AbstractArray{<:AbstractArray{<:Number}}) = dxs
 differential2zygote(dxs::AbstractArray) = map(differential2zygote, dxs)
+differential2zygote(dxs::Dict) = Dict(k => differential2zygote(v) for (k, v) in dxs)
 
 # Mostly used in rule genfuncs
 _iszerotype(T) = T === Nothing || T <: AbstractZero

--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -185,7 +185,7 @@ Params(xs::Tuple) = Params(collect(xs))
 
 Base.in(x, ps::Params) = x in ps.params
 
-Base.map(::typeof(_project), args::Tuple{Params}, grad) = grad  # skip _project in gradient(f, ::Params)
+_project(::Tuple{Params}, grad) = grad  # skip _project in gradient(f, ::Params)
 
 function Base.union!(ps::Params, itrs...)
   foreach(itr -> foreach(x -> push!(ps, x), itr), itrs)

--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -132,8 +132,7 @@ julia> res.grad[w]
 function withgradient(f, args...)
   y, back = pullback(f, args...)
   grad = back(sensitivity(y))
-  results = isnothing(grad) ? map(_ -> nothing, args) : map(_project, args, grad)
-  (val=y, grad=results)
+  (val=y, grad=_project(args, grad))
 end
 
 # Param-style wrappers

--- a/src/compiler/reverse.jl
+++ b/src/compiler/reverse.jl
@@ -6,6 +6,7 @@ using IRTools: IR, Variable, Pipe, xcall, var, prewalk, postwalk,
 @inline tuple_va(N, xs) = xs
 @inline tuple_va(N, x, xs...) = (x, tuple_va(N, xs...)...)
 @inline tuple_va(::Val{N}, ::Nothing) where N = ntuple(_ -> nothing, Val(N))
+@inline tuple_va(::Val{N}, x::AbstractZero) where N = ntuple(_ -> x, Val(N))
 
 iscall(x, m::Module, n::Symbol) = isexpr(x, :call) && x.args[1] == GlobalRef(m, n)
 

--- a/src/compiler/show.jl
+++ b/src/compiler/show.jl
@@ -9,4 +9,7 @@ function funcname(T)
 end
 
 Base.show(io::IO, j::Pullback{S}) where S = print(io, "∂($(funcname(S.parameters[1])))")
+function Base.show(io::IO, P::Type{<:Pullback{S}}) where S
+  @isdefined(S) ? print(io, "Pullback{", S, ", ...}") : print(io, "Pullback{S, T}")
+end
 

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -229,7 +229,7 @@ reconstruct_if_dict(x̄, _keys::Nothing) = x̄
 
 function reconstruct_if_dict(x̄, _keys)
   # This reverses `collect_if_dict`, which returns `_keys::Nothing` if x is not a Dict
-  @assert x̄ isa AbstractVector{<:Union{Nothing, AbstractZero, NamedTuple{(:first,:second)}}}
+  @assert x̄ isa AbstractVector # {<:Union{Nothing, AbstractZero, NamedTuple{(:first,:second)}}}
   # we don't compute gradients with respect to keys
   # @assert all(x -> x === nothing || x[1] == 0 || x[1] === nothing, x̄)
   d̄ = Dict(k => x === nothing || x isa AbstractZero ? x : x[2] for (x, k) in zip(x̄, _keys))
@@ -428,6 +428,7 @@ _symmetric_back(Δ::LowerTriangular, uplo) = collect(uplo == 'U' ? transpose(Δ)
 
 @adjoint function Symmetric(A::AbstractMatrix, uplo=:U)
   S = Symmetric(A, uplo)
+  back(Δ::AbstractZero) = (Δ, nothing)
   back(Δ::AbstractMatrix) = (_symmetric_back(Δ, S.uplo), nothing)
   back(Δ::NamedTuple) = (_symmetric_back(Δ.data, S.uplo), nothing)
   return S, back
@@ -452,6 +453,7 @@ end
 
 @adjoint function LinearAlgebra.Hermitian(A::AbstractMatrix, uplo=:U)
   H = Hermitian(A, uplo)
+  back(Δ::AbstractZero) = (Δ, nothing)
   back(Δ::AbstractMatrix) = (_hermitian_back(Δ, H.uplo), nothing)
   back(Δ::NamedTuple) = (_hermitian_back(Δ.data, H.uplo), nothing)
   return H, back

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -315,8 +315,16 @@ function _pullback(cx::AContext, ::typeof(prod), f, xs::AbstractArray)
   return _pullback(cx, (f, xs) -> prod(f.(xs)), f, xs)
 end
 
-@adjoint real(x::AbstractArray) = real(x), r̄ -> (real(r̄),)
-@adjoint conj(x::AbstractArray) = conj(x), r̄ -> (conj(r̄),)
+@adjoint function real(x::AbstractArray)
+  real_array_pullback(r̄::AbstractZero) = (r̄,)
+  real_array_pullback(r̄) = (real(r̄),)
+  return real(x), real_array_pullback
+end
+@adjoint function conj(x::AbstractArray)
+  conj_array_pullback(r̄::AbstractZero) = (r̄,)
+  conj_array_pullback(r̄) = (conj(r̄),)
+  return conj(x), conj_array_pullback
+end
 @adjoint imag(x::AbstractArray) = imag(x), ī -> (complex.(0, real.(ī)),)
 
 

--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -284,6 +284,7 @@ end
 @inline function _broadcast_forward(::Type{<:Dual}, out, args::Vararg{Any, N}) where {N}
   valN = Val(N)
   y = broadcast(x -> value(x), out)
+  bc_fwd_back(ȳ::AbstractZero) = ȳ
   function bc_fwd_back(ȳ)
     dargs = ntuple(valN) do i
       unbroadcast(args[i], broadcast((y1, o1) -> y1 * partials(o1,i), ȳ, out))
@@ -297,6 +298,7 @@ end
 @inline function _broadcast_forward(::Type{<:Complex}, out, args::Vararg{Any, N}) where {N}
     valN = Val(N)
     y = broadcast(x -> Complex(value(real(x)), value(imag(x))), out)
+    bc_fwd_back(ȳ::AbstractZero) = ȳ
     function bc_fwd_back(ȳ)
       dargs = ntuple(valN) do i
         unbroadcast(args[i], broadcast((y1, o1) -> (real(y1)*partials(real(o1),i) + imag(y1)*partials(imag(o1), i)), ȳ, out))
@@ -311,6 +313,7 @@ end
 @inline function _broadcast_forward_complex(::Type{<:Dual}, out, args::Vararg{Any, N}) where {N}
     valN = Val(N)
     y = broadcast(x -> value(x), out)
+    bc_fwd_back(ȳ::AbstractZero) = ȳ
     function bc_fwd_back(ȳ)
       dargs = ntuple(valN) do i
         unbroadcast(args[i], broadcast((y1, o1) -> y1 * Complex(partials(o1, i), partials(o1, i+N)), ȳ, out))
@@ -335,6 +338,7 @@ end
 @inline function _broadcast_forward_complex(::Type{<:Complex}, out, args::Vararg{Any, N}) where {N}
     valN = Val(N)
     y = broadcast(x -> Complex(value(real(x)), value(imag(x))), out)
+    bc_fwd_back(ȳ::AbstractZero) = ȳ
     function bc_fwd_back(ȳ)
       dargs = ntuple(valN) do i
         unbroadcast(args[i], broadcast((y1, o1) -> _adjoint_complex(N, y1, o1, i), ȳ, out))

--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -206,11 +206,12 @@ if VERSION >= v"1.4.0-DEV.304"
   @adjoint! function Core._apply_iterate(::typeof(iterate), f, args...)
     y, back = Core._apply(_pullback, (__context__, f), args...)
     st = map(_empty, args)
-    y, function (Δ)
+    function _apply_iterate_pullback(Δ)
       Δ = back(Δ)
-      Δ === nothing ? nothing :
-        (nothing, first(Δ), unapply(st, Base.tail(Δ))...)
+      Δ isa Union{Nothing,AbstractZero} && return Δ
+      return (nothing, first(Δ), unapply(st, Base.tail(Δ))...)
     end
+    return y, _apply_iterate_pullback
   end
 end
 

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -271,8 +271,8 @@ using Zygote: ZygoteRuleConfig
         @test Zygote.gradient(f_notimplemented, 0.1) === (nothing,)
         @test Zygote.gradient(x -> f_notimplemented(x[1]), 0.1) === (nothing,)
         if isdefined(Base, :only)
-            @test Zygote.gradient(x -> f_notimplemented(only(x)), (0.1,)) === (nothing,)
-            @test Zygote.gradient(x -> f_notimplemented(only(x)), [0.1]) === (nothing,)
+            @test Zygote.gradient(x -> f_notimplemented(only(x)), (0.1,)) === ((nothing,),)
+            @test_broken Zygote.gradient(x -> f_notimplemented(only(x)), [0.1]) === (nothing,)
         end
     end
 

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -174,11 +174,11 @@ end
 
   # Ensure that nothings work with numeric types.
   _, back = Zygote.pullback(getindex, randn(4), [1])
-  @test back([nothing]) == (zeros(4), nothing)
+  @test back([nothing]) === nothing
 
   # Ensure that nothings work with non-numeric types.
   _, back = Zygote.pullback(getindex, [randn(2) for _ in 1:3], [1])
-  @test back([nothing]) == (nothing, nothing)
+  @test back([nothing]) === nothing
 end
 
 @testset "view" begin

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -1,5 +1,5 @@
 using Zygote, Test, Random, LinearAlgebra, Statistics, SparseArrays, FillArrays,
-    AbstractFFTs, FFTW, Distances
+    AbstractFFTs, FFTW, Distances, ChainRulesCore
 using Zygote: gradient
 using Base.Broadcast: broadcast_shape
 using Distributed: pmap, CachingPool, workers
@@ -38,6 +38,7 @@ _joinreim(A) = A
 
 function _dropimaggrad(A)
   back(Δ) = real(Δ)
+  back(Δ::AbstractZero) = Δ
   back(Δ::Nothing) = nothing
   return Zygote.hook(back, A)
 end

--- a/test/lib/array.jl
+++ b/test/lib/array.jl
@@ -24,7 +24,7 @@ end
         k = 2
         i = findfirst(p -> p[1] == k, collect(d))
         g = gradient(d -> collect(d)[i][2], d)[1]
-        @test g == Dict(k => 1, 2 => nothing)
+        @test g == Dict(k => 1, 1 => nothing)
 
         g = gradient(d -> sum(v^2 for (_,v) in collect(d)), d)[1]
         @test g isa Dict{Int,Int}

--- a/test/lib/array.jl
+++ b/test/lib/array.jl
@@ -24,8 +24,7 @@ end
         k = 2
         i = findfirst(p -> p[1] == k, collect(d))
         g = gradient(d -> collect(d)[i][2], d)[1]
-        @test g isa Dict{Int64, <:Union{Nothing, Int64}}
-        @test g[k] == 1
+        @test g == Dict(k => 1, 2 => nothing)
 
         g = gradient(d -> sum(v^2 for (_,v) in collect(d)), d)[1]
         @test g isa Dict{Int,Int}

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -3,13 +3,8 @@ using Zygote: hessian_dual, hessian_reverse
 
 @testset "hessian: $hess" for hess in [hessian_dual, hessian_reverse]
 
-  if hess == hessian_dual
-    @test hess(x -> x[1]*x[2], randn(2)) ≈ [0 1; 1 0]
-    @test hess(((x,y),) -> x*y, randn(2)) ≈ [0 1; 1 0]  # original docstring version
-  else
-    @test_broken hess(x -> x[1]*x[2], randn(2)) ≈ [0 1; 1 0]  # can't differentiate ∇getindex
-    @test_broken hess(((x,y),) -> x*y, randn(2)) ≈ [0 1; 1 0]
-  end
+  @test hess(x -> x[1]*x[2], randn(2)) ≈ [0 1; 1 0]
+  @test hess(((x,y),) -> x*y, randn(2)) ≈ [0 1; 1 0]  # original docstring version
   @test hess(x -> sum(x.^3), [1 2; 3 4]) ≈ Diagonal([6, 18, 12, 24])
   @test hess(sin, pi/2) ≈ -1
 


### PR DESCRIPTION
Following on https://github.com/FluxML/Zygote.jl/pull/1385, this allows us to propagate `ZeroTangent`, `NoTangent` and `NotImplemented` inside the boundary of `pullback`. Doing so should prevent lossy conversions back and forth, as well as inadvertent dropping of the erroring functionality `NotImplemented` brings. Conversions remain the same for the user-level API, which means this only partially addresses https://github.com/FluxML/Zygote.jl/issues/1227.

This PR can be seen as an incremental step towards #603. There are a couple of options for next steps:
- Allowing `Tangent`s to pass through without conversion
- Supporting thunks (#966)
- Switching all internal rules to use CR zeros instead of Nothing (or converting them to `rrule`s.

### PR Checklist

- [x] Tests are added
- [N/A] Documentation, if applicable
