### PR TITLE
Accumulate mutable structs with `Ref`

### DIFF
--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -29,11 +29,11 @@ function accum(x::RefValue, y::RefValue)
   return x
 end
 function accum(x::NamedTuple, ref::RefValue)
-  fieldnames(ref[]) ⊆ fieldnames(x) || throw(ArgumentError("$(ref[]) keys from Ref must be a subset of $x keys"))
+  fieldnames(typeof(ref[])) ⊆ fieldnames(typeof(x)) || throw(ArgumentError("$(ref[]) keys from Ref must be a subset of $x keys"))
   ref
 end
 function accum(ref::RefValue, x::NamedTuple)
-  fieldnames(x) ⊆ fieldnames(ref[]) || throw(ArgumentError("$x keys from Ref must be a subset of $(ref[]) keys"))
+  fieldnames(typeof(x)) ⊆ fieldnames(typeof(ref[])) || throw(ArgumentError("$x keys must be a subset of $(ref[]) keys from Ref"))
   ref
 end
 

--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -15,6 +15,7 @@ accum(x, y, zs...) = accum(accum(x, y), zs...)
 
 accum(x::Tuple, ys::Tuple...) = map(accum, x, ys...)
 accum(x::AbstractArray, ys::AbstractArray...) = Base.broadcast_preserving_zero_d(accum, x, ys...)
+accum(::Tuple{}, ::NamedTuple{}) = ()
 
 @generated function accum(x::NamedTuple, y::NamedTuple)
   # assumes that y has no keys apart from those also in x
@@ -230,7 +231,7 @@ end
     else
       dx = grad_mut(__context__, x)
       dx[] = (; dx[]..., pair(Val(f), accum(getfield(dx[], f), Δ))...)
-      return (dx,nothing)
+      return (dx[],nothing)
     end
   end
   unwrap(val), back

--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -28,8 +28,14 @@ function accum(x::RefValue, y::RefValue)
   @assert x === y
   return x
 end
-accum(x::NamedTuple, ref::RefValue) = ref
-accum(ref::RefValue, x::NamedTuple) = ref
+function accum(x::NamedTuple, ref::RefValue)
+  fieldnames(ref[]) ⊆ fieldnames(x) || throw(ArgumentError("$(ref[]) keys from Ref must be a subset of $x keys"))
+  ref
+end
+function accum(ref::RefValue, x::NamedTuple)
+  fieldnames(x) ⊆ fieldnames(ref[]) || throw(ArgumentError("$x keys from Ref must be a subset of $(ref[]) keys"))
+  ref
+end
 
 accum(x::NamedTuple, y::ChainRulesCore.Tangent) = accum(x, wrap_chainrules_output(y))
 accum(x::ChainRulesCore.Tangent, y::NamedTuple) = accum(wrap_chainrules_output(x), y)

--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -29,6 +29,7 @@ function accum(x::RefValue, y::RefValue)
   return x
 end
 function accum(x::NamedTuple, ref::RefValue)
+    # We do not actually do any accumulation here, because the ref will already have been mutated.
   fieldnames(typeof(ref[])) ⊆ fieldnames(typeof(x)) || throw(ArgumentError("$(ref[]) keys from Ref must be a subset of $x keys"))
   ref
 end

--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -33,6 +33,7 @@ function accum(x::NamedTuple, ref::RefValue)
   ref
 end
 function accum(ref::RefValue, x::NamedTuple)
+    # We do not actually do any accumulation here, because the ref will already have been mutated.
   fieldnames(typeof(x)) ⊆ fieldnames(typeof(ref[])) || throw(ArgumentError("$x keys must be a subset of $(ref[]) keys from Ref"))
   ref
 end

--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -28,8 +28,8 @@ function accum(x::RefValue, y::RefValue)
   @assert x === y
   return x
 end
-accum(x, ref::RefValue) = accum(x, ref[])
-accum(ref::RefValue, x) = accum(ref[], x)
+accum(x::NamedTuple, ref::RefValue) = accum(x, ref[])
+accum(ref::RefValue, x::NamedTuple) = accum(ref[], x)
 
 accum(x::NamedTuple, y::ChainRulesCore.Tangent) = accum(x, wrap_chainrules_output(y))
 accum(x::ChainRulesCore.Tangent, y::NamedTuple) = accum(wrap_chainrules_output(x), y)

--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -28,8 +28,8 @@ function accum(x::RefValue, y::RefValue)
   @assert x === y
   return x
 end
-accum(x::NamedTuple, ref::RefValue) = accum(x, ref[])
-accum(ref::RefValue, x::NamedTuple) = accum(ref[], x)
+accum(x::NamedTuple, ref::RefValue) = ref
+accum(ref::RefValue, x::NamedTuple) = ref
 
 accum(x::NamedTuple, y::ChainRulesCore.Tangent) = accum(x, wrap_chainrules_output(y))
 accum(x::ChainRulesCore.Tangent, y::NamedTuple) = accum(wrap_chainrules_output(x), y)

--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -15,7 +15,6 @@ accum(x, y, zs...) = accum(accum(x, y), zs...)
 
 accum(x::Tuple, ys::Tuple...) = map(accum, x, ys...)
 accum(x::AbstractArray, ys::AbstractArray...) = Base.broadcast_preserving_zero_d(accum, x, ys...)
-accum(::Tuple{}, ::NamedTuple{}) = ()
 
 @generated function accum(x::NamedTuple, y::NamedTuple)
   # assumes that y has no keys apart from those also in x
