### PR TITLE
Fix broadcasts which are type unstable with Dual numbers

### DIFF
--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -282,25 +282,40 @@ end
   out = dual_function(f).(args...)
   T = eltype(out)
   if !isconcretetype(T) || T <: Union{Dual, Complex{<:Dual}}
-    return _broadcast_forward(out, args...)
+    if any(eltype(a) <: Complex for a in args)
+      return _broadcast_forward_complex(out, args...)
+    else
+      return _broadcast_forward(out, args...)
+    end
   else
     return (out, _ -> nothing)
   end
 end
 
+# Real input
 @inline _extract_value(x) = value(x)
 @inline _extract_value(x::Complex) = Complex(value(real(x)), value(imag(x)))
-# Real input, real output
-@inline function _broadcast_scalar_pullback(::Type{<:Real}, N, Δz::Real, df, i)
-  return Δz * partials(df, i)
+@inline _broadcast_scalar_pullback(ȳ, out, i) = ȳ * partials(out, i)
+@inline function _broadcast_scalar_pullback(ȳ, out::Complex, i)
+  return real(ȳ) * partials(real(out), i) + imag(ȳ) * partials(imag(out), i)
 end
-# Real input, complex output
-@inline function _broadcast_scalar_pullback(::Type{<:Real}, N, Δz::Complex, df, i)
-  return real(Δz) * partials(real(df), i) + imag(Δz) * partials(imag(df), i)
+@inline function _broadcast_forward(out, args::Vararg{Any, N}) where {N}
+  valN = Val(N)
+  y = broadcast(x -> _extract_value(x), out)
+  function bc_fwd_back(ȳ)
+    dargs = ntuple(valN) do i
+      unbroadcast(args[i], 
+        broadcast((y1, o1) -> _broadcast_scalar_pullback(y1, o1, i), ȳ, out)
+      )
+    end
+    (nothing, nothing, dargs...) # nothings for broadcasted & f
+  end
+  return y, bc_fwd_back
 end
+
 # This handles complex input and real output. We use the gradient definition from ChainRules here
 # since it agrees with what Zygote did for real(x).
-@inline function _broadcast_scalar_pullback(::Type{<:Complex}, N, Δz::Real, df, i)
+@inline function _broadcast_scalar_pullback_complex(N, Δz, df, i)
   return Δz * Complex(partials(df, i), partials(df, i + N))
 end
 # # # This is for complex input and complex output
@@ -309,29 +324,24 @@ end
 # then we do the following for the adjoint
 # Δu ∂u/∂x + Δv∂v/∂x + i(Δu∂u/∂y + Δv ∂v/∂y )
 # this follows https://juliadiff.org/ChainRulesCore.jl/stable/maths/complex.html
-@inline function _broadcast_scalar_pullback(::Type{<:Complex}, N, Δz::Complex, df, i)
+@inline function _broadcast_scalar_pullback_complex(N, Δz, df::Complex, i)
   Δu, Δv = reim(Δz)
   du, dv = reim(df)
   return Complex(Δu * partials(du, i) + Δv * partials(dv, i), Δu * partials(du, i + N) + Δv * partials(dv, i + N))
 end
