### PR TITLE
Fix macOS aarch64 CI: gate sqrt(::Symmetric) broken marker on x86_64

### DIFF
--- a/test/gradcheck_p2.jl
+++ b/test/gradcheck_p2.jl
@@ -439,8 +439,11 @@ end
         @testset "similar eigenvalues" begin
           λ[1] = λ[3] + sqrt(eps(eltype(λ))) / 10
           A2 = U * Diagonal(λ) * U'
+          # This gradient test is only broken on x86_64 + Julia >= 1.12; on
+          # aarch64 the near-degenerate `sqrt(::Symmetric)` gradient passes,
+          # so gating on the architecture avoids an "Unexpected Pass" there.
           broken = f == sqrt && MT <: Symmetric{Float64} && domain == Real
-          broken = broken && (VERSION >= v"1.12")
+          broken = broken && (VERSION >= v"1.12") && Sys.ARCH === :x86_64
           # @show f MT domain
           @test _gradtest_hermsym(f, ST, A2) broken=broken
         end


### PR DESCRIPTION
## Problem

The macOS CI job (`Julia 1 - macOS-latest - aarch64`) fails on master with:

```
Error in testset "similar eigenvalues" at test/gradcheck_p2.jl:445
  Unexpected Pass
  Expression: _gradtest_hermsym(f, ST, A2)
  Got correct result, please change to @test if no longer broken.
```

This is **not** caused by the failing commit's content — it's an `@test_broken` that has started passing.

## Root cause

The broken marker for the near-degenerate `sqrt(::Symmetric{Float64})` gradient (domain `Real`, Julia ≥ 1.12) was calibrated in #1596 back when the macOS runner was **x86_64**. Since #1627 switched the macOS runner to **aarch64**, the floating-point result of this delicate case now lands within tolerance and the gradient test passes — turning the `@test_broken` into an Unexpected Pass that aborts the suite.

The split is architecture-specific:

| Platform | gradtest result | `broken=true` correct? |
|---|---|---|
| Ubuntu x86_64, Julia 1.12 | fails | ✅ yes (job passes) |
| macOS aarch64, Julia 1.12 | passes | ❌ no (Unexpected Pass) |

Reproduced locally on an M1 (aarch64, Julia 1.12.6) where the gradtest returns `true`, and confirmed against the Ubuntu x86_64 CI job where it still genuinely fails.

## Fix

Gate the broken marker on `Sys.ARCH === :x86_64` so the case is only marked broken where it actually fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)