### PR TITLE
Swap PyCall to PythonCall

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -68,9 +68,9 @@ Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
-PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
+PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 
 [targets]
-test = ["ChainRulesTestUtils", "Conda", "CUDA", "Distances", "FFTW", "FiniteDifferences", "PyCall", "Test"]
+test = ["ChainRulesTestUtils", "Conda", "CUDA", "Distances", "FFTW", "FiniteDifferences", "PythonCall", "Test"]

--- a/test/features.jl
+++ b/test/features.jl
@@ -689,7 +689,7 @@ end
   using PythonCall: pyimport, pyconvert
   math = pyimport("math")
   pysin(x) = math.sin(x)
-  Zygote.@adjoint pysin(x) = pyconvert(Float64, math.sin(x)), δ -> (δ * math.cos(x),)
+  Zygote.@adjoint pysin(x) = pyconvert(Float64, math.sin(x)), δ -> (pyconvert(Float64, δ * math.cos(x)),)
   @test Zygote.gradient(pysin, 1.5) == Zygote.gradient(sin, 1.5)
 end
 

--- a/test/features.jl
+++ b/test/features.jl
@@ -686,10 +686,10 @@ end
 end
 
 @testset "PythonCall custom @adjoint" begin
-  using PythonCall: pyimport
+  using PythonCall: pyimport, pyconvert
   math = pyimport("math")
   pysin(x) = math.sin(x)
-  Zygote.@adjoint pysin(x) = math.sin(x), (δ) -> (δ * math.cos(x), )
+  Zygote.@adjoint pysin(x) = pyconvert(Float64, math.sin(x)), δ -> (δ * math.cos(x),)
   @test Zygote.gradient(pysin, 1.5) == Zygote.gradient(sin, 1.5)
 end
 

--- a/test/features.jl
+++ b/test/features.jl
@@ -685,13 +685,9 @@ end
   end == ([8 112; 36 2004],)
 end
 
-@testset "PyCall custom @adjoint" begin
-  # Trigger Python install if required. Required for Buildkite CI!
-  import Conda
-  Conda.list()
-
-  import PyCall
-  math = PyCall.pyimport("math")
+@testset "PythonCall custom @adjoint" begin
+  using PythonCall: pyimport
+  math = pyimport("math")
   pysin(x) = math.sin(x)
   Zygote.@adjoint pysin(x) = math.sin(x), (δ) -> (δ * math.cos(x), )
   @test Zygote.gradient(pysin, 1.5) == Zygote.gradient(sin, 1.5)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,17 +1,17 @@
 using Zygote, Test, LinearAlgebra
 using Zygote: gradient, ZygoteRuleConfig
-using CUDA
-using CUDA: has_cuda
 
 @testset "all" begin  # Overall testset ensures it keeps running after failure
-
-  if has_cuda()
-    @testset "CUDA tests" begin
-      include("cuda.jl")
+  if !haskey(ENV, "GITHUB_ACTION")
+    using CUDA
+    if CUDA.has_cuda()
+      @testset "CUDA tests" begin
+        include("cuda.jl")
+      end
+      @info "CUDA tests have run"
+    else
+      @warn "CUDA not found - Skipping CUDA Tests"
     end
-    @info "CUDA tests have run"
-  else
-    @warn "CUDA not found - Skipping CUDA Tests"
   end
 
   @testset "deprecated.jl" begin


### PR DESCRIPTION
The former was giving us setup-related headaches on CI, and we can use any Python FFI for the one test which needs it.

As a bonus, stops loading CUDA.jl on GHA so we can get rid of errors on nightly. Hopefully with this we'll be back to green CI.

### PR Checklist

- [x] Tests are added
- [ ] ~~Documentation, if applicable~~
