### PR TITLE
Fix GPU broadcast of tuple-valued functions leaking Duals (#1424)

### DIFF
--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -295,15 +295,55 @@ end
   end
 
 
+# Does this (possibly nested) type contain a `ForwardDiff.Dual` anywhere?
+_has_dual(::Type{<:Dual}) = true
+_has_dual(::Type{<:Complex{<:Dual}}) = true
+_has_dual(::Type{T}) where {T<:Tuple} = any(_has_dual, fieldtypes(T))
+_has_dual(::Type) = false
+
+# Recursively strip `ForwardDiff.Dual` values from a broadcast output element,
+# descending into `Tuple`s (e.g. the result of `broadcast(tuple, x, y)`).
+@inline _strip_dual(x::Dual) = value(x)
+@inline _strip_dual(x::Complex{<:Dual}) = Complex(value(real(x)), value(imag(x)))
+@inline _strip_dual(x::Tuple) = map(_strip_dual, x)
+
+# Contract an incoming cotangent element `ȳ1` with the partials of the output
+# element `o1` w.r.t. the i-th broadcast argument, descending into `Tuple`s.
+@inline _dual_partial(ȳ1, o1::Dual, i) = ȳ1 * partials(o1, i)
+@inline _dual_partial(ȳ1::Tuple, o1::Tuple, i) = mapreduce((y1, p1) -> _dual_partial(y1, p1, i), +, ȳ1, o1)
+@inline _dual_partial(::Nothing, o1, i) = false  # missing cotangent component → zero contribution
+
 @inline function broadcast_forward(f, args::Vararg{Any,N}) where N
   out = dual_function(f).(args...)
   T = eltype(out)
-  T <: Union{Dual, Complex{<:Dual}} || return (out, _ -> nothing)
-  if any(eltype(a) <: Complex for a in args)
-    _broadcast_forward_complex(T, out, args...)
+  if T <: Union{Dual, Complex{<:Dual}}
+    if any(eltype(a) <: Complex for a in args)
+      return _broadcast_forward_complex(T, out, args...)
+    else
+      return _broadcast_forward(T, out, args...)
+    end
+  elseif _has_dual(T)
+    # The output element is a `Tuple` (possibly nested) of `Dual`s, as produced by
+    # e.g. `broadcast(tuple, x, y)`. Strip the `Dual`s from the returned value and
+    # contract the partials in the pullback, rather than leaking `Dual`s to the
+    # caller and returning a `nothing` gradient. See FluxML/Zygote.jl#1424.
+    return _broadcast_forward_tuple(out, args...)
   else
-    _broadcast_forward(T, out, args...)
+    return (out, _ -> nothing)
   end
+end
+
+# Real input, `Tuple`-of-`Dual` output (e.g. `broadcast(tuple, x, y)`).
+@inline function _broadcast_forward_tuple(out, args::Vararg{Any, N}) where {N}
+  valN = Val(N)
+  y = broadcast(_strip_dual, out)
+  function bc_fwd_back(ȳ)
+    dargs = ntuple(valN) do i
+      unbroadcast(args[i], broadcast((ȳ1, o1) -> _dual_partial(ȳ1, o1, i), ȳ, out))
+    end
+    (nothing, nothing, dargs...) # nothings for broadcasted & f
+  end
+  return y, bc_fwd_back
 end
 
 # Real input and real output pullback

--- a/test/cuda.jl
+++ b/test/cuda.jl
@@ -60,6 +60,22 @@ end
   @test gradient(x -> sum(exp.(x)), Diagonal(a_gpu))[1] isa Diagonal
   # non-differentiables
   @test gradient((x,y) -> sum(x.^2 .+ y'), a_gpu, a_gpu .> 0)[2] === nothing
+
+  # https://github.com/FluxML/Zygote.jl/issues/1424 : a broadcast whose output
+  # element is a Tuple (here `tuple.(x, y)`) must not leak ForwardDiff `Dual`s
+  # into the primal, and its pullback must not be `nothing`.
+  let x = cu(Float32[1, 2, 3]), y = cu(Float32[4, 5, 6])
+    f(x, y) = broadcast(tuple, x, y)
+    o, back = pullback(f, x, y)
+    @test eltype(o) == Tuple{Float32,Float32}
+    @test collect(o) == collect(broadcast(tuple, x, y))
+    gx, gy = back(o)
+    oc, backc = pullback(f, collect(x), collect(y))
+    gxc, gyc = backc(oc)
+    @test gx isa CuArray && gy isa CuArray
+    @test collect(gx) ≈ gxc
+    @test collect(gy) ≈ gyc
+  end
 end
 
 @testset "sum(f, x)" begin


### PR DESCRIPTION
Fixes #1424.

`broadcast(tuple, x, y)` on a GPU array takes the forward-mode path, whose output element is a `Tuple` of `ForwardDiff.Dual`s. `broadcast_forward` only recognised `Dual`/`Complex{Dual}` element types, so for a tuple output it returned the raw dual-laden array as the primal and a `nothing` pullback:

```julia
julia> o, back = pullback((x,y) -> broadcast(tuple, x, y), CUDA.rand(2), CUDA.rand(2));

julia> eltype(o)
Tuple{ForwardDiff.Dual{Nothing, Float32, 2}, ForwardDiff.Dual{Nothing, Float32, 2}}   # leaks Duals

julia> back(o)
(nothing, nothing)
```

This PR teaches `broadcast_forward` to recognise output element types that contain `Dual`s nested inside `Tuple`s: it strips the duals from the returned value and contracts the partials in the pullback, mirroring the CPU reverse-mode path. The CPU forward fast-path is unaffected (tuple outputs there already go through generic reverse mode).

After the fix (verified on an RTX 5090, CUDA 6.2, Julia 1.12):

```julia
julia> eltype(o)
Tuple{Float32, Float32}

julia> back(o)   # matches the CPU result
(Float32[...], Float32[...])
```

A regression test is added to `test/cuda.jl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)