### PR TITLE
CI: skip coverage on non-uploading jobs; cancel superseded runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,11 @@ on:
     branches:
       - master
     tags: '*'
+# Cancel superseded in-progress runs on the same PR/branch; never cancel
+# master pushes or tag builds.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
@@ -43,6 +48,10 @@ jobs:
         env:
            JULIA_PKG_SERVER: ""
       - uses: julia-actions/julia-runtest@v1
+        with:
+          # Coverage instrumentation markedly slows this compile-heavy suite, so
+          # only enable it on the single job that uploads coverage (below).
+          coverage: ${{ matrix.version == '1' && matrix.os == 'ubuntu-latest' }}
         env:
            JULIA_PKG_SERVER: ""
       - uses: julia-actions/julia-processcoverage@v1


### PR DESCRIPTION
Two CI-time reductions that **preserve coverage exactly** — no test cases changed.

## 1. Gate coverage instrumentation to the job that uploads it

`julia-actions/julia-runtest` defaults `coverage: true`, so all five test jobs (`min`/`1`/`nightly` on ubuntu, plus windows and macOS) run with `--code-coverage` — but only the ubuntu / Julia 1 job uploads to codecov. This suite is **~97–99% compilation time**, and coverage instrumentation markedly slows compilation. Setting

```yaml
coverage: ${{ matrix.version == '1' && matrix.os == 'ubuntu-latest' }}
```

keeps the uploaded report byte-for-byte identical (the `processcoverage`/`codecov` steps are already gated the same way) while speeding the other four jobs — notably the slow windows/macOS ones.

## 2. Cancel superseded runs

A `concurrency` group cancels in-progress runs on the same PR/branch when a newer commit is pushed; `master` pushes and tag builds are exempt. Frees the shared FluxML runner pool.

## Measurements

Pulled the CI step breakdown: the ubuntu job's ~17 min is almost entirely `julia-runtest` (~14.8 min); dep precompile is 83 s (cached). Per-item timing shows every heavy item is 97–99% compile, <3% gradient math:

| item | time | % compile |
|---|---|---|
| features | 264 s | 99.3% |
| chainrules | 220 s | 99.3% |
| lib | 97 s | 98.7% |
| gradcheck pt.2 | 86 s | 97.3% |

Coverage instrumentation inflates exactly this cost on four jobs that discard the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)