### PR TITLE
Remove stale broken marker for 0-d generator gradient test

### DIFF
--- a/test/gradcheck_p1.jl
+++ b/test/gradcheck_p1.jl
@@ -192,7 +192,7 @@ end
   @test gradient(p -> sum(collect(p*i for i in Iterators.take(p*[1.0, 2.0, 3.0], 2))), 2.0) == (12.0,)
   # generator 0-d behavior handled incorrectly
   @test_broken gradient(p -> sum(collect(p*i for i in 1.0)), 2.0)
-  @test gradient(p -> sum(collect(p*i for i in fill(1.0))), 2.0)[1] == 1.0  broken=VERSION<v"1.12"
+  @test gradient(p -> sum(collect(p*i for i in fill(1.0))), 2.0)[1] == 1.0
   
   # adjoints for iterators
   @test gradient(x -> sum(collect(Iterators.take([x*i for i in 1:5], 4))), 1.0) == (10.0,)


### PR DESCRIPTION
## Problem

CI on `Julia min (1.10) - ubuntu-latest` fails with an **Unexpected Pass** at `test/gradcheck_p1.jl:195`:

```
Error During Test at test/gradcheck_p1.jl:195
 Unexpected Pass
 Expression: (gradient((p->sum(collect((p * i for i = fill(1.0))))), 2.0))[1] == 1.0
 Got correct result, please change to @test if no longer broken.
```

## Cause

The test was marked `broken=VERSION<v"1.12"` (added in #1593), asserting the 0-d generator gradient was wrong on Julia < 1.12. PR #1626 ("Fix UndefVarError(`j`) in non-differentiable pullbacks") fixed this generator / non-differentiable-pullback path, so the gradient is now correct on Julia 1.10 as well. A `broken=` test that succeeds is itself a failure.

Bisected to #1626: the same Unexpected Pass first appears in the run immediately following that commit.

## Fix

Drop the stale marker — the gradient now returns the correct `1.0` on all supported versions (verified on 1.10 via CI and 1.12 locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)