### PR TITLE
Fix FFT plan adjoint: use adjoint plan instead of N*inv(P) (#899)

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -671,20 +671,16 @@ AbstractFFTs.rfft(x::Fill, dims...) = AbstractFFTs.rfft(collect(x), dims...)
 AbstractFFTs.irfft(x::Fill, d, dims...) = AbstractFFTs.irfft(collect(x), d, dims...)
 AbstractFFTs.brfft(x::Fill, d, dims...) = AbstractFFTs.brfft(collect(x), d, dims...)
 
-# the adjoint jacobian of an FFT with respect to its input is the reverse FFT of the
-# gradient of its inputs, but with different normalization factor
-@adjoint function *(P::AbstractFFTs.Plan, xs)
-  return P * xs, function(Δ)
-    N = prod(size(xs)[[P.region...]])
-    return (nothing, N * (P \ Δ))
-  end
-end
-
+# The adjoint Jacobian of applying a plan to its input is the *adjoint* plan applied
+# to the cotangent. The old `N * (P \ Δ)` formula assumed `P' == N * inv(P)`, which only
+# holds for plans that are unitary up to the scaling `N`; it gave a gradient off by a
+# constant factor for e.g. the orthonormal DCT or `rfft` (see #899).
+#
+# For `*`, AbstractFFTs already ships a correct (and `ProjectTo`-aware, hence type
+# stable) `rrule`, so we let ChainRules handle it rather than defining an adjoint here.
+# AbstractFFTs has no rule for `\`, so we provide one using the adjoint plan `P'`.
 @adjoint function \(P::AbstractFFTs.Plan, xs)
-  return P \ xs, function(Δ)
-    N = prod(size(Δ)[[P.region...]])
-    return (nothing, (P * Δ)/N)
-  end
+  return P \ xs, Δ -> (nothing, ProjectTo(xs)(P' \ Δ))
 end
 
 # FillArray functionality

--- a/test/gradcheck_p4.jl
+++ b/test/gradcheck_p4.jl
@@ -130,6 +130,21 @@ end
   x = randn(Float32,16,16)
   @test typeof(gradient(x->sum(abs2,ifft(fft(x,1),1)),x)[1]) == Array{Float32,2}
   @test typeof(gradient(x->sum(abs2,irfft(rfft(x,1),16,1)),x)[1]) == Array{Float32,2}
+
+  # #899: the plan adjoint must use the adjoint plan, not `N * inv(P)`. The latter is
+  # wrong for non-unitary plans such as the (orthonormal) DCT and `rfft`, giving a
+  # gradient off by a constant factor. Check the whole gradient against finite diffs.
+  fdgrad(f, x) = map(eachindex(x)) do i
+    h = 1e-6; xp = copy(x); xp[i] += h; xm = copy(x); xm[i] -= h
+    (f(xp) - f(xm)) / 2h
+  end
+  let x = randn(10)
+    for p in (plan_dct(x), plan_rfft(x))
+      @test gradient(v -> sum(abs2, p * v), x)[1] ≈ fdgrad(v -> sum(abs2, p * v), x) rtol=1e-4
+    end
+    p = plan_dct(x)
+    @test gradient(v -> sum(abs2, p \ v), x)[1] ≈ fdgrad(v -> sum(abs2, p \ v), x) rtol=1e-4
+  end
 end
 
 @testset "FillArrays" begin


### PR DESCRIPTION
Fixes #899.

## Problem

Zygote's hand-written `@adjoint *(P::AbstractFFTs.Plan, xs)` computed the
pullback as `N * (P \ Δ)`, which assumes `P' == N * inv(P)`. That identity
holds only for plans that are unitary up to the scaling factor `N` (e.g. the
standard complex FFT). It is **wrong** for non-unitary plans such as the
orthonormal DCT and `rfft`, producing a gradient off by a constant factor — 10×
too large for the DCT plan in the issue.

```julia
julia> using Zygote, FFTW
julia> x = rand(10); p = plan_dct(x);
julia> gradient(v -> sum(abs2, p*v), x)[1] ≈ 2 * (p' * (p*x))   # correct adjoint
```

was `false` before this PR (off by a factor), and is `true` after.

## Fix

`AbstractFFTs` (≥ 1.5) already ships a correct, `ProjectTo`-aware ChainRules
`rrule` for `*(::Plan, x)` and `*(::ScaledPlan, x)` that applies the *adjoint
plan* `P'`. So this PR:

- **Deletes** Zygote's `@adjoint *(P::Plan, xs)` and defers to AbstractFFTs.
  This both fixes the math and fixes a Float32 type-instability (AbstractFFTs
  projects the cotangent back to the input type).
- **Keeps a corrected `\` adjoint**, since AbstractFFTs has no rule for
  `\(::Plan, x)`. It now applies the adjoint plan `P'` and projects to the
  input element type.

## Verification

- New gradient matches finite differences for `plan_dct`, `plan_rfft` (also
  previously wrong) and `plan_fft`, for both `*` and `\`.
- The existing `plan_fft` indicator-matrix assertions are unchanged: for plans
  that are unitary up to `N`, the old and new formulas are identical
  (`P'Δ == N*(P\Δ)`), so there is no regression.
- `gradcheck_p4` passes (4128 pass, pre-existing broken markers unchanged).
- Added a finite-difference regression test in the `AbstractFFTs` testset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)