### PR TITLE
Adjoint for `parent` for `LowerTriangular` and `UpperTriangular`

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -355,6 +355,8 @@ end
 
 @adjoint parent(x::LinearAlgebra.Adjoint) = parent(x), ȳ -> (LinearAlgebra.Adjoint(ȳ),)
 @adjoint parent(x::LinearAlgebra.Transpose) = parent(x), ȳ -> (LinearAlgebra.Transpose(ȳ),)
+@adjoint parent(x::LinearAlgebra.UpperTriangular) = parent(x), ȳ -> (LinearAlgebra.UpperTriangular(ȳ),)
+@adjoint parent(x::LinearAlgebra.LowerTriangular) = parent(x), ȳ -> (LinearAlgebra.LowerTriangular(ȳ),)
 
 function _kron(mat1::AbstractMatrix,mat2::AbstractMatrix)
     m1, n1 = size(mat1)

--- a/test/lib/array.jl
+++ b/test/lib/array.jl
@@ -96,3 +96,13 @@ end
         end
     end
 end
+
+@testset "parent" begin
+    @testset "$constructor" for constructor in [LowerTriangular, UpperTriangular]
+        x = randn(2, 2)
+        y, pb = Zygote.pullback(x) do x
+            sum(parent(constructor(2 .* x)))
+        end
+        @test first(pb(one(y))) ≈ constructor(2 * ones(2, 2))
+    end
+end


### PR DESCRIPTION
`LowerTriangular` and `UpperTriangular` is missing adjoints for `parent` which can lead to downstream issues: https://github.com/TuringLang/Bijectors.jl/pull/280#issuecomment-1668051434

This PR adds those, similar to the existing for `Adjoint` and `Transposed`.

It's unclear to me whether this should actually go into ChainRules.jl or not :confused:

I'll add tests in a bit.