### PR TITLE
Fix wrong/NaN gradient for broadcasted abs at the origin (#1529)

### DIFF
--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -294,6 +294,27 @@ end
     end
   end
 
+# `abs` is non-differentiable at the origin. ForwardDiff/DiffRules pick the
+# subgradient `1` there for real inputs, and produce `NaN` for complex inputs
+# (`abs(z) == hypot(re, im)`, whose derivative is `0/0` at the origin). Both
+# disagree with the ChainRules convention used everywhere else in Zygote, which
+# is `0`. Route the forward-mode broadcast of `abs` (the GPU `sum(abs, x)` path,
+# and `abs.(x)` on the CPU fast path) through a NaN-safe definition that matches.
+# See https://github.com/FluxML/Zygote.jl/issues/1529
+@inline dual_function(::typeof(abs)) = _abs_dualsafe ∘ only ∘ dualize
+
+@inline function _abs_dualsafe(d::Dual{T}) where {T}
+    v = value(d)
+    return Dual{T}(abs(v), sign(v) * partials(d))
+end
+@inline function _abs_dualsafe(z::Complex{<:Dual{T}}) where {T}
+    dr, di = reim(z)
+    vr, vi = value(dr), value(di)
+    a = hypot(vr, vi)
+    s = iszero(a) ? zero(a) : inv(a)  # subgradient 0 at the origin
+    return Dual{T}(a, (vr * s) * partials(dr) + (vi * s) * partials(di))
+end
+
 
 @inline function broadcast_forward(f, args::Vararg{Any,N}) where N
   out = dual_function(f).(args...)

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -119,6 +119,18 @@ end
     @test Zygote.hessian(fun, collect(1:9)) ≈ [14 0 0 0 0 0 2 0 0; 0 16 0 0 0 0 0 4 0; 0 0 18 0 0 0 0 0 6; 0 0 0 14 0 0 8 0 0; 0 0 0 0 16 0 0 10 0; 0 0 0 0 0 18 0 0 12; 2 0 0 8 0 0 0 0 0; 0 4 0 0 10 0 0 0 0; 0 0 6 0 0 12 0 0 0]
 end
 
+# https://github.com/FluxML/Zygote.jl/issues/1529
+@testset "issue #1529 broadcasted abs at the origin" begin
+    # `abs` is non-differentiable at 0; the forward-mode broadcast path must use
+    # the ChainRules subgradient (0) rather than ForwardDiff's 1 (real) / NaN
+    # (complex via `hypot`). This keeps `abs.(x)` consistent with `sum(abs, x)`.
+    @test gradient(x -> sum(abs.(x)), Float32[0.0])[1] == Float32[0.0]
+    @test gradient(x -> sum(abs.(x)), ComplexF32[0.0 + 0.0im])[1] == ComplexF32[0.0 + 0.0im]
+    # away from the origin the gradient is unchanged
+    @test gradient(x -> sum(abs.(x)), Float32[3.0, -2.0])[1] == Float32[1.0, -1.0]
+    @test gradient(x -> sum(abs.(x)), ComplexF32[3.0 + 4.0im])[1] ≈ ComplexF32[0.6 + 0.8im]
+end
+
 @testset "issue #1601 mixed complex/real broadcast" begin
     cpx(l, x) = real(l) + x
     f(x) = sum(@. real(cpx(im + x, x)))

--- a/test/cuda.jl
+++ b/test/cuda.jl
@@ -83,6 +83,14 @@ end
   g3_gpu = gradient(f3, a_gpu')[1]
   @test g3_gpu isa Adjoint{Float32, <:CuArray{Float32, 1}}  # preserves structure
   @test g3_gpu |> collect ≈ g3
+
+  # https://github.com/FluxML/Zygote.jl/issues/1529 : `sum(abs, x)` on the GPU
+  # goes through the forward-mode broadcast; at a zero input ForwardDiff used to
+  # give 1 (real) / NaN (complex via `hypot`) instead of the CPU's 0.
+  @test collect(gradient(f, cu(Float32[0.0]))[1]) == Float32[0.0]
+  @test collect(gradient(f, cu(ComplexF32[0.0 + 0.0im]))[1]) == ComplexF32[0.0 + 0.0im]
+  ca = ComplexF32[3.0 + 4.0im, 0.0 + 0.0im, -1.0 + 0.0im]
+  @test collect(gradient(f, cu(ca))[1]) ≈ gradient(f, ca)[1]
 end
 
 @testset "jacobian" begin


### PR DESCRIPTION
Fixes #1529.

## Problem

`abs` is non-differentiable at the origin. The forward-mode broadcast path — used on the GPU for `sum(abs, x)` (which is rewritten to `sum(abs.(x))`), and on the CPU fast path for `abs.(x)` — differentiates through ForwardDiff. ForwardDiff/DiffRules pick the subgradient `1` for real inputs at `0`, and produce `NaN` for complex inputs (`abs(z) == hypot(re, im)`, whose derivative is `0/0` at the origin). Both disagree with the ChainRules convention used everywhere else in Zygote, which is `0`.

```julia
julia> gradient(x -> sum(abs, x), cu(Float32[0.0]))[1]        # was [1.0],   CPU sum(abs,x) gives [0.0]
julia> gradient(x -> sum(abs, x), cu(ComplexF32[0.0+0im]))[1] # was [NaN+NaN*im], CPU gives [0+0im]
```

The same latent discrepancy affected the **CPU** broadcast path: `gradient(x->sum(abs.(x)), [0f0])` also gave `[1.0]` (and `[NaN+NaN*im]` for complex), while the dedicated `sum(abs, x)` rrule gave the correct `[0.0]`.

## Fix

Route the forward-mode broadcast of `abs` through a NaN-safe `_abs_dualsafe` that uses the subgradient `0` at the origin (matching ChainRules) and is identical to ForwardDiff away from the origin. This makes the GPU `sum(abs, x)` path and the CPU `abs.(x)` path agree with the ChainRules `sum(abs, x)` rule, for both real and complex inputs, at and away from the origin.

|  | before (broadcast) | after | `sum(abs, x)` rrule |
|---|---|---|---|
| real `[0]` | `[1.0]` | `[0.0]` | `[0.0]` |
| complex `[0+0im]` | `[NaN+NaN·im]` | `[0+0im]` | `[0+0im]` |
| nonzero real/complex | correct | unchanged | matches |

## Tests

- `test/complex.jl`: CPU broadcast `abs.(x)` for real and complex, at the origin and away from it.
- `test/cuda.jl`: GPU `sum(abs, x)` at a zero input (real and complex), plus a complex GPU-vs-CPU comparison.

Verified live on an RTX 5090 (CUDA 6.2, Julia 1.12.6); the existing GPU `abs`/`abs2` broadcast suite continues to pass.

## Scope note

This covers `abs` as the literal broadcasted function (`sum(abs, x)`, `abs.(x)`). A user-written closure that calls `abs` internally (e.g. `sum(x->abs(x), x)`) would still hit ForwardDiff's `abs` at exactly `0`; covering that would require globally overriding `abs(::Dual)`, which is avoided here as too invasive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)