### PR TITLE
Remove DynamicPPL integration test

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -20,7 +20,6 @@ jobs:
         package:
           - {user: FluxML, repo: Flux.jl, group: All}
           - {user: FluxML, repo: NNlib.jl, group: All}
-          - {user: TuringLang, repo: DynamicPPL.jl, group: All}
           - {user: TuringLang, repo: DistributionsAD.jl, group: Zygote}
           - {user: SciML, repo: DiffEqFlux.jl, group: Layers}
           - {user: SciML, repo: DiffEqFlux.jl, group: BasicNeuralDE}


### PR DESCRIPTION
This PR removes the DynamicPPL integration test as described in https://github.com/FluxML/Zygote.jl/pull/1563#issuecomment-2755672589. DynamicPPL's CI doesn't have any Zygote tests so there's no need for you all to spend GitHub runner time on this.

(Sorry it took a while. I was thinking that it'd be nice to have integration tests for Bijectors.jl, where we do test against Zygote; however I looked into it and found that it would a little bit of refactoring on the Bijectors end, and I'm not sure when I can get round to that, so I thought I'd just make this patch first.)

### PR Checklist

- [ ] ~~Tests are added~~ (n/a)
- [ ] ~~Documentation, if applicable~~ (n/a)
