### PR TITLE
Don't dualize integer args in broadcast (fix #1602)

### DIFF
--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -264,8 +264,12 @@ using ForwardDiff: Dual, Partials, value, partials
 # See https://github.com/FluxML/Zygote.jl/issues/1601
 #     https://github.com/FluxML/Zygote.jl/issues/1461
 @inline dual(x, i, ::Val{N}, ::Val{C}) where {N,C} = x
-@inline dual(x::Bool, i, ::Val{N}, ::Val{false}) where {N} = x
-@inline dual(x::Bool, i, ::Val{N}, ::Val{true}) where {N} = x
+# Integers (incl. Bool) are not differentiable, so leave them untouched rather than
+# seeding partials. This also avoids silently wrong results from ForwardDiff v1, where
+# `Dual(1,1) != 1` breaks integer comparisons inside the broadcasted function.
+# See https://github.com/FluxML/Zygote.jl/issues/1602
+@inline dual(x::Integer, i, ::Val{N}, ::Val{false}) where {N} = x
+@inline dual(x::Integer, i, ::Val{N}, ::Val{true}) where {N} = x
 @inline dual(x::Real, i, ::Val{N}, ::Val{false}) where {N} = Dual(x, ntuple(==(i), N))
 @inline dual(x::Real, i, ::Val{N}, ::Val{true}) where {N} = Dual(x, ntuple(==(i), 2N))
 # For complex since ForwardDiff.jl doesn't play nicely with complex numbers we

--- a/test/gradcheck_p4.jl
+++ b/test/gradcheck_p4.jl
@@ -301,6 +301,25 @@ end
   end
 end
 
+@testset "issue #1602 integer args in broadcast are not dualized" begin
+  # Integers (e.g. a `1:N` index range) broadcast through a function must stay integers,
+  # otherwise ForwardDiff v1's `Dual(1,1) != 1` silently breaks integer comparisons.
+  generate_i(i, a, d) = ifelse(i == 1, a, d)
+  function f_std(a, d)
+    N = 3
+    x = ones(N)
+    v = @. generate_i(1:N, a, d)
+    return sum(v .* x)
+  end
+  @test gradient(f_std, 0.2, 0.5) == (1.0, 2.0)
+
+  # gradient w.r.t. the integer range itself is dropped (not differentiable)
+  @test gradient((a, d) -> sum(@. ifelse((0:4) >= 2, a^2, d)), 1.3, 0.7) == (3 * 2 * 1.3, 2.0)
+
+  # genuine differentiable args alongside an integer array still get correct gradients
+  @test gradient(x -> sum(x .* [2, 3, 4]), [1.0, 2.0, 3.0])[1] == [2.0, 3.0, 4.0]
+end
+
 @testset "norm" begin
     # rrule for norm is defined in ChainRules. These tests just check various norm-related
     # issues are resolved


### PR DESCRIPTION
Fixes #1602.

## Problem

Broadcasting a function whose result depends on an integer comparison can produce a silently wrong gradient:

```julia
generate_i(i, a, d) = ifelse(i == 1, a, d)
function f_std(a, d)
    N = 3
    x = ones(N)
    v = @. generate_i(1:N, a, d)
    return sum(v .* x)
end

Zygote.gradient(f_std, 0.2, 0.5)   # (0.0, 3.0)  -- wrong, should be (1.0, 2.0)
```

## Root cause

Zygote's fast broadcasting path (`broadcast_forward`) turns every argument of the broadcasted function into a ForwardDiff `Dual` to extract derivatives. Integer arguments — here the index range `1:N` — were being dualized too. Since ForwardDiff v1 ([JuliaDiff/ForwardDiff.jl#481](https://github.com/JuliaDiff/ForwardDiff.jl/pull/481)) makes `Dual(1,1) != 1`, the `i == 1` test inside `generate_i` silently evaluated to `false`, giving the wrong result. With pre-v1 ForwardDiff `Dual(1,1) == 1` held, so this worked by accident.

## Fix

Integers are not differentiable, so `dual` now leaves `Integer` values untouched instead of seeding partials for them. This generalizes the existing `Bool` special case (`Bool <: Integer`).

This restores correct gradients when integer ranges/arrays flow through a broadcast, keeps integer comparisons working inside broadcasted functions, and leaves all genuinely-differentiable (float/complex) gradients unchanged.

## Verification

- The MWE now returns `(1.0, 2.0)`.
- Verified a battery of broadcast gradients against ForwardDiff (sin, polynomials, mixed real, complex output, integer-array multiply, `ifelse` over ranges) — all match.
- Added a regression testset in `test/gradcheck_p4_tests.jl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)