@@ -29,6 +28,8 @@ function accum(x::RefValue, y::RefValue)
   @assert x === y
   return x
 end
+accum(x, ref::RefValue) = accum(x, ref[])
+accum(ref::RefValue, x) = accum(ref[], x)
 
 accum(x::NamedTuple, y::ChainRulesCore.Tangent) = accum(x, wrap_chainrules_output(y))
 accum(x::ChainRulesCore.Tangent, y::NamedTuple) = accum(wrap_chainrules_output(x), y)
@@ -231,7 +232,7 @@ end
     else
       dx = grad_mut(__context__, x)
       dx[] = (; dx[]..., pair(Val(f), accum(getfield(dx[], f), Δ))...)
-      return (dx[],nothing)
+      return (dx,nothing)
     end
   end
   unwrap(val), back


### PR DESCRIPTION
In several downstream packages in SciML, ref https://github.com/SciML/ModelingToolkit.jl/pull/3585, https://github.com/SciML/SciMLSensitivity.jl/issues/1212 and others, accumulation into a mutable Tangent throws errors of the form.

```julia
julia> gs = gradient(new_p) do new_p
           new_params = SciMLStructures.replace(SciMLStructures.Tunable(), mtkparams, new_p)
           new_prob = remake(prob, p = new_params)
           new_sol = solve(new_prob, Tsit5())
           sum(new_sol)
       end
ERROR: MethodError: no method matching +(::Base.RefValue{…}, ::@NamedTuple{…})
The function `+` exists, but no method is defined for this combination of argument types.

Closest candidates are:
  +(::Any, ::Any, ::Any, ::Any...)
   @ Base operators.jl:596
  +(::MutableArithmetics.Zero, ::Any)
   @ MutableArithmetics ~/.julia/packages/MutableArithmetics/tNSBd/src/rewrite.jl:64
  +(::Any, ::MutableArithmetics.Zero)
   @ MutableArithmetics ~/.julia/packages/MutableArithmetics/tNSBd/src/rewrite.jl:65
  ...

Stacktrace:
  [1] accum(x::Base.RefValue{…}, y::@NamedTuple{…})
    @ Zygote ~/.julia/packages/Zygote/wfLOG/src/lib/lib.jl:9
  [2] accum(::Base.RefValue{…}, ::@NamedTuple{…}, ::Nothing, ::Vararg{…})
    @ Zygote ~/.julia/packages/Zygote/wfLOG/src/lib/lib.jl:14
  [3] maybe_eager_initialize_problem
    @ ~/.julia/packages/SciMLBase/z4OYD/src/remake.jl:1211 [inlined]
  [4] (::Zygote.Pullback{Tuple{…}, Any})(Δ::Tuple{Thunk{…}, @NamedTuple{…}})
    @ Zygote ~/.julia/packages/Zygote/wfLOG/src/compiler/interface2.jl:0
  [5] #remake#753
    @ ~/.julia/packages/SciMLBase/z4OYD/src/remake.jl:266 [inlined]
  [6] (::Zygote.Pullback{Tuple{…}, Any})(Δ::Base.RefValue{Any})
    @ Zygote ~/.julia/packages/Zygote/wfLOG/src/compiler/interface2.jl:0
  [7] remake
    @ ~/.julia/packages/SciMLBase/z4OYD/src/remake.jl:214 [inlined]
  [8] (::Zygote.Pullback{Tuple{…}, Any})(Δ::Base.RefValue{Any})
    @ Zygote ~/.julia/packages/Zygote/wfLOG/src/compiler/interface2.jl:0
  [9] #12
    @ ./REPL[28]:3 [inlined]
 [10] (::Zygote.Pullback{Tuple{…}, Tuple{…}})(Δ::Float64)
    @ Zygote ~/.julia/packages/Zygote/wfLOG/src/compiler/interface2.jl:0
 [11] (::Zygote.var"#88#89"{Zygote.Pullback{Tuple{…}, Tuple{…}}})(Δ::Float64)
    @ Zygote ~/.julia/packages/Zygote/wfLOG/src/compiler/interface.jl:97
 [12] gradient(f::Function, args::Vector{Float64})
    @ Zygote ~/.julia/packages/Zygote/wfLOG/src/compiler/interface.jl:154
 [13] top-level scope
    @ REPL[28]:1
Some type information was truncated. Use `show(err)` to see complete types.
```

The reason is that the `literal_getproperty` adjoint returns `Ref` instead of the Tangent itself for mutable structs. This creates an issue at the accumulation stage when only a partial graph has accumulated.

Motivating case:

```julia
mutable struct MWEM{F}
    f::F
end
ctx = Zygote.Context()
y,b = Zygote.pullback(ctx, MWEM(rand(3))) do iprob
    sum(iprob.f)
end
b(y) # ((f = [1.3008144940009554, 1.3008144940009554, 1.3008144940009554],),)
ctx.cache 
# IdDict{Any, Any} with 1 entry:
#   MWEM{Vector{Float64}}([0.178069, 0.96279, 0.159955]) => RefValue{Any}((f = [1.30081, 1.30081, 1.30081],))
```
Notice how the `Ref` is removed in the output. 

Since the accumulation happens for the mutables in the pullback (and has several other issues with creating statefulness), this way unifies the return types from both branches, and thus fixes the errors seen downstream. 

### PR Checklist

- [x] Tests are added
- [ ] Documentation, if applicable
