### PR TITLE
Restore Zygote.refresh()

### DIFF
--- a/docs/src/adjoints.md
+++ b/docs/src/adjoints.md
@@ -130,7 +130,7 @@ julia> @adjoint width(p::Point) = p.x, x̄ -> (Point(x̄, 0),)
 
 julia> @adjoint height(p::Point) = p.y, ȳ -> (Point(0, ȳ),)
 
-julia> Zygote.refresh() # currently needed when defining new adjoints
+julia> Zygote.refresh() # needed when defining new adjoints or rrules for already-differentiated signatures
 
 julia> gradient(a -> height(a), Point(1, 2))
 (Point(0.0, 1.0),)

--- a/src/Zygote.jl
+++ b/src/Zygote.jl
@@ -55,6 +55,16 @@ include("profiler/Profile.jl")
 
 using InteractiveUtils
 
+# Clear Zygote's internal caches and force the pullback-generating `@generated`
+# functions to be re-run. This is needed to pick up `ChainRulesCore.rrule`s (or
+# `@adjoint`s) defined *after* a gradient has already been taken for the relevant
+# signature, since the cached generated code does not always get invalidated
+# (see https://github.com/FluxML/Zygote.jl/issues/1599).
+function refresh()
+  include(joinpath(@__DIR__, "compiler", "interface2.jl"))
+  return
+end
+
 macro profile(ex)
   @capture(ex, f_(x__)) || error("@profile f(args...)")
   quote

--- a/test/compiler_tests.jl
+++ b/test/compiler_tests.jl
@@ -341,3 +341,32 @@ end
 end
 
 end
+
+@testitem "refresh" begin
+  # https://github.com/FluxML/Zygote.jl/issues/1599
+  # `Zygote.refresh()` must pick up an `rrule` defined *after* a gradient has
+  # already been computed (and cached) for the same signature.
+  using ChainRulesCore
+
+  function refresh1599(x::AbstractArray)
+    y = similar(x)
+    for i in eachindex(x)
+      y[i] = x[i] > 0 ? x[i]^2 : zero(eltype(x))
+    end
+    sum(y)
+  end
+
+  x = [1.7, 2.1, -1.5, -0.1, 3.1]
+  # Mutation is not differentiable, so this fails and caches the failing pullback.
+  @test_throws Exception Zygote.gradient(refresh1599, x)
+
+  function ChainRulesCore.rrule(::typeof(refresh1599), x)
+    J = [xᵢ > 0 ? 2xᵢ : zero(xᵢ) for xᵢ in x]
+    refresh1599_pullback(v) = NoTangent(), J * unthunk(v)
+    refresh1599(x), refresh1599_pullback
+  end
+
+  Zygote.refresh()
+
+  @test Zygote.gradient(refresh1599, x)[1] == [3.4, 4.2, 0.0, 0.0, 6.2]
+end


### PR DESCRIPTION
Fixes #1599.

## Problem

#1560 removed `Zygote.refresh()` with the claim that it was no longer required. That holds only for *redefining a method* (which is invalidated through Julia's natural method edges), e.g. the example in that PR:

```julia
g(x) = 2x; g'(10)   # 2.0
g(x) = 3x; g'(10)   # 3.0
```

It does **not** hold for the documented use case of defining a `ChainRulesCore.rrule` (or `@adjoint`) *after* a gradient has already been computed for the relevant signature. The cached generated pullback is not invalidated, so the newly-defined rule is silently ignored — the behaviour reported in #1599:

```julia
using Zygote, ChainRulesCore
f5(x) = (y = similar(x); for i in eachindex(x); y[i] = x[i] > 0 ? x[i]^2 : zero(eltype(x)); end; sum(y))

Zygote.gradient(f5, [1.7, 2.1, -1.5, -0.1, 3.1])   # errors: mutating arrays not supported

ChainRulesCore.rrule(::typeof(f5), x) = ...         # define a rule

Zygote.gradient(f5, [1.7, 2.1, -1.5, -0.1, 3.1])   # still errors!  rule ignored
```

Since `refresh()` was documented (see `docs/src/adjoints.md`), its removal was also a silent breaking change.

## Fix

Restore `refresh()`. The original implementation used `Requires.@include`, which was removed in #1560, so it is reimplemented with a plain `include` of `compiler/interface2.jl`. Re-evaluating the two pullback-generating `@generated` functions forces previously-cached pullbacks to be regenerated, picking up newly-defined rules:

```julia
Zygote.refresh()
Zygote.gradient(f5, [1.7, 2.1, -1.5, -0.1, 3.1])   # ([3.4, 4.2, 0.0, 0.0, 6.2],)
```

## Changes

- `src/Zygote.jl`: restore `refresh()`.
- `test/compiler_tests.jl`: add a `@testitem "refresh"` reproducing #1599.
- `docs/src/adjoints.md`: clarify the existing note on when `refresh()` is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)