### PR TITLE
chore: add unthunk_tangent rule for Ref

### DIFF
--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -4,6 +4,7 @@
 @inline ZygoteRules.unthunk_tangent(x::NTuple{N,<:Number}) where N = x
 @inline ZygoteRules.unthunk_tangent(x::AbstractArray{<:Number,N}) where N = x
 @inline ZygoteRules.unthunk_tangent(x::AbstractArray) = map(unthunk_tangent, x)
+@inline ZygoteRules.unthunk_tangent(r::Base.RefValue) = r[] = unthunk_tangent(r[])
 ZygoteRules.unthunk_tangent(d::IdDict) = IdDict([unthunk_tangent(k) => unthunk_tangent(v) for (k, v) in d])
 @non_differentiable unthunk_tangent(::IdDict)
 


### PR DESCRIPTION
Sometimes internal types can "leak" out after the back pass when working with adjoints of types. See https://github.com/SciML/ModelingToolkit.jl/actions/runs/13965380427/job/39094467215#step:6:5266 for an example where an `InplaceableThunk` is returned. This is because of a missing dispatch for `unthunk_tangent(::RefValue)` which this PR adds. I don't have a very simple case yet where this fails for a test, but it is seen in the wild with v0.7.x in SciML

### PR Checklist

- [ ] Tests are added
- [ ] Documentation, if applicable
