### PR TITLE
Update Documenter to version >= 1.0

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,4 +3,4 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
-Documenter = "0.24"
+Documenter = "1.0"

--- a/src/compiler/interface.jl
+++ b/src/compiler/interface.jl
@@ -133,7 +133,7 @@ If no gradient is defined, `∂f/∂x` will be `nothing`.
 `f(args...)` must be a real number, see [`jacobian`](@ref) for array output.
 
 See also [`withgradient`](@ref) to keep the value `f(args...)`,
-and [`pullback`](@ref) for value and back-propagator.
+and [`pullback`](@ref "Pullbacks") for value and back-propagator.
 
 ```jldoctest; setup=:(using Zygote)
 julia> gradient(*, 2.0, 3.0, 5.0)


### PR DESCRIPTION
This also fixes a broken link to the `pullback` function (not just nice to have fixed, but also necessary because Documenter is now "strict" by default).

Tested by building the documentation locally

Closes #1578