### PR TITLE
Preserve 0d arrays in `Zygote.accum`

### DIFF
--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -22,7 +22,7 @@ accum(x, y) =
 accum(x, y, zs...) = accum(accum(x, y), zs...)
 
 accum(x::Tuple, ys::Tuple...) = map(accum, x, ys...)
-accum(x::AbstractArray, ys::AbstractArray...) = accum.(x, ys...)
+accum(x::AbstractArray, ys::AbstractArray...) = Base.broadcast_preserving_zero_d(accum, x, ys...)
 
 @generated function accum(x::NamedTuple, y::NamedTuple)
   # assumes that y has no keys apart from those also in x

--- a/test/lib/lib.jl
+++ b/test/lib/lib.jl
@@ -4,5 +4,6 @@
         t2 = (a=1, b=2)
         @test Zygote.accum(t1, t2) == (a = 2, b = 4, c = 3)
         @test_throws ArgumentError Zygote.accum(t2, t1)
+        @test Zygote.accum(fill(0.0), fill(0.0)) == fill(0.0)
     end
 end


### PR DESCRIPTION
`Zygote.accum` mirrored an [old Julia bug](https://github.com/JuliaLang/julia/issues/28866) that got fixed by Julia 1.6, which is the version supported by Zygote. This pr changes the behavior to match Julia's

### PR Checklist

- [x] Tests are added
- [x] Documentation, if applicable
