### PR TITLE
Remove Molly.jl from Downstream.yml CI

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -25,7 +25,6 @@ jobs:
           - {user: SciML, repo: DiffEqFlux.jl, group: Layers}
           - {user: SciML, repo: DiffEqFlux.jl, group: BasicNeuralDE}
           - {user: SciML, repo: NeuralPDE.jl, group: NNPDE}
-          - {user: JuliaMolSim, repo: Molly.jl, group: Zygote}
     steps:
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v1


### PR DESCRIPTION
Molly.jl no longer uses Zygote: https://github.com/JuliaMolSim/Molly.jl/pull/182.

Are there any other packages here which should go? The fewer we have to deal with, the faster CI runs and the fewer false positives we get from it.

See also: https://github.com/FluxML/ZygoteRules.jl/pull/33.

### PR Checklist

- ~~[ ] Tests are added~~
- ~~[ ] Documentation, if applicable~~
