### PR TITLE
Add adjoints for 3-arg `get` on AbstractDict

### DIFF
--- a/src/lib/base.jl
+++ b/src/lib/base.jl
@@ -52,6 +52,41 @@ end
   val, dict_getindex_pullback
 end
 
+# `get(d, k, default)`: routes the gradient back into the dict when the key is
+# present, and into `default` otherwise. Without this rule Zygote would try to
+# differentiate `Base.get`'s implementation, which reaches into `Dict` internals.
+@adjoint function get(d::AbstractDict, k, default)
+  if haskey(d, k)
+    val = d[k]
+    return val, function (Δ)
+      accum_param(__context__, val, Δ) === nothing && return
+      grad = grad_mut(__context__, d)
+      grad[k] = accum(get(grad, k, nothing), Δ)
+      return (grad, nothing, nothing)
+    end
+  else
+    return default, Δ -> (nothing, nothing, Δ)
+  end
+end
+
+# `get(default, d, k)` (the do-block form): like above, but `default` is a
+# callable that is only evaluated -- and only differentiated through -- when the
+# key is missing. See https://github.com/FluxML/Zygote.jl/issues/1610
+@adjoint function get(default::Base.Callable, d::AbstractDict, k)
+  if haskey(d, k)
+    val = d[k]
+    return val, function (Δ)
+      accum_param(__context__, val, Δ) === nothing && return
+      grad = grad_mut(__context__, d)
+      grad[k] = accum(get(grad, k, nothing), Δ)
+      return (nothing, grad, nothing)
+    end
+  else
+    y, back = _pullback(__context__, default)
+    return y, Δ -> (back(Δ)[1], nothing, nothing)
+  end
+end
+
 @adjoint! function setindex!(d::AbstractDict, v, k)
   setindex!(d, v, k), function (_)
     Δ = get(grad_mut(__context__, d), k, nothing)

--- a/test/lib/base.jl
+++ b/test/lib/base.jl
@@ -19,6 +19,28 @@
         @test first(g_hard) isa Diagonal
     end
 
+    @testset "Dict get" begin
+        # https://github.com/FluxML/Zygote.jl/issues/1610
+        d = Dict(:a => 2.0, :b => 3.0)
+
+        # get(d, k, default)
+        @test gradient(d -> get(d, :a, 0.0), d)[1] == Dict(:a => 1.0)
+        g = gradient((d, def) -> get(d, :missing, def), d, 10.0)
+        @test g[1] === nothing
+        @test g[2] == 1.0
+
+        # get(default, d, k) -- the do-block form
+        hit = Ref(false)
+        @test gradient(d -> get(() -> (hit[] = true; 0.0), d, :a), d)[1] == Dict(:a => 1.0)
+        @test hit[] == false  # default is not evaluated when the key is present
+        @test gradient(y -> get(() -> 2y, d, :missing), 5.0)[1] == 2.0
+
+        # value-typed (array) gradients route through the dict
+        da = Dict(:x => ones(3))
+        @test gradient(d -> sum(get(d, :x, zeros(3))), da)[1] == Dict(:x => ones(3))
+        @test gradient(d -> sum(get(() -> zeros(3), d, :x)), da)[1] == Dict(:x => ones(3))
+    end
+
     @testset "Dict iteration" begin
         # https://github.com/FluxML/Zygote.jl/issues/1065
         function sumkv(d)


### PR DESCRIPTION
## Summary

Fixes #1610.

Zygote has an adjoint for `getindex(::AbstractDict, k)`, but none for the three-argument `get` forms:

- `get(d, k, default)` — value default
- `get(default, d, k)` — the do-block / callable form

Without these, Zygote falls back to differentiating `Base.get`'s implementation, which reaches into `Dict` internals (`h.vals[index]`) and fails with:

```
MethodError: no method matching getindex(::Dict{Any, Any})
```

This is what bites the MWE in #1610: a struct with a custom `getproperty` that looks values up via `get(kwargs, name) do … end`. The custom `getproperty` itself is handled fine — Zygote differentiates through its body — but the `get(...) do ... end` lookup had no rule. (Plain `dict[key]` already worked.)

## What the rules do

- **Key present** → route the cotangent into the dict at that key (same as the existing `getindex` adjoint).
- **Key absent** → route the cotangent into `default`: directly for the value form, and through `_pullback` of the closure for the do-block form. In the do-block form the closure is correctly *not* evaluated when the key is present.

## Verification

The exact MWE from #1610 now differentiates correctly **without** any user-side `rrule` (gradient matches the analytic `2·D·Ψ` to ~1e-16). New tests cover both `get` forms, key-present/absent branches, scalar and array-valued gradients, and that the do-block default is not evaluated on a hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)