-@inline function _broadcast_forward(out, args::Vararg{Any, N}) where {N}
-  valN = Val(N)
-  y = broadcast(x -> _extract_value(x), out)
-  function bc_fwd_back(ȳ)
-    dargs = ntuple(valN) do i
-      unbroadcast(args[i], 
-        broadcast(
-          (y1, o1) -> _broadcast_scalar_pullback(eltype(args[i]), N, y1, o1, i), 
-          ȳ, 
-          out
+@inline function _broadcast_forward_complex(out, args::Vararg{Any, N}) where {N}
+    valN = Val(N)
+    y = broadcast(x -> _extract_value(x), out)
+    function bc_fwd_back(ȳ)
+      dargs = ntuple(valN) do i
+        unbroadcast(args[i], 
+          broadcast((y1, o1) -> _broadcast_scalar_pullback_complex(N, y1, o1, i), ȳ, out)
         )
-      )
+      end
+      (nothing, nothing, dargs...) # nothings for broadcasted & f
     end
-    (nothing, nothing, dargs...) # nothings for broadcasted & f
-  end
-  return y, bc_fwd_back
+    return y, bc_fwd_back
 end
-
 
 using GPUArraysCore  # replaces @require CUDA block, weird indenting to preserve git blame
 

--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -281,9 +281,10 @@ end
 @inline function broadcast_forward(f, args::Vararg{Any,N}) where N
   out = dual_function(f).(args...)
   T = eltype(out)
+  println(T)
   if !isconcretetype(T) || T <: Union{Dual, Complex{<:Dual}}
     if any(eltype(a) <: Complex for a in args)
-      return _broadcast_forward_complex(T, out, args...)
+      return _broadcast_forward_complex(out, args...)
     else
       return _broadcast_forward(out, args...)
     end
@@ -315,36 +316,28 @@ end
 
 # This handles complex input and real output. We use the gradient definition from ChainRules here
 # since it agrees with what Zygote did for real(x).
-@inline function _broadcast_forward_complex(::Type{<:Dual}, out, args::Vararg{Any, N}) where {N}
-    valN = Val(N)
-    y = broadcast(x -> value(x), out)
-    function bc_fwd_back(ȳ)
-      dargs = ntuple(valN) do i
-        unbroadcast(args[i], broadcast((y1, o1) -> y1 * Complex(partials(o1, i), partials(o1, i+N)), ȳ, out))
-      end
-      (nothing, nothing, dargs...) # nothings for broadcasted & f
-    end
-    return y, bc_fwd_back
+@inline function _broadcast_scalar_pullback_complex(N, Δz, df::Dual, i)
+  return Δz * Complex(partials(df, i), partials(df, i + N))
 end
-
 # # # This is for complex input and complex output
 # If we assume that
 # f(x + iy) = u(x,y) + iv(x,y)
 # then we do the following for the adjoint
 # Δu ∂u/∂x + Δv∂v/∂x + i(Δu∂u/∂y + Δv ∂v/∂y )
 # this follows https://juliadiff.org/ChainRulesCore.jl/stable/maths/complex.html
-function _adjoint_complex(N, Δz, df, i)
-    Δu, Δv = reim(Δz)
-    du, dv = reim(df)
-    return Complex(Δu*partials(du, i) + Δv*partials(dv, i), Δu*partials(du, i+N) + Δv*partials(dv, i+N))
+function _broadcast_scalar_pullback_complex(N, Δz, df::Complex, i)
+  Δu, Δv = reim(Δz)
+  du, dv = reim(df)
+  return Complex(Δu * partials(du, i) + Δv * partials(dv, i), Δu * partials(du, i + N) + Δv * partials(dv, i + N))
 end
-
-@inline function _broadcast_forward_complex(::Type{<:Complex}, out, args::Vararg{Any, N}) where {N}
+@inline function _broadcast_forward_complex(out, args::Vararg{Any, N}) where {N}
     valN = Val(N)
-    y = broadcast(x -> Complex(value(real(x)), value(imag(x))), out)
+    y = broadcast(x -> _extract_value(x), out)
     function bc_fwd_back(ȳ)
       dargs = ntuple(valN) do i
-        unbroadcast(args[i], broadcast((y1, o1) -> _adjoint_complex(N, y1, o1, i), ȳ, out))
+        unbroadcast(args[i], 
+          broadcast((y1, o1) -> _broadcast_scalar_pullback_complex(N, y1, o1, i), ȳ, out)
+        )
       end
       (nothing, nothing, dargs...) # nothings for broadcasted & f
     end

--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -283,7 +283,7 @@ end
   T = eltype(out)
   if !isconcretetype(T) || T <: Union{Dual, Complex{<:Dual}}
     if any(eltype(a) <: Complex for a in args)
-      return _broadcast_forward_complex(out, args...)
+      return _broadcast_forward_complex(T, out, args...)
     else
       return _broadcast_forward(out, args...)
     end
@@ -297,7 +297,7 @@ end
 @inline _extract_value(x::Complex) = Complex(value(real(x)), value(imag(x)))
 @inline _broadcast_scalar_pullback(ȳ, out, i) = ȳ * partials(out, i)
 @inline function _broadcast_scalar_pullback(ȳ::Complex, out, i)
-  return Complex(real(ȳ) * partials(real(out), i), imag(ȳ) * partials(imag(out), i))
+  return real(ȳ) * partials(real(out), i) + imag(ȳ) * partials(imag(out), i)
 end
 @inline function _broadcast_forward(out, args::Vararg{Any, N}) where {N}
   valN = Val(N)

--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -281,42 +281,26 @@ end
 @inline function broadcast_forward(f, args::Vararg{Any,N}) where N
   out = dual_function(f).(args...)
   T = eltype(out)
-  println(T)
   if !isconcretetype(T) || T <: Union{Dual, Complex{<:Dual}}
-    if any(eltype(a) <: Complex for a in args)
-      return _broadcast_forward_complex(out, args...)
-    else
-      return _broadcast_forward(out, args...)
-    end
+    return _broadcast_forward(out, args...)
   else
     return (out, _ -> nothing)
   end
 end
 
-# Real input
 @inline _extract_value(x) = value(x)
 @inline _extract_value(x::Complex) = Complex(value(real(x)), value(imag(x)))
-@inline _broadcast_scalar_pullback(ȳ, out, i) = ȳ * partials(out, i)
-@inline function _broadcast_scalar_pullback(ȳ::Complex, out, i)
-  return real(ȳ) * partials(real(out), i) + imag(ȳ) * partials(imag(out), i)
+# Real input, real output
+@inline function _broadcast_scalar_pullback(::Type{<:Real}, N, Δz::Real, df, i)
+  return Δz * partials(df, i)
 end
-@inline function _broadcast_forward(out, args::Vararg{Any, N}) where {N}
-  valN = Val(N)
-  y = broadcast(x -> _extract_value(x), out)
-  function bc_fwd_back(ȳ)
-    dargs = ntuple(valN) do i
-      unbroadcast(args[i], 
-        broadcast((y1, o1) -> _broadcast_scalar_pullback(y1, o1, i), ȳ, out)
-      )
-    end
-    (nothing, nothing, dargs...) # nothings for broadcasted & f
-  end
-  return y, bc_fwd_back
+# Real input, complex output
+@inline function _broadcast_scalar_pullback(::Type{<:Real}, N, Δz::Complex, df, i)
+  return real(Δz) * partials(real(df), i) + imag(Δz) * partials(imag(df), i)
 end
-
 # This handles complex input and real output. We use the gradient definition from ChainRules here
 # since it agrees with what Zygote did for real(x).
-@inline function _broadcast_scalar_pullback_complex(N, Δz, df::Dual, i)
+@inline function _broadcast_scalar_pullback(::Type{<:Complex}, N, Δz::Real, df, i)
   return Δz * Complex(partials(df, i), partials(df, i + N))
 end
 # # # This is for complex input and complex output
@@ -325,24 +309,29 @@ end
 # then we do the following for the adjoint
 # Δu ∂u/∂x + Δv∂v/∂x + i(Δu∂u/∂y + Δv ∂v/∂y )
 # this follows https://juliadiff.org/ChainRulesCore.jl/stable/maths/complex.html
-function _broadcast_scalar_pullback_complex(N, Δz, df::Complex, i)
+@inline function _broadcast_scalar_pullback(::Type{<:Complex}, N, Δz::Complex, df, i)
   Δu, Δv = reim(Δz)
   du, dv = reim(df)
   return Complex(Δu * partials(du, i) + Δv * partials(dv, i), Δu * partials(du, i + N) + Δv * partials(dv, i + N))
 end
-@inline function _broadcast_forward_complex(out, args::Vararg{Any, N}) where {N}
-    valN = Val(N)
-    y = broadcast(x -> _extract_value(x), out)
-    function bc_fwd_back(ȳ)
-      dargs = ntuple(valN) do i
-        unbroadcast(args[i], 
-          broadcast((y1, o1) -> _broadcast_scalar_pullback_complex(N, y1, o1, i), ȳ, out)
+@inline function _broadcast_forward(out, args::Vararg{Any, N}) where {N}
+  valN = Val(N)
+  y = broadcast(x -> _extract_value(x), out)
+  function bc_fwd_back(ȳ)
+    dargs = ntuple(valN) do i
+      unbroadcast(args[i], 
+        broadcast(
+          (y1, o1) -> _broadcast_scalar_pullback(eltype(args[i]), N, y1, o1, i), 
+          ȳ, 
+          out
         )
-      end
-      (nothing, nothing, dargs...) # nothings for broadcasted & f
+      )
     end
-    return y, bc_fwd_back
+    (nothing, nothing, dargs...) # nothings for broadcasted & f
+  end
+  return y, bc_fwd_back
 end
+
 
 using GPUArraysCore  # replaces @require CUDA block, weird indenting to preserve git blame
 

--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -281,39 +281,37 @@ end
 @inline function broadcast_forward(f, args::Vararg{Any,N}) where N
   out = dual_function(f).(args...)
   T = eltype(out)
-  T <: Union{Dual, Complex{<:Dual}} || return (out, _ -> nothing)
-  if any(eltype(a) <: Complex for a in args)
-    _broadcast_forward_complex(T, out, args...)
+  if !isconcretetype(T) || T <: Union{Dual, Complex{<:Dual}}
+    if any(eltype(a) <: Complex for a in args)
+      return _broadcast_forward_complex(out, args...)
+    else
+      return _broadcast_forward(out, args...)
+    end
   else
-    _broadcast_forward(T, out, args...)
+    return (out, _ -> nothing)
   end
 end
 
-# Real input and real output pullback
-@inline function _broadcast_forward(::Type{<:Dual}, out, args::Vararg{Any, N}) where {N}
+# Real input
+@inline _extract_value(x) = value(x)
+@inline _extract_value(x::Complex) = Complex(value(real(x)), value(imag(x)))
+@inline _broadcast_scalar_pullback(ȳ, out, i) = ȳ * partials(out, i)
+@inline function _broadcast_scalar_pullback(ȳ::Complex, out, i)
+  return Complex(real(ȳ) * partials(real(out), i), imag(ȳ) * partials(imag(out), i))
+end
+@inline function _broadcast_forward(out, args::Vararg{Any, N}) where {N}
   valN = Val(N)
-  y = broadcast(x -> value(x), out)
+  y = broadcast(x -> _extract_value(x), out)
   function bc_fwd_back(ȳ)
     dargs = ntuple(valN) do i
-      unbroadcast(args[i], broadcast((y1, o1) -> y1 * partials(o1,i), ȳ, out))
+      unbroadcast(args[i], 
+        broadcast((y1, o1) -> _broadcast_scalar_pullback(y1, o1, i), ȳ, out)
+      )
     end
     (nothing, nothing, dargs...) # nothings for broadcasted & f
   end
   return y, bc_fwd_back
 end
-
-# This handles the complex output and real input pullback
-@inline function _broadcast_forward(::Type{<:Complex}, out, args::Vararg{Any, N}) where {N}
-    valN = Val(N)
-    y = broadcast(x -> Complex(value(real(x)), value(imag(x))), out)
-    function bc_fwd_back(ȳ)
-      dargs = ntuple(valN) do i
-        unbroadcast(args[i], broadcast((y1, o1) -> (real(y1)*partials(real(o1),i) + imag(y1)*partials(imag(o1), i)), ȳ, out))
-      end
-      (nothing, nothing, dargs...) # nothings for broadcasted & f
-    end
-    return y, bc_fwd_back
-  end
 
 # This handles complex input and real output. We use the gradient definition from ChainRules here
 # since it agrees with what Zygote did for real(x).

--- a/test/features.jl
+++ b/test/features.jl
@@ -798,6 +798,9 @@ end
   @test gradient(xs -> sum(map((x -> x<2 ? false : x^2), xs)), [1,2,3])[1][2:3] == [4, 6]
   @test gradient(xs -> mapreduce((x -> x<2 ? false : x^2), +, xs), [1,2,3])[1][2:3] == [4, 6]
 
+  # type stable forward pass with input, but type unstable with dualized input
+  
+
   # with Ref, Val, Symbol
   @test gradient(x -> sum(x .+ Ref(x[1])), [1,2,3]) == ([4,1,1],)
   @test gradient(x -> sum(x .+ (x[1],)), [1,2,3]) == ([4,1,1],)


### PR DESCRIPTION
Closes https://github.com/FluxML/Zygote.jl/issues/1439.

This is acheived by moving a dispatch from the element type of the output of broadcasting, to each individual element within the pullback, along with ensuring non-concrete element type arrays take the same path as concrete Dual arrays. This should hopefully compile away when the eltype is concrete, and indeed some simple benchmarks show no loss of performance, but I've hardly been exhaustive.

I've also added a few tests covering various real / complex input / output combinations, and a specific case that produced errors before rather than silently failing.

While its nice that this works, it could be worth adding a note to the documentation about the performance of broadcasting which has a type stable forward pass but becomes type unstable on Dual inputs, and perhaps that likewise such Dual input stability is required for the code to work on the GPU. But I'm not sure where that could go.

### PR Checklist

- [x] Tests are added
- [ ] Documentation, if applicable
