### PR TITLE
Updated PyCall module to Pythoncall 

### DIFF
--- a/src/forward/number.jl
+++ b/src/forward/number.jl
@@ -38,7 +38,7 @@ for f in [>, <, ==, ===, !=, in]
   @eval @tangent $f(a, b) = $f(a, b), (_, _) -> false
 end
 
-@tangent convert(T::Type{<:Real}, x::Real) = convert(T, x), (_, ẋ) -> convert(T, ẋ)
+@tangent pyconvert(T::Type{<:Real}, x::Real) = pyconvert(T, x), (_, ẋ) -> pyconvert(T, ẋ)
 
 @tangent function Colon()(xs...)
   c = Colon()(xs...)

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -487,10 +487,10 @@ end
   return H, back
 end
 
-@adjoint convert(::Type{R}, A::LinearAlgebra.HermOrSym{T,S}) where {T,S,R<:Array} = convert(R, A),
-  Δ -> (nothing, convert(S, Δ),)
+@adjoint pyconvert(::Type{R}, A::LinearAlgebra.HermOrSym{T,S}) where {T,S,R<:Array} = pyconvert(R, A),
+  Δ -> (nothing, pyconvert(S, Δ),)
 @adjoint Matrix(A::LinearAlgebra.HermOrSym{T,S}) where {T,S} = Matrix(A),
-  Δ -> (convert(S, Δ),)
+  Δ -> (pyconvert(S, Δ),)
 
 @adjoint function lyap(A::AbstractMatrix, C::AbstractMatrix)
   X = lyap(A, C)

--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -362,7 +362,7 @@ using GPUArraysCore  # replaces @require CUDA block, weird indenting to preserve
     broadcast_forward(f, args...)
 
   @adjoint (::Type{T})(xs::Array) where {T <: AbstractGPUArray} =
-    T(xs), Δ -> (convert(Array, Δ), )
+    T(xs), Δ -> (pyconvert(Array, Δ), )
 
   @adjoint function sum(xs::AbstractGPUArray; dims = :)
     placeholder = similar(xs)
@@ -383,8 +383,8 @@ using GPUArraysCore  # replaces @require CUDA block, weird indenting to preserve
     return res, sum_gpuarray_kw_pullback
   end
 
-  @adjoint function Base.convert(::Type{T}, xs::Array)  where {T<:AbstractGPUArray}
-    Base.convert(T, xs), Δ -> (nothing, Base.convert(Array, Δ),)
+  @adjoint function Base.pyconvert(::Type{T}, xs::Array)  where {T<:AbstractGPUArray}
+    Base.pyconvert(T, xs), Δ -> (nothing, Base.pyconvert(Array, Δ),)
   end
 
   pull_block_vert(sz, Δ::AbstractGPUArray, A::Number) = @allowscalar Δ[sz]

--- a/src/lib/number.jl
+++ b/src/lib/number.jl
@@ -1,8 +1,8 @@
 function ChainRulesCore.rrule(
-    ::ZygoteRuleConfig, ::typeof(convert), T::Type{<:Real}, x::Real
+    ::ZygoteRuleConfig, ::typeof(pyconvert), T::Type{<:Real}, x::Real
 )
-    convert_pullback(Δ) = (NoTangent(), NoTangent(), Δ)
-    return convert(T, x), convert_pullback
+    pyconvert_pullback(Δ) = (NoTangent(), NoTangent(), Δ)
+    return pyconvert(T, x), pyconvert_pullback
 end
 
 function ChainRulesCore.rrule(

--- a/src/lib/tempCodeRunnerFile.jl
+++ b/src/lib/tempCodeRunnerFile.jl
@@ -1,0 +1,1 @@
+convert

--- a/test/features.jl
+++ b/test/features.jl
@@ -686,8 +686,9 @@ end
   import Conda
   Conda.list()
 
-  import PyCall
-  math = PyCall.pyimport("math")
+  add PythonCall
+  using PythonCall
+  math = pyimport("math")
   pysin(x) = math.sin(x)
   Zygote.@adjoint pysin(x) = math.sin(x), (δ) -> (δ * math.cos(x), )
   @test Zygote.gradient(pysin, 1.5) == Zygote.gradient(sin, 1.5)

--- a/test/lib/number.jl
+++ b/test/lib/number.jl
@@ -10,10 +10,10 @@
   @testset "basics" begin
     @test gradient(Base.literal_pow, ^, 3//2, Val(-5))[2] isa Rational
 
-    @test gradient(convert, Rational, 3.14) == (nothing, 1.0)
-    @test gradient(convert, Rational, 2.3) == (nothing, 1.0)
-    @test gradient(convert, UInt64, 2) == (nothing, 1.0)
-    @test gradient(convert, BigFloat, π) == (nothing, 1.0)
+    @test gradient(pyconvert, Rational, 3.14) == (nothing, 1.0)
+    @test gradient(pyconvert, Rational, 2.3) == (nothing, 1.0)
+    @test gradient(pyconvert, UInt64, 2) == (nothing, 1.0)
+    @test gradient(pyconvert, BigFloat, π) == (nothing, 1.0)
 
     @test gradient(Rational, 2) == (1//1,)
 


### PR DESCRIPTION
PyCall module has been changed and updated to PythonCall along with the related methods.
It provides flexibility of conversion. PythonCall supports far more combinations of types of T and x and can be extended to support more types.
PythonCall uses a separate Conda environment for each Julia environment/project/package and installs Python (and other Python packages) into that. This means that different Julia projects can maintain an isolated set of Python dependencies (including the Python version itself).
PythonCall supports Julia 1.6.1+ and Python 3.7+. PyCall requires numpy to be installed, PythonCall doesn't (it provides the same fast array access through the buffer protocol and array interface).
