### PR TITLE
Fix wrong/`nothing` gradient for loop-carried variable swaps (#1198)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Zygote"
 uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
-version = "0.7.11"
+version = "0.7.12"
 
 [workspace]
 projects = ["test", "docs"]
@@ -50,7 +50,7 @@ Distances = "0.10"
 FillArrays = "1"
 ForwardDiff = "0.10.36, 1"
 GPUArraysCore = "0.2"
-IRTools = "0.4.12"
+IRTools = "0.4.16"
 LogExpFunctions = "0.3.29, 1"
 MacroTools = "0.5.10"
 NaNMath = "1"

--- a/test/features.jl
+++ b/test/features.jl
@@ -723,6 +723,28 @@ end
   # https://github.com/FluxML/Zygote.jl/issues/731
   f731(x) = sum([x' * x, x...])
   @test_broken gradient(f731, ones(3)) # MethodError: no method matching +(::Tuple{Float64, Float64, Float64}, ::Vector{Float64})
+
+  # https://github.com/FluxML/Zygote.jl/issues/1198
+  # Loop-carried variables that permute every iteration (a swap or rotation)
+  # used to drop the gradient (silent `nothing`): the adjoint loop swaps two
+  # block arguments per iteration, which was mis-lowered as a non-parallel copy.
+  function swap1198(x)
+    a, b = x, 2x
+    for _ in 1:3
+      a, b = b, a
+    end
+    return a
+  end
+  @test gradient(swap1198, 1.0) == (2.0,)  # 3 swaps of (x, 2x) -> returns 2x
+
+  function rotate1198(x)
+    v0, v1, v2 = x, 2x, 3x
+    for _ in 1:4
+      v0, v1, v2 = v1, v2, v0
+    end
+    return v0
+  end
+  @test gradient(rotate1198, 1.0) == (2.0,)  # 4 rotations -> v0 holds 2x
 end
 
 @testset "accumulation" begin


### PR DESCRIPTION
Fixes #1198.

## Summary

Gradients through a loop that **permutes loop-carried variables** every
iteration were silently wrong (typically `nothing`):

```julia
function f(x)
    a, b = x, 2x
    for _ in 1:3
        a, b = b, a      # swap each iteration
    end
    return a
end

gradient(f, 1.0)   # was (nothing,), should be (2.0,)
```

The original report hit this with a Chebyshev propagator that rotates three
buffers (`v0, v1, v2 = v1, v2, v0`).

## Root cause

Not in Zygote's source transform — the adjoint IR it emits is correct. The
bug was one level down, in **IRTools'** `slots!` pass that lowers block
arguments to slot assignments.

Zygote's reverse pass turns a loop-carried permutation into an adjoint loop
whose back-edge passes two block arguments in swapped positions — a *parallel*
copy. `slots!` lowered it as a *sequential* one:

```
phi_a = phi_b   # a = b
phi_b = phi_a   # b = a   ← reads the already-overwritten slot ⇒ b = b
```

so the gradient seed bounced between the two slots and was never fed into the
relevant pullback. (Only loops were affected: a single `a, b = b, a` outside a
loop has no back-edge and lowered fine, which is why the `1*b` workaround in
the issue "fixed" it — `*` introduces a fresh SSA value.)

## Fix

Fixed in IRTools by sequentialising each branch's block arguments as a proper
parallel copy, breaking cycles (swaps, rotations) with a temporary:
FluxML/IRTools.jl#133 (released in IRTools 0.4.16).

This PR:
- bumps the `IRTools` compat lower bound to `0.4.16` to pull in the fix;
- adds a regression test (`test/features.jl`) covering the issue's swap
  (2-cycle) and rotation (3-cycle) cases.

The original issue's reproduction now matches finite differences for both the
primal value and the gradient.

> [!NOTE]
> Depends on IRTools 0.4.16 being registered; CI will only resolve once it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)