### PR TITLE
Add rule for `push!(::IdSet)`

### DIFF
--- a/src/lib/base.jl
+++ b/src/lib/base.jl
@@ -17,6 +17,19 @@ end
   end
 end
 
+# IdSet (needed for nested AD with implicit params)
+
+grad_mut(::IdSet) = IdSet()
+
+function _pullback(cx::AContext, ::typeof(push!), s::IdSet, @nospecialize(x))
+  res = push!(s, x)
+  function idset_push!_pullback(_)
+    Δ = pop!(grad_mut(cx, s), x, nothing)
+    (nothing, Δ, nothing)
+  end
+  return res, idset_push!_pullback
+end
+
 # Dictionaries
 
 grad_mut(d::AbstractDict) = Dict()


### PR DESCRIPTION
This is required on 1.11 because the underlying implementation changed in https://github.com/JuliaLang/julia/commit/cb01a3b4521abbca1756f64537082561e815dc5e from using an IdDict (which Zygote can diff through) to a direct `ccall`.

### PR Checklist

- [x] Tests are added
- [ ] ~~Documentation, if applicable~~
