### PR TITLE
Allow `f` to return a Tuple in `withgradient(f, args...)`

### DIFF
--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -119,13 +119,15 @@ julia> ∇ == gradient(/, 1, 2)
 true
 ```
 
-If `f` returns a Tuple or NamedTuple, then it calculates
-`gradient(first∘f, args...)` but returns the whole `f(args...)`:
+Allows you to capture auxillary outputs, in addition to the scalar
+used by `gradient`. To do this, `f` must return a Tuple or NamedTuple.
+Then it calculates `grad = gradient(first∘f, args...)
+but returns the whole `val = f(args...)`:
 
 ```jldoctest; setup=:(using Zygote)
 julia> withgradient([1,2,4]) do x
           z = 1 ./ x
-          sum(z), z
+          sum(z), z  # here z is an auxillary output
        end
 (val = (1.75, [1.0, 0.5, 0.25]), grad = ([-1.0, -0.25, -0.0625],))
 

--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -115,10 +115,8 @@ as a named tuple.
 julia> y, ∇ = withgradient(/, 1, 2)
 (val = 0.5, grad = (0.5, -0.25))
 
-julia> ∇ == gradient(/, 1, 2)  # explicit mode
+julia> ∇ == gradient(/, 1, 2)
 true
-
-julia> w = [3.0];
 ```
 
 If `f` returns a Tuple or NamedTuple, then it calculates
@@ -140,7 +138,9 @@ julia> withgradient(3.0, 4.0) do x, y
 Also supports implicit mode:
 
 ```jldoctest; setup=:(using Zygote)
-julia> res = withgradient(() -> sum(abs2, w), Params([w]))  # implicit mode
+julia> w = [3.0];
+
+julia> res = withgradient(() -> sum(abs2, w), Params([w]))
 (val = 9.0, grad = Grads(...))
 
 julia> res.grad[w]

--- a/test/features.jl
+++ b/test/features.jl
@@ -866,3 +866,21 @@ end
   end
   @test gradient(f760, 3)[1] ≈ 123.93054835019153
 end
+
+@testset "withgradient" begin
+  @test withgradient([1,2,4]) do x
+    z = 1 ./ x
+    sum(z), z
+  end == (val = (1.75, [1.0, 0.5, 0.25]), grad = ([-1.0, -0.25, -0.0625],))
+
+  @test withgradient(3.0, 4.0) do x, y
+    (div = x/y, mul = x*y)
+  end == (val = (div = 0.75, mul = 12.0), grad = (0.25, -0.1875))
+
+  f3(x) = sum(sin, x), sum(cos, x), sum(tan, x)
+  g1 = gradient(first∘f3, [1,2,3.0])
+  y2, g2 = withgradient(first∘f3, [1,2,3.0])
+  y3, g3 = withgradient(f3, [1,2,3.0])
+  @test g1[1] ≈ g2[1] ≈ g3[1]
+end
+


### PR DESCRIPTION
Maybe we should allow this:
```julia
julia> withgradient([1,2,4]) do x
          z = 1 ./ x
          sum(z), z
       end
(val = (1.75, [1.0, 0.5, 0.25]), grad = ([-1.0, -0.25, -0.0625],))
```
 i.e. return `(val=f(x), grad=gradient(first∘f, x))` when `f` returns a Tuple: Currently an error. 