### PR TITLE
Allow pullback through 0-length arrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Zygote"
 uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
-version = "0.6.71"
+version = "0.6.72"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -282,7 +282,8 @@ z2d(::Tuple{Vararg{Nothing}}, ::Tuple) = NoTangent()  # collapse all-zero case
 z2d(dx, ::Any) = dx
 z2d(dx::AbstractArray{<:Number}, primal::AbstractArray) = dx
 z2d(dx::AbstractArray{<:AbstractArray{<:Number}}, primal::AbstractArray) = dx
-z2d(dx::AbstractArray, primal::AbstractArray) = map(z2d, dx, primal)
+z2d(dx::AbstractArray, primal::AbstractArray) = isempty(dx) ? NoTangent() : map(Zygote.z2d, dx, primal)
+
 #=
 # As an optimisation, we can convert by `reinterpret` for bitstypes, e.g. arrays of tuples of numbers
 function z2d(dx::AbstractArray{S}, primal::AbstractArray{P}) where {S,P}

--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -55,7 +55,7 @@ end
 
 function unbroadcast(x::AbstractArray, x̄)
   N = ndims(x̄)
-  if length(x) == length(x̄)
+  if size(x) == size(x̄)
     _project(x, x̄)  # ProjectTo handles reshape, offsets, structured matrices, row vectors
   else
     dims = ntuple(d -> size(x, d) == 1 ? d : ndims(x̄)+1, ndims(x̄))

--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -55,7 +55,7 @@ end
 
 function unbroadcast(x::AbstractArray, x̄)
   N = ndims(x̄)
-  if size(x) == size(x̄)
+  if length(x) == length(x̄)
     _project(x, x̄)  # ProjectTo handles reshape, offsets, structured matrices, row vectors
   else
     dims = ntuple(d -> size(x, d) == 1 ? d : ndims(x̄)+1, ndims(x̄))

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -419,6 +419,9 @@ end
     @test z2d_compiled.d === z2d_fallback.d
     @test z2d_compiled.c.a === z2d_fallback.c.a
     @test z2d_compiled.c.b === z2d_fallback.c.b
+
+    # empty arrays => NoTangent()
+    @test z2d(ones(1, 0), ones(16, 0)) === NoTangent()
 end
 
 @testset "ChainRules translation" begin


### PR DESCRIPTION
I'm having trouble boiling down a MWE, because it seems to depend on other factors? But it is related to executing the pullback through a form like this:

```
@views foo.(eachrow(μs)[mask], eachrow(σs)[mask], permutedims(eachcol(x)[xmask]))
```

`unbroadcast` only compares lengths of the inputs, but arrays with a 0-length dimension will naturally have the same length. In this PR, `NoTangent()` is returned if a zero-length array is recieved.

Test for the transform added, but unfortunately without an MWE can't test the broadcast directly.

```
ERROR: DimensionMismatch: dimensions must match: a has dims (Base.OneTo(1600), Base.OneTo(0)), b has dims (Base.OneTo(1), Base.OneTo(0)), mismatch at 1
Stacktrace:
  [1] promote_shape
    @ .\indices.jl:178 [inlined]
  [2] _promote_tuple_shape
    @ .\iterators.jl:394 [inlined]
  [3] axes
    @ .\iterators.jl:391 [inlined]
  [4] axes
    @ .\generator.jl:52 [inlined]
  [5] _similar_shape
    @ .\array.jl:711 [inlined]
  [6] collect(itr::Base.Generator{Base.Iterators.Zip{Tuple{…}}, Base.var"#4#5"{typeof(Zygote.z2d)}})
    @ Base .\array.jl:833
  [7] map
    @ .\abstractarray.jl:3409 [inlined]
  [8] z2d
    @ 
  [9] zygote2differential
    @ C:\Users\nicho\.julia\packages\Zygote\Tt5Gx\src\compiler\chainrules.jl:275 [inlined]
 [10] _project
    @ 
 [11] unbroadcast(x::Base.ReshapedArray{SubArray{…}, 2, SubArray{…}, Tuple{}}, x̄::Matrix{Any})
    @
```