### PR TITLE
Improve literal function and module detection

### DIFF
--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -152,6 +152,7 @@ Convert `dx` from the format Zygote uses internally to differentials types Chain
 @inline wrap_chainrules_input(::Nothing) = ChainRules.ZeroTangent()
 @inline wrap_chainrules_input(::Tuple{Vararg{Nothing}}) = ChainRules.ZeroTangent()
 @inline wrap_chainrules_input(::AbstractArray{Nothing}) = ChainRules.ZeroTangent()
+@inline wrap_chainrules_input(dxs::AbstractArray{T}) where {T<:AbstractZero} = first(dxs)
 @inline function wrap_chainrules_input(dxs::Union{Tuple, NamedTuple})
   xp = map(wrap_chainrules_input, dxs)
   # This produces Tangent{Any} since it does not get to see the primal, `x`.

--- a/src/compiler/reverse.jl
+++ b/src/compiler/reverse.jl
@@ -99,7 +99,7 @@ function instrument_getindex!(ir, v, ex)
 end
 
 function instrument_iterate!(ir, v, ex)
-  func = trylookup(ir.from, ex.args[1])
+  func = ex.args[1]
   if func == GlobalRef(Base, :indexed_iterate) && length(ex.args) >= 3
     obj, idx, rest = ex.args[2], trylookup(ir.from, ex.args[3]), ex.args[4:end]
     if idx isa Union{QuoteNode,Integer}

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -169,6 +169,7 @@ module MyMod
 end
 
 @eval usesmod(x) = Base.getproperty($MyMod, :func)(x, Base.getproperty($MyMod, :C))
+usesmod2(x) = Base.getproperty(MyMod, :func)(x, Base.getproperty(MyMod, :C))
 
 @testset "inference for `getproperty`" begin
     Gaussian = _Gaussian(:getproperty)
@@ -221,6 +222,7 @@ end
 
     # Const properties on modules should be lowered as-is (not differentiated)
     @test @inferred gradient(usesmod, 1)[1] == 1.0
+    @test @inferred gradient(usesmod2, 1)[1] == 1.0
 end
 
 # issue 897


### PR DESCRIPTION
Previously, instrumentation would be thrown off by storing a function in a variable/SSA value. Likewise, module references like `Main.Base` would be ignored because they're lowered as GlobalRefs.

This continues some of the work started in https://github.com/FluxML/Zygote.jl/pull/1371 and should fix a couple of edge cases.

### PR Checklist

- [x] Tests are added
- [N/A] Documentation, if applicable
