### PR TITLE
Un-collapse nothings in `gradient`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -57,7 +57,7 @@ Requires = "1.1"
 SpecialFunctions = "1.6, 2"
 Statistics = "1"
 Tracker = "0.2"
-ZygoteRules = "0.2.4"
+ZygoteRules = "0.2.5"
 julia = "1.6"
 
 [extras]

--- a/test/lib/number.jl
+++ b/test/lib/number.jl
@@ -3,8 +3,8 @@
     @test gradient(floor, 1) === (0.0,)
     @test gradient(ceil, 1) === (0.0,)
     @test gradient(round, 1) === (0.0,)
-    @test gradient(hash, 1) === nothing
-    @test gradient(div, 1, 2) === nothing
+    @test gradient(hash, 1) === (nothing,)
+    @test gradient(div, 1, 2) === (nothing, nothing)
   end
 
   @testset "basics" begin

--- a/test/structures.jl
+++ b/test/structures.jl
@@ -64,5 +64,5 @@ end
   end
 
   m, b = Zygote._pullback(Zygote.Context(), nameof, M)
-  @test b(m) == (nothing, nothing)
+  @test b(m) === nothing
 end


### PR DESCRIPTION
Companion to https://github.com/FluxML/ZygoteRules.jl/pull/26. After some discussion in https://github.com/FluxML/Zygote.jl/pull/1466 and elsewhere, we decided preserving the Tuple return was the way to go.

### PR Checklist

- [x] Tests are added
- [x] Documentation, if applicable
