### PR TITLE
Fix `accum` genfunc error on nightly

### DIFF
--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -27,7 +27,7 @@ accum(x::AbstractArray, ys::AbstractArray...) = accum.(x, ys...)
 @generated function accum(x::NamedTuple, y::NamedTuple)
   # assumes that y has no keys apart from those also in x
   if fieldnames(y) ⊈ fieldnames(x)
-    return :(throw(ArgumentError("$y keys must be a subset of $x keys")))
+    return :(throw(ArgumentError("$(typeof(y)) keys must be a subset of $(typeof(x)) keys")))
   end
 
   grad(field) = field in fieldnames(y) ? :(y.$field) : :nothing

--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -26,7 +26,9 @@ accum(x::AbstractArray, ys::AbstractArray...) = accum.(x, ys...)
 
 @generated function accum(x::NamedTuple, y::NamedTuple)
   # assumes that y has no keys apart from those also in x
-  fieldnames(y) ⊆ fieldnames(x) || throw(ArgumentError("$y keys must be a subset of $x keys"))
+  if fieldnames(y) ⊈ fieldnames(x)
+    return :(throw(ArgumentError("$y keys must be a subset of $x keys")))
+  end
 
   grad(field) = field in fieldnames(y) ? :(y.$field) : :nothing
   Expr(:tuple, [:($f=accum(x.$f, $(grad(f)))) for f in fieldnames(x)]...)


### PR DESCRIPTION
Somewhere between 1.10 and 1.11, world age handling and permitted operations in `@generated` functions became more strict. This makes string interpolation fail, apparently.

Alongside #1462, this should fix the remaining visible errors on nightly CI.

### PR Checklist

- [ ] Tests are added
- [ ] Documentation, if applicable
