### PR TITLE
chore: handle `accum` when no grads are present

### DIFF
--- a/src/lib/lib.jl
+++ b/src/lib/lib.jl
@@ -15,6 +15,7 @@ accum(x, y, zs...) = accum(accum(x, y), zs...)
 
 accum(x::Tuple, ys::Tuple...) = map(accum, x, ys...)
 accum(x::AbstractArray, ys::AbstractArray...) = Base.broadcast_preserving_zero_d(accum, x, ys...)
+accum(::Tuple{}, ::NamedTuple{}) = ()
 
 @generated function accum(x::NamedTuple, y::NamedTuple)
   # assumes that y has no keys apart from those also in x


### PR DESCRIPTION
Handles the case when there are no gradients to accumulate, as a follow on to #1574 

cc @ChrisRackauckas 

### PR Checklist

- [ ] Tests are added
- [ ] Documentation, if applicable
