### PR TITLE
fix broadcasting into buffers

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -168,7 +168,7 @@ _reverse(x::Symmetric) = Symmetric(_reverse(x.data), x.uplo == 'U' ? :L : :U)
 
 # With mismatched lengths, map stops early. With mismatched shapes, it makes a vector.
 # So we keep axes(x) to restore gradient dx to its full length & correct shape.
-_tryaxes(x) = axes(x)
+_tryaxes(x::AbstractArray) = axes(x)
 _tryaxes(x::Tuple) = Val(length(x))
 _tryaxes(x::Number) = x
 _restore(dx::AbstractArray{Nothing}, ax::Tuple) = similar(dx, ax)

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -323,9 +323,10 @@ end
 takefunc(itr, dy) = _restore(dy, _tryaxes(itr))
 
 @adjoint function Iterators.take(itr, n)
+  take_pullback(::AbstractArray{Nothing}) = nothing
   take_pullback(dy::NamedTuple{(:xs,:n)}) = (dy.xs, dy.n)
   take_pullback(dy::NamedTuple{(:n,:xs)}) = (dy.xs, dy.n)
-  take_pullback(dy) = (takefunc(itr, dy), nothing)
+  take_pullback(dy::AbstractArray) = (takefunc(itr, dy), nothing)
   Iterators.take(itr, n), take_pullback
 end
 

--- a/src/lib/buffer.jl
+++ b/src/lib/buffer.jl
@@ -44,7 +44,7 @@ end
   end
 end
 
-_pullback(cx::AContext, ::typeof(Broadcast.materialize!), b::Buffer, x::AbstractArray) =
+_pullback(cx::AContext, ::typeof(Broadcast.materialize!), b::Buffer, x) =
   _pullback(cx, copyto!, b, x)
 
 @adjoint function copy(b::Buffer)

--- a/src/lib/buffer.jl
+++ b/src/lib/buffer.jl
@@ -48,6 +48,16 @@ end
   copyto!(b, xs), copyto!_buffer_broadcast_pullback
 end
 
+function _pullback(cx::AContext, ::typeof(copyto!), b::Buffer, g::Base.Generator)
+    xs, collect_pullback = _pullback(cx, collect, g)
+    function copyto!_buffer_generator_pullback(_)
+        grad = grad_mut(cx, b)
+        _, dg = collect_pullback(reshape(first(grad, length(xs)), size(xs)))
+        return (nothing, nothing, dg)
+    end
+    copyto!(b, xs), copyto!_buffer_generator_pullback
+  end
+
 @adjoint! function push!(b::Buffer, x)
   function push!_buffer_pullback(_)
     grad = grad_mut(__context__, b)

