### PR TITLE
Actually make sure conda env dir is set on Buildkite CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,7 +5,7 @@ steps:
           version: "1.6"
       - JuliaCI/julia-test#v1: ~
     command:
-      - mkdir -p "${JULIA_DEPOT_PATH}/conda/3/x86_64"
+      - mkdir -p "$${JULIA_DEPOT_PATH}/conda/3/x86_64"
     agents:
       queue: "juliagpu"
       cuda: "*"
@@ -17,7 +17,7 @@ steps:
           version: "1"
       - JuliaCI/julia-test#v1: ~
     command:
-      - mkdir -p "${JULIA_DEPOT_PATH}/conda/3/x86_64"
+      - mkdir -p "$${JULIA_DEPOT_PATH}/conda/3/x86_64"
     agents:
       queue: "juliagpu"
       cuda: "*"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -17,6 +17,7 @@ steps:
           version: "1"
       - JuliaCI/julia-test#v1: ~
     command:
+      - ls "$${JULIA_DEPOT_PATH}"
       - mkdir -p "$${JULIA_DEPOT_PATH}/conda/3/x86_64"
     agents:
       queue: "juliagpu"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -17,7 +17,6 @@ steps:
           version: "1"
       - JuliaCI/julia-test#v1: ~
     command:
-      - ls "$${JULIA_DEPOT_PATH}"
       - mkdir -p "$${JULIA_DEPOT_PATH}/conda/3/x86_64"
     agents:
       queue: "juliagpu"

--- a/Project.toml
+++ b/Project.toml
@@ -61,6 +61,7 @@ julia = "1.6"
 
 [extras]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
+Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 ChainRulesTestUtils = "cdddcdb0-9152-4a09-a978-84456f9df70a"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
@@ -71,4 +72,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 
 [targets]
-test = ["ChainRulesTestUtils", "CUDA", "Distances", "FFTW", "FiniteDifferences", "PyCall", "Test"]
+test = ["ChainRulesTestUtils", "Conda", "CUDA", "Distances", "FFTW", "FiniteDifferences", "PyCall", "Test"]

--- a/test/features.jl
+++ b/test/features.jl
@@ -684,7 +684,7 @@ end
 @testset "PyCall custom @adjoint" begin
   # Trigger Python install if required. Required for Buildkite CI!
   import Conda
-  Conda.list() 
+  Conda.list()
 
   import PyCall
   math = PyCall.pyimport("math")

--- a/test/features.jl
+++ b/test/features.jl
@@ -682,6 +682,10 @@ end
 end
 
 @testset "PyCall custom @adjoint" begin
+  # Trigger Python install if required. Required for Buildkite CI!
+  import Conda
+  Conda.list()
+
   import PyCall
   math = PyCall.pyimport("math")
   pysin(x) = math.sin(x)

--- a/test/features.jl
+++ b/test/features.jl
@@ -684,7 +684,7 @@ end
 @testset "PyCall custom @adjoint" begin
   # Trigger Python install if required. Required for Buildkite CI!
   import Conda
-  Conda.list()
+  Conda.list() 
 
   import PyCall
   math = PyCall.pyimport("math")


### PR DESCRIPTION
The original fix was incorrect due to https://buildkite.com/docs/pipelines/environment-variables#runtime-variable-interpolation, but happened to pass by coincidence. Now that I know what to look for, it should be easy to verify this is doing the right thing,