### PR TITLE
Don't create nested thunks when accumulating

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Zygote"
 uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
-version = "0.7.3"
+version = "0.7.4"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -44,7 +44,7 @@ accum(x::Nothing, y::AbstractThunk) = y
 accum(x::AbstractThunk, y::Nothing) = x
 
 accum(x, y::AbstractThunk) = accum(x, unthunk(y))
-accum(x::AbstractThunk, y) = accum(unthunk(x), y))
+accum(x::AbstractThunk, y) = accum(unthunk(x), y)
 accum(x::AbstractThunk, y::AbstractThunk) = accum(unthunk(x), unthunk(y))
 
 # Core functions

--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -43,9 +43,9 @@ accum(x::ChainRulesCore.Tangent, y::NamedTuple) = accum(wrap_chainrules_output(x
 accum(x::Nothing, y::AbstractThunk) = y
 accum(x::AbstractThunk, y::Nothing) = x
 
-accum(x, y::AbstractThunk) = @thunk(accum(x, unthunk(y)))
-accum(x::AbstractThunk, y) = @thunk(accum(unthunk(x), y))
-accum(x::AbstractThunk, y::AbstractThunk) = @thunk(accum(unthunk(x), unthunk(y)))
+accum(x, y::AbstractThunk) = accum(x, unthunk(y))
+accum(x::AbstractThunk, y) = accum(unthunk(x), y))
+accum(x::AbstractThunk, y::AbstractThunk) = accum(unthunk(x), unthunk(y))
 
 # Core functions
 @_adjoint_keepthunks deepcopy(x) = deepcopy(x), ȳ -> (ȳ,)


### PR DESCRIPTION
Otherwise, it's too easy to create massive types that freeze compilation and blow the stack.

Ideally, we'd avoid allocations by using [`ChainRulesCore.add!!`](https://juliadiff.org/ChainRulesCore.jl/stable/rule_author/superpowers/gradient_accumulation.html#Maybe-mutating-accumulation-(add!!)). But:
- The ChainRulesCore APIs (including `add!!`) don't support `nothing` as a zero tangent.
- I'm not sure if this is safe.

Hopefully fixes https://github.com/FluxML/Flux.jl/issues/2585, https://github.com/FluxML/Zygote.jl/pull/966#issuecomment-2608751377.

### PR Checklist

- [ ] Tests are added
- [ ] Documentation, if applicable
