### PR TITLE
Handle `Expr(:boundscheck)`

### DIFF
--- a/src/compiler/reverse.jl
+++ b/src/compiler/reverse.jl
@@ -132,6 +132,10 @@ function instrument(ir::IR)
     elseif isexpr(ex, :(=))
       @assert ex.args[1] isa GlobalRef
       pr[v] = xcall(Zygote, :global_set, QuoteNode(ex.args[1]), ex.args[2])
+    elseif isexpr(ex, :boundscheck)
+      # Expr(:boundscheck) now appears in common Julia code paths, so we need to handle it.
+      # For correctness sake, fix to true like https://github.com/dfdx/Umlaut.jl/issues/34.
+      pr[v] = true
     else
       ex = instrument_new!(pr, v, ex)
       ex = instrument_literals!(pr, v, ex)

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -225,3 +225,12 @@ end
 
 # issue 897
 @test gradient(x -> sum(norm, collect(eachcol(x))), ones(3, 400))[1] ≈ fill(0.5773502691896258, 3, 400)
+
+# Tests adapted from https://github.com/dfdx/Umlaut.jl/pull/35
+@eval _boundscheck_foo(x) = ifelse($(Expr(:boundscheck)), 2x, x)
+
+@testset "Meta Expr handling" begin
+  y, (dx,) = withgradient(_boundscheck_foo, 1)
+  @test y == 2
+  @test dx == 2
+end


### PR DESCRIPTION
Fixes https://github.com/FluxML/Zygote.jl/issues/1438. We follow the same route as [Diffractor](https://github.com/JuliaDiff/Diffractor.jl/pull/177)and [Umlaut](https://github.com/dfdx/Umlaut.jl/pull/35)/Yota by always turning on bounds checking for correctness.

### PR Checklist

- [x] Tests are added
- [N/A] Documentation, if applicable
