### PR TITLE
Eager parameter updating

### DIFF
--- a/docs/src/utils.md
+++ b/docs/src/utils.md
@@ -26,6 +26,7 @@ Zygote.hook
 Zygote.Buffer
 Zygote.forwarddiff
 Zygote.checkpointed
+Zygote.eager_update!
 ```
 
 `Params` and `Grads` can be copied to and from arrays using the `copy!` function.

--- a/src/lib/grad.jl
+++ b/src/lib/grad.jl
@@ -57,7 +57,7 @@ function Zygote._pullback(ctx::Zygote.AContext, ::typeof(eager_update!), f,(mode
     function pullback_eager_update!(Δy)
         y, pb = Zygote._pullback(ctx, f, model, xs...)
         ret = pb(Δy)
-        update(state, model, ret[2])
+        update!(state, model, ret[2])
         return (nothing, nothing, (nothing, ret[3:end]...), nothing)
     end
     return y, pullback_eager_update!

--- a/src/lib/grad.jl
+++ b/src/lib/grad.jl
@@ -39,19 +39,19 @@ Eagerly updates the model parameters, discarding the updated gradients to save m
 
 If `f` is a function that takes a single layer, called as `h = f(model.layers[i], h, other_args...)` then we can eagerly update with:
 
-```
+```julia
 h = f(Zygote.eager_update!(state.layers[i], model.layers[i], Optimisers.update!), h, other_args...)
 ```
 
 or combine this with gradient checkpointing (for additional memory saving at the cost of increased execution time) with:
 
-```
+```julia
 h = Zygote.checkpointed(f, eager_update!(state.layers[i], model.layers[i], Optimisers.update!), h, other_args...)
 ```
 
 If `model.layers[i]` itself is callable, we can use the above by first wrapping it:
 
-```
+```julia
 f(model, xs...) = model(xs...)
 h = f(Zygote.eager_update!(state.layers[i], model.layers[i], Optimisers.update!), h, other_args...)
 ```

--- a/src/lib/grad.jl
+++ b/src/lib/grad.jl
@@ -50,6 +50,9 @@ If eg. `f` needs to call `model.layers[i]` (which holds the parameters) as `f(mo
 ```
 h = eager_update!(f, (model.layers[i], h, other_args...), (Optimisers.update!, opt_state.layers[i]))
 ```
+
+!!! warning
+    If different layers share trainable parameters, then `eager_update` will likely give wrong results.
 """
 eager_update!(f, (model, xs...), (update!, state)) = f(model, xs...)
 function Zygote._pullback(ctx::Zygote.AContext, ::typeof(eager_update!), f,(model, xs...), (update!, state))


### PR DESCRIPTION
This adds something like Zygote's `checkpointed`, but additionally accepts an optimizer state and an update function. The model parameters are updated during the backward pass and then the gradients are discarded, allowing you to train models when you can't fit both the model weights and the full gradients in memory together.

I wasn't quite sure if this should be PR'd to Flux instead?

### PR Checklist

- [ ] Tests are added
- [ ] Documentation, if applicable