### PR TITLE
Fix wrong GPU gradient for Bool-valued broadcasts (#1597)

### DIFF
--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -369,8 +369,18 @@ using GPUArraysCore  # replaces @require CUDA block, weird indenting to preserve
        # Ordinary broadcasting calls broadcast_forward anyway when certain its' safe,
        # so perhaps this can be deleted? Possible edge case here:
        # https://github.com/FluxML/Zygote.jl/pull/1018#issuecomment-873629415
-  @adjoint broadcasted(::AbstractGPUArrayStyle, f, args...) =
+  @adjoint function broadcasted(::AbstractGPUArrayStyle, f, args...)
+    # Bool-valued broadcasts (e.g. `x .> 3`) are non-differentiable and must be
+    # evaluated on the plain values: running predicates like `>` through ForwardDiff
+    # `Dual`s gives wrong results, because ForwardDiff (>= v1) compares Duals with a
+    # total order that breaks value-ties using the partials. See
+    # https://github.com/FluxML/Zygote.jl/issues/1597
+    # This mirrors the `T == Bool` short-circuit in `_broadcast_generic` above.
+    if Broadcast.combine_eltypes(f, args) == Bool
+      return (f.(args...), _ -> nothing)
+    end
     broadcast_forward(f, args...)
+  end
 
   @adjoint (::Type{T})(xs::Array) where {T <: AbstractGPUArray} =
     T(xs), Δ -> (convert(Array, Δ), )

--- a/test/cuda_tests.jl
+++ b/test/cuda_tests.jl
@@ -49,7 +49,10 @@ end
   @test gradient(x -> sum(x .> 3), a_gpu) == (nothing,)
   g3 = gradient(x -> sum(x .^ 3) / count(x .> 3), a)[1]              # was Can't differentiate gc_preserve_end expression
   @test_skip cu(g3) ≈ gradient(x -> sum(x .^ 3) / sum(x .> 3), a_gpu)[1]  # was KernelException -- not fixed by PR #1018
-  @test_broken cu(g3) ≈ gradient(x -> sum(x .^ 3) / count(x .> 3), a_gpu)[1]
+  # https://github.com/FluxML/Zygote.jl/issues/1597 : Bool broadcasts must not go
+  # through ForwardDiff Duals on GPU (predicate ties get broken using partials).
+  @test cu(g3) ≈ gradient(x -> sum(x .^ 3) / count(x .> 3), a_gpu)[1]
+  @test gradient(x -> sum(x .^ 3) / sum(x .> 3), a_gpu)[1] ≈ cu(g3)
 
   # Projection: eltype preservation:
   @test gradient(x -> 2.3 * sum(x.^4), a_gpu)[1] isa CuArray{Float32}


### PR DESCRIPTION
Fixes #1597.

### Problem

```julia
a_gpu = cu(Float32.(1:9))
gradient(x -> sum(x .^ 3) / count(x .> 3), a_gpu)[1]  # wrong, divides by 7 instead of 6
```

`count(a_gpu .> 3)` is `6`, but during differentiation it became `7`, giving a gradient of `3x²/7` instead of the correct `x²/2`.

### Root cause

On GPU, every broadcast goes through the forward-mode adjoint
(`@adjoint broadcasted(::AbstractGPUArrayStyle, f, args...)`), which dualizes the
arguments with `ForwardDiff.Dual` and applies `f`. For a Bool-valued broadcast like
`x .> 3` this evaluates the predicate `>` on `Dual`s.

Since **ForwardDiff v1**, `Dual` comparisons implement a *total order that breaks
value-ties using the partials*:

```julia
Dual(3.0, (1.0, 0.0)) > 3   # true  (should be false: 3.0 > 3 is false)
```

So the boolean mask `a_gpu .> 3` gained an extra `true` at the tied element `x == 3`,
making `count`/`sum` over the mask off by the number of tied elements → wrong gradient.

This is why it used to work: pre-1.0 ForwardDiff compared `Dual`s by value only.

### Fix

The CPU broadcast path already short-circuits Bool-valued broadcasts and evaluates
them on the plain values (the `T == Bool` branch in `_broadcast_generic`). This PR
adds the same guard to the GPU path: Bool-valued broadcasts are evaluated on the
plain values with a no-op pullback, never going through `Dual`s.

This is orthogonal to #1602 / `cl/broadcast-integer-dual` (which avoids dualizing
*integer inputs*); that change alone does not fix this issue, because here `x` is a
legitimately-dualized `Float32` array and the value-tie tiebreak still fires in the
`Dual`-vs-real comparison.

### Test

Converted the existing `@test_broken` for this exact case in `test/cuda_tests.jl`
into a passing test, plus the `sum(x .> 3)` variant. Verified on a local CUDA GPU
that the GPU gradient now matches the CPU result and that the differentiable
real/complex broadcasting testsets are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
