### PR TITLE
Keep gradients of CuSparseMatrixCSC sparse via ProjectTo (#1313)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -29,12 +29,14 @@ ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 
 [weakdeps]
 Atom = "c52e3926-4ff0-5f6e-af25-54175e0327b1"
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 
 [extensions]
 ZygoteAtomExt = "Atom"
+ZygoteCUDAExt = "CUDA"
 ZygoteColorsExt = "Colors"
 ZygoteDistancesExt = "Distances"
 ZygoteTrackerExt = "Tracker"
@@ -42,6 +44,7 @@ ZygoteTrackerExt = "Tracker"
 [compat]
 AbstractFFTs = "1.5"
 Atom = "0.12"
+CUDA = "5.4, 6"
 ChainRules = "1.72.2"
 ChainRulesCore = "1.25.1"
 Colors = "0.13"

--- a/ext/ZygoteCUDAExt.jl
+++ b/ext/ZygoteCUDAExt.jl
@@ -1,0 +1,49 @@
+module ZygoteCUDAExt
+
+using CUDA: CuArray
+using CUDA.CUSPARSE: CuSparseMatrixCSC
+using ChainRulesCore: ChainRulesCore, ProjectTo, project_type
+
+# Projection onto the sparsity pattern of a `CuSparseMatrixCSC`, mirroring
+# ChainRulesCore's `ProjectTo(::SparseMatrixCSC)` (which keeps gradients of a
+# sparse primal sparse) but doing the gather on the GPU so it works without
+# scalar indexing. Without this, gradients w.r.t. a `CuSparseMatrixCSC` come
+# back as a dense `CuArray`, breaking `update!` and disagreeing with the CPU
+# sparse path. See FluxML/Zygote.jl#1313.
+function ChainRulesCore.ProjectTo(x::CuSparseMatrixCSC{T}) where {T<:Number}
+    m, n = size(x)
+    Ti = eltype(x.rowVal)
+    # Column index of each stored entry, expanded from `colPtr` on the host
+    # (length `n+1`, cheap) and moved to the device once.
+    colptr = Array(x.colPtr)
+    col = Vector{Ti}(undef, length(x.rowVal))
+    @inbounds for c in 1:n, k in colptr[c]:(colptr[c+1]-1)
+        col[k] = c
+    end
+    # Column-major linear index of each stored entry, used to gather from a
+    # dense cotangent without scalar indexing.
+    lin = x.rowVal .+ Ti(m) .* (CuArray(col) .- one(Ti))
+    return ProjectTo{CuSparseMatrixCSC}(;
+        element = ProjectTo(zero(T)),
+        dims = (m, n),
+        colPtr = x.colPtr,
+        rowVal = x.rowVal,
+        lin = lin,
+    )
+end
+
+function (project::ProjectTo{CuSparseMatrixCSC})(dx::AbstractArray)
+    m, n = project.dims
+    size(dx) == (m, n) || throw(DimensionMismatch(
+        "variable with size(x) == $(project.dims) cannot have a gradient with size(dx) == $(size(dx))"))
+    nzval = vec(dx)[project.lin]
+    Tv = project_type(project.element)
+    nzval = eltype(nzval) === Tv ? nzval : Tv.(nzval)
+    return CuSparseMatrixCSC(project.colPtr, project.rowVal, nzval, project.dims)
+end
+
+# Cotangent already sparse: densify (small, no scalar indexing) and reuse the
+# gather above so the result has the *primal's* pattern, not the cotangent's.
+(project::ProjectTo{CuSparseMatrixCSC})(dx::CuSparseMatrixCSC) = project(CuArray(dx))
+
+end # module

--- a/test/cuda.jl
+++ b/test/cuda.jl
@@ -1,5 +1,7 @@
 using LinearAlgebra
+using SparseArrays
 using CUDA
+using CUDA.CUSPARSE: CuSparseMatrixCSC
 using Zygote: Grads
 using Random: randn!
 import FiniteDifferences
@@ -198,4 +200,26 @@ end
     @test gradcheck_gpu(x->sum(imag, x.^2 .+ abs.(sinh.(conj.(x)))), ygpu)
 
 
+end
+
+@testset "sparse projection" begin
+  # https://github.com/FluxML/Zygote.jl/issues/1313 : the gradient w.r.t. a
+  # `CuSparseMatrixCSC` must stay sparse (with the primal's pattern) and match
+  # the CPU sparse path, instead of coming back dense.
+  M = sprand(10, 10, 0.3)
+  x = randn(10)
+  g_cpu = gradient(M -> sum((M*x).^2), M)[1]
+  @test g_cpu isa SparseMatrixCSC
+
+  Mg = CuSparseMatrixCSC(Float32.(M))
+  xg = cu(Float32.(x))
+  g_gpu = gradient(M -> sum((M*xg).^2), Mg)[1]
+  @test g_gpu isa CuSparseMatrixCSC{Float32}
+  @test collect(g_gpu.colPtr) == M.colptr
+  @test collect(g_gpu.rowVal) == M.rowval
+  @test collect(g_gpu.nzVal) ≈ Float32.(g_cpu.nzval)
+
+  # the result must support sparsity-preserving updates (the original bug was an
+  # exception in `update!` because the gradient was dense)
+  @test Mg - 0.1f0 * g_gpu isa CuSparseMatrixCSC
 end


### PR DESCRIPTION
Fixes #1313.

On the CPU, the gradient w.r.t. a `SparseMatrixCSC` is projected back onto the primal's sparsity pattern by ChainRulesCore's `ProjectTo(::SparseMatrixCSC)`. There is no corresponding projection for `CuSparseMatrixCSC`, so GPU gradients came back as a dense `CuArray` — disagreeing with the CPU result and breaking `update!` on a sparse parameter:

```julia
julia> gradient(M -> sum((M*xg).^2), Mg)[1] |> typeof
CuArray{Float32, 2, …}   # dense, off-pattern entries are nonzero
```

This PR adds a `CUDA` package extension (`ZygoteCUDAExt`) defining `ProjectTo(::CuSparseMatrixCSC)`. It mirrors the CPU sparse projection but gathers the stored entries from the dense cotangent **on the GPU** (via column-major linear indices precomputed once at projector construction), so it does no scalar indexing and works under `CUDA.allowscalar(false)`.

After the fix (verified on an RTX 5090, CUDA 6.2, Julia 1.12):

```julia
julia> gradient(M -> sum((M*xg).^2), Mg)[1] |> typeof
CuSparseMatrixCSC{Float32, Int32}   # same pattern as the primal, values match the CPU path
```

A regression test is added to `test/cuda.jl`.

### Note on the home for this projection
As discussed in the issue, the projection is arguably better placed upstream (ChainRulesCore can't depend on CUDA; the `AbstractGPUSparseMatrixCSC` abstract type lives in GPUArrays, which could provide a backend-generic version covering AMDGPU/oneAPI/Metal too). This PR is the most direct fix that works today from Zygote's side; happy to move it upstream instead if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)