### PR TITLE
Replace "may" with "might" to avoid ambiguity

### DIFF
--- a/docs/src/limitations.md
+++ b/docs/src/limitations.md
@@ -48,7 +48,7 @@ We got an error message and a long stacktrace. The error informs us that our cod
 
 !!! warning
 
-    Non-mutating functions may also use mutation under the hood. This can be done for performance reasons or code re-use.
+    Non-mutating functions might also use mutation under the hood. This can be done for performance reasons or code re-use.
 
 ```julia
 function g!(x, y)


### PR DESCRIPTION
As written, "Non-mutating functions may also use mutation under the hood" might imply that non-mutating functions are _allowed to_ use mutation under the hood

[Please delete this text and describe your change here.
For bugfixes, please detail the bug and include a test case which your patch fixes.
If you are adding a new feature, please clearly describe the design, its rationale, the possible alternatives considered.
It is easiest to merge new features when there is clear precedent in other systems; we need to know we're taking
the right direction since it can be hard to change later.]

### PR Checklist

- [ ] Tests are added
- [ ] Documentation, if applicable
