### PR TITLE
Remove `@adjoint`s for `sort` and `filter`

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -251,20 +251,6 @@ end
 
 @adjoint iterate(r::UnitRange, i...) = iterate(r, i...), _ -> nothing
 
-@adjoint function sort(x::AbstractArray; by=identity)
-  p = sortperm(x, by=by)
-  return x[p], x̄ -> (x̄[invperm(p)],)
-end
-
-@adjoint function filter(f, x::AbstractVector)
-    t = map(f, x)
-    x[t], Δ -> begin
-        dx = _zero(x, eltype(Δ))
-        dx[t] .= Δ
-        (nothing, dx)
-    end
-end
-
 # Iterators
 
 @adjoint function enumerate(xs)

--- a/test/gradcheck.jl
+++ b/test/gradcheck.jl
@@ -425,13 +425,17 @@ end
       [2,3,1],
       [1, 2, 3],
       [1,2,3],
-      [2,1,3]
+      [2,1,3],
+      [1,3,2],
+      [3,2,1]
   ]
   for i = 1:3
     @test gradient(v->sort(v)[i], [3.,1,2])[1][correct[1][i]] == 1
     @test gradient(v->sort(v)[i], [1.,2,3])[1][correct[2][i]] == 1
     @test gradient(v->sort(v,by=x->x%10)[i], [11,2,99])[1][correct[3][i]] == 1
     @test gradient(v->sort(v,by=x->x%10)[i], [2,11,99])[1][correct[4][i]] == 1
+    @test gradient(v->sort(v,rev=true)[i], [3.,1,2])[1][correct[5][i]] == 1
+    @test gradient(v->sort(v,rev=true)[i], [1.,2,3])[1][correct[6][i]] == 1
   end
 end
 


### PR DESCRIPTION
This removes the definitions of `sort` and `filter`, as these are covered by ChainRules.
This also fixes #1492 , as the ChainRules `rrule` for `sort` includes all keywords.