### PR TITLE
Prefer numeric zero over ZeroTangent for numeric arrays

### DIFF
--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -162,6 +162,7 @@ end
 # For arrays, whitelist the safe ones, but always look inside Any[]:
 @inline wrap_chainrules_input(dxs::AbstractArray{<:Number}) = dxs
 @inline wrap_chainrules_input(dxs::AbstractArray{<:AbstractArray{<:Number}}) = dxs
+@inline wrap_chainrules_input(dxs::AbstractArray{<:Union{Nothing,T}}) where T <: Number = map(x -> x === nothing ? zero(T) : x, dxs)
 @inline wrap_chainrules_input(dxs::AbstractArray) = map(wrap_chainrules_input, dxs)
 
 #=

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -420,3 +420,15 @@ end
     @test z2d_compiled.c.a === z2d_fallback.c.a
     @test z2d_compiled.c.b === z2d_fallback.c.b
 end
+
+@testset "ChainRules translation" begin
+    @test Zygote.wrap_chainrules_input(nothing) == ZeroTangent()
+    @test Zygote.wrap_chainrules_input((nothing,)) == ZeroTangent()
+    @test Zygote.wrap_chainrules_input([nothing]) == ZeroTangent()
+    @test Zygote.wrap_chainrules_input(((1.0, 2.0), 3.0)) == Tangent{Any}(Tangent{Any}(1.0, 2.0), 3.0)
+    @test Zygote.wrap_chainrules_input((; a = 1.0, b = 2.0)) == Tangent{Any}(a = 1.0, b = 2.0)
+    @test Zygote.wrap_chainrules_input(Ref(1)) == 1
+    @test Zygote.wrap_chainrules_input([2.0; 4.0]) == [2.0; 4.0]
+    @test Zygote.wrap_chainrules_input([[2.0; 4.0], [1.0; 3.0]]) == [[2.0; 4.0], [1.0; 3.0]]
+    @test Zygote.wrap_chainrules_input([nothing; 4.0]) == [0.0; 4.0] # ChainRules uses the numeric zero where possible
+end


### PR DESCRIPTION
If Zygote produces an `Array{Union{Nothing, <: Number}}`, when passed through `wrap_chainrules_input`, produces an `Array{Any}` because the `nothing` objects are mapped to `ZeroTangent` objects. However, ChainRules uses the `zero` of the type whenever possible so that the array maintains a concrete element type. This PR provides such a method.

Related to https://github.com/JuliaDiff/ChainRules.jl/issues/807

Note: It's possible that this case was only possible due to an upstream issue. Currently, I suspect that when Zygote provides an array with Tangents with NamedTuple components and ZeroTangents, the components of the NamedTuple are extracted and the ZeroTangent is mapped to `nothing` instead of performing the `zero(T)` optimization. But I wasn't able to track down the responsible code yet.

Also added tests to cover the related methods.

### PR Checklist

- [x] Tests are added
- [x] Documentation, if applicable **Doesn't seem to be documented in any way**