--- a/src/lib/buffer.jl
+++ b/src/lib/buffer.jl
@@ -7,15 +7,16 @@ grad_mut(cx::Context, b::Buffer{T}, ::Type{S}=Union{}) where {T<:Number, S<:Numb
 @non_differentiable Buffer(::Any...)
 
 @adjoint function getindex(b::Buffer, i...)
-  b[i...], function (Δ)
+  function getindex_buffer_pullback(Δ)
     grad = grad_mut(__context__, b, eltype(Δ))
     grad[i...] = accum(grad[i...], Δ)
     return
   end
+  b[i...], getindex_buffer_pullback
 end
 
 @adjoint! function setindex!(b::Buffer, v, i...)
-  setindex!(b, v, i...), function (_)
+  function setindex!_buffer_pullback(_)
     grad = grad_mut(__context__, b)
     v̄ = grad[i...]
     zero = eltype(grad) <: Number ? 0 : nothing
@@ -26,22 +27,25 @@ end
     end
     (nothing, v̄, map(_->nothing, i)...)
   end
+  setindex!(b, v, i...), setindex!_buffer_pullback
 end
 
 @adjoint! function copyto!(b::Buffer, bc::Base.Broadcast.Broadcasted)
   xs, map_pullback = ∇map(__context__, i -> bc[i], eachindex(bc))
-  copyto!(b, xs), function (_)
+  function copyto!_buffer_pullback(_)
     grad = grad_mut(__context__, b)
     d, = map_pullback(reshape(first(grad, length(xs)), size(xs)))
     return (nothing, nothing, d.bc)
   end
+  copyto!(b, xs), copyto!_buffer_pullback
 end
 
 @adjoint! function push!(b::Buffer, x)
-  push!(b, x), function (y)
+  function push!_buffer_pullback(_)
     grad = grad_mut(__context__, b)
     return (nothing, pop!(grad))
   end
+  push!(b, x), push!_buffer_pullback
 end
 
 

--- a/src/tools/buffer.jl
+++ b/src/tools/buffer.jl
@@ -72,8 +72,8 @@ function Base.deleteat!(b::Buffer, i)
   return b
 end
 
-@forward Buffer.data  Base.eltype, Base.length, Base.ndims, Base.size, Base.axes, 
-                      Base.eachindex, Base.stride, Base.strides, Base.findfirst, 
+@forward Buffer.data  Base.eltype, Base.length, Base.ndims, Base.size, Base.axes,
+                      Base.eachindex, Base.stride, Base.strides, Base.findfirst,
                       Base.keys
 
 Base.IteratorSize(::Type{<:Buffer{<:Any, A}}) where {A} = Base.IteratorSize(A)
@@ -84,3 +84,5 @@ function Base.iterate(b::Buffer, state=(eachindex(b),))
   y === nothing && return nothing
   b[y[1]], (state[1], tail(y)...)
 end
+
+Base.BroadcastStyle(::Type{Buffer{T,A}}) where {T,A} = Base.BroadcastStyle(A)

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -1544,6 +1544,12 @@ using Zygote: Buffer
     return sum(copy(b))
   end == (nothing,)
 
+  @test gradient(1.1) do p
+    b = Zygote.Buffer(zeros(3))
+    b .= (p*i for i in eachindex(b))
+    return sum(copy(b) .* (2:4))
+  end[1] ≈ 1*2 + 2*3 + 3*4
+
   @test gradient(2) do x
     b = Zygote.Buffer([])
     push!(b, x)

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -1573,11 +1573,17 @@ using Zygote: Buffer
     return sum(copy(b) .* (2:4))
   end[1] ≈ 1*2 + 2*3 + 3*4
 
-  @test_broken gradient(1.1) do p
+  @test gradient(1.1) do p
     b = Zygote.Buffer(zeros(3))
     copyto!(b, (p*i for i in eachindex(b)))
     return sum(copy(b) .* (2:4))
   end[1] ≈ 1*2 + 2*3 + 3*4
+
+  @test_broken gradient(1.1) do p
+    b = Zygote.Buffer(zeros(3))
+    copyto!(b, p)
+    return sum(copy(b) .* (2:4))
+  end[1] ≈ 1*2
 
   @test gradient(2) do x
     b = Zygote.Buffer([])

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -523,7 +523,7 @@ end
   @test gradtest(x -> maximum(x, dims=[1, 2]), rand(2, 3, 4))
 
   @test gradient(x -> 1 / maximum(x), [1., 2, 3])[1] == [0, 0, -1/9]
-  
+
   # issue 1224, second order
   f1244(w, x) = sum(maximum((w * x).^2, dims=1))
   g1244(w, x) = sum(gradient(f1244, w, x)[2].^2)
@@ -1538,6 +1538,12 @@ using Zygote: Buffer
     return sum(copy(b))
   end == ([2,2,2],)
 
+  @test gradient([1, 2, 3]) do xs
+    b = Zygote.Buffer(xs)
+    b .= 2
+    return sum(copy(b))
+  end == (nothing,)
+
   @test gradient(2) do x
     b = Zygote.Buffer([])
     push!(b, x)
@@ -1701,7 +1707,7 @@ end
 end
 
 @testset "FillArrays" begin
-  
+
   @test gradcheck(x->sum(Fill(x[], (2, 2))), [0.1])
   @test first(Zygote.gradient(sz->sum(Ones(sz)), 6)) === nothing
   @test first(Zygote.gradient(sz->sum(Zeros(sz)), 6)) === nothing


### PR DESCRIPTION
Hi,

I'm using Zygote as an AD backend in Integrals.jl and while I was writing tests I noticed I couldn't assign a number to length-1 `Buffer` using broadcasting. I think this is because the method signature for the pullback on `materialize!` is too restrictive, since `copyto!` allows for arbitrary iterators on the rhs of `buf .= itr`. I also added a test for a MWE.

### PR Checklist

- [X] Tests are added
- [X] Documentation, if applicable

Update: A more complete MWE brings up a second issue:
<details>
<summary>MWE 2</summary>

```julia
julia> using Zygote
julia> gradient(1) do p
           b = Zygote.Buffer([1,2,3])
           b .= p
           return sum(copy(b))
         end
ERROR: MethodError: no method matching (::ChainRulesCore.ProjectTo{Float64, @NamedTuple{}})(::Vector{Float64})

Closest candidates are:
  (::ChainRulesCore.ProjectTo{T})(::ChainRulesCore.NotImplemented) where T
   @ ChainRulesCore ~/.julia/packages/ChainRulesCore/zoCjl/src/projection.jl:121
  (::ChainRulesCore.ProjectTo{<:Number})(::ChainRulesCore.Tangent{<:Complex})
   @ ChainRulesCore ~/.julia/packages/ChainRulesCore/zoCjl/src/projection.jl:192
  (::ChainRulesCore.ProjectTo{<:Number})(::ChainRulesCore.Tangent{<:Number})
   @ ChainRulesCore ~/.julia/packages/ChainRulesCore/zoCjl/src/projection.jl:193
  ...

Stacktrace:
 [1] _project
   @ Zygote ~/.julia/dev/Zygote/src/compiler/chainrules.jl:189 [inlined]
 [2] map(f::typeof(Zygote._project), t::Tuple{Int64}, s::Tuple{Vector{Float64}})
   @ Base ./tuple.jl:318
 [3] gradient(::Function, ::Int64, ::Vararg{Int64})
   @ Zygote ~/.julia/dev/Zygote/src/compiler/interface.jl:98
 [4] top-level scope
   @ REPL[11]:1
```
</details>

Update 2: I added an adjoint for copyto! that fixes the MWE, however I'll try to add a generic adjoint for `copyto!(buffer, itr)` next

Update 3: I started about this the wrong way and the manual has [details here](https://docs.julialang.org/en/v1/manual/interfaces/#man-interfaces-broadcasting) on how to bypass broadcasting machinery, so an adjoint for `Base.materialize!` will have to be discarded and has to be replaced by an adjoint for `copyto!(buffer, broadcasted)`

Update 4: I finished writing an adjoint and added a test for broadcasted assignment to a buffer from a generator. I'll happily incorporate any feedback and improvements.