### PR TITLE
Backport `typesof` fix for 0.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Zygote"
 uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
-version = "0.6.76"
+version = "0.6.77"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -1,5 +1,5 @@
 using InteractiveUtils
-using InteractiveUtils: typesof
+using Base: typesof
 using Core: Typeof
 import Base: copy!, IdSet
 import Base.Broadcast: broadcasted, materialize!

--- a/src/compiler/reverse.jl
+++ b/src/compiler/reverse.jl
@@ -1,4 +1,4 @@
-using IRTools: IR, Variable, Pipe, xcall, var, prewalk, postwalk,
+using IRTools: IRTools, IR, Variable, Pipe, xcall, var, prewalk, postwalk,
   blocks, predecessors, successors, argument!, arguments, branches,
   insertafter!, finish, expand!, prune!, substitute!, substitute,
   block, block!, branch!, return!, stmt, meta
@@ -238,7 +238,7 @@ Base.show(io::IO, x::Alpha) = print(io, "@", x.id)
 
 alpha(x) = x
 alpha(x::Variable) = Alpha(x.id)
-Variable(a::Alpha) = Variable(a.id)
+IRTools.Variable(a::Alpha) = Variable(a.id)
 
 sig(b::IRTools.Block) = unique([arg for br in branches(b) for arg in br.args if arg isa Variable])
 sig(pr::Primal) = Dict(b.id => sig(b) for b in blocks(pr.ir))


### PR DESCRIPTION
Backports #1569 to the 0.6 branch, which is still used by some packages (e.g. AbstractDifferentiation.jl).

It would be great to have a release once merged.