### PR TITLE
Add AccThunk to avoid prematurely unthunking thunks

### DIFF
--- a/src/Zygote.jl
+++ b/src/Zygote.jl
@@ -13,6 +13,7 @@ using IRTools
 using MacroTools
 using MacroTools: @forward
 
+import ChainRules
 import Distributed: pmap, CachingPool, workers
 export Params, withgradient, gradient, withjacobian, jacobian, hessian, diaghessian, pullback, pushforward, @code_adjoint
 export rrule_via_ad

--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -1,5 +1,13 @@
-using Base: RefValue
-using Base: ismutabletype
+using Base: RefValue, ismutabletype, tail
+
+struct AccThunk{T} <: AbstractThunk
+    thunks::Vector{T}
+end
+
+_maybe_thunks(x) = x
+_maybe_thunks(x::AccThunk) = x.thunks
+
+ChainRules.unthunk(acc::AccThunk) = reduce(accum, unthunk.(acc.thunks))
 
 # Interfaces
 
@@ -7,9 +15,8 @@ accum() = nothing
 accum(x) = x
 
 accum(x, y) =
-  x === nothing ? y :
-  y === nothing ? x :
-  x + y
+  x === nothing ?
+    y : (y === nothing ? x : x + y)
 
 accum(x, y, zs...) = accum(accum(x, y), zs...)
 
@@ -35,9 +42,9 @@ accum(x::ChainRulesCore.Tangent, y::NamedTuple) = accum(wrap_chainrules_output(x
 accum(x::Nothing, y::AbstractThunk) = y
 accum(x::AbstractThunk, y::Nothing) = x
 
-accum(x, y::AbstractThunk) = accum(x, unthunk(y))
-accum(x::AbstractThunk, y) = accum(unthunk(x), y)
-accum(x::AbstractThunk, y::AbstractThunk) = accum(unthunk(x), unthunk(y))
+accum(x::AbstractThunk, y::AbstractThunk) = AccThunk(vcat(_maybe_thunks(x), _maybe_thunks(y)))
+accum(x::AbstractThunk, y) = AccThunk(vcat(_maybe_thunks(x), [y]))
+accum(x, y::AbstractThunk) = AccThunk(vcat([x], _maybe_thunks(y)))
 
 # Core functions
 @_adjoint_keepthunks deepcopy(x) = deepcopy(x), ȳ -> (ȳ,)
@@ -55,7 +62,7 @@ accum_param(::Context{false}, _, Δ) = Δ
   isbitstype(x) && return :(Δ)
   quote
     if haskey(cache(cx), x)
-      cache(cx)[x] = accum(cache(cx)[x],Δ)
+      cache(cx)[x] = accum(cache(cx)[x], Δ)
       return
     else
       return Δ
@@ -95,8 +102,6 @@ end
 end
 
 # Tuples
-
-using Base: tail
 
 @_adjoint_keepthunks tuple(xs...) = xs, identity
 

--- a/test/features_tests.jl
+++ b/test/features_tests.jl
@@ -882,4 +882,16 @@ end
   @test g1[1] ≈ g2[1] ≈ g3[1]
 end
 
+# https://github.com/FluxML/Flux.jl/issues/2585
+@testset "Nested thunks" begin
+    W = ones(Float32, 10, 10)
+    x = [ones(Float32, 10) for i in 1:512]
+    gs = gradient(W) do W
+        sum((W * xi)[1] for xi in x)
+    end
+    dW = gs[1]
+    @test all(dW[1, :] .== 512)
+    @test all(dW[2:end, :] .== 0)
+end
+
 end


### PR DESCRIPTION
- Add `AccThunk` type (as suggested in https://github.com/FluxML/Zygote.jl/pull/1555) that holds thunks to-be-accumulated without unthunking prematurely.
- Add reduced MWE from https://github.com/FluxML/Flux.jl/issues/2585 as test, that leads to infinite compilation without `AccThunk`.

### PR Checklist

- [x] Tests are added