### PR TITLE
Remove @adjoint for logabsdet

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -376,8 +376,6 @@ function _pullback(cx::AContext, ::typeof(kron), a::AbstractMatrix, b::AbstractM
   return res, back ∘ unthunk_tangent
 end
 
-@adjoint logabsdet(xs::AbstractMatrix) = logabsdet(xs), Δ -> (Δ[1] * inv(xs)',)
-
 @adjoint function inv(A::Union{Number, AbstractMatrix})
   Ainv = inv(A)
   return Ainv, function (Δ)


### PR DESCRIPTION
This PR removes the `@adjoint` for `logabsdet` from Zygote. There is an equivalent `rrule` defined in ChainRules, so this should be redundant. Merging will close https://github.com/FluxML/Zygote.jl/issues/1431 and will help resolve https://github.com/JuliaDiff/ChainRules.jl/issues/719.
