### PR TITLE
Add adjoint for real-valued `(:)` ranges (#954)

### DIFF
--- a/src/lib/range.jl
+++ b/src/lib/range.jl
@@ -1,2 +1,21 @@
 @adjoint StepRange{Int64, Int64}(a::Int64, b::Int64) = a:b, Δ -> (nothing, nothing)
 @adjoint StepRange{Int64, Int64}(a::Int64, b::Int64, c::Int64) = a:b:c, Δ -> (nothing, nothing, nothing)
+
+# ChainRules marks `(:)` as `@non_differentiable`, which silently drops the gradient
+# w.r.t. the endpoints of a *real* range (issue #954). The endpoints carry a genuine
+# gradient: for `r = start:step:stop`, `r[i] = start + (i-1)*step`, while `stop` only
+# determines the length and is non-differentiable.
+@adjoint function (:)(start::Real, stop::Real)
+  start:stop, function (Δ)
+    Δ === nothing && return (nothing, nothing)
+    (sum(Δ), nothing)
+  end
+end
+
+@adjoint function (:)(start::Real, step::Real, stop::Real)
+  start:step:stop, function (Δ)
+    Δ === nothing && return (nothing, nothing, nothing)
+    dstep = sum(i -> (i - 1) * Δ[i], eachindex(Δ); init = zero(eltype(Δ)) * zero(step))
+    (sum(Δ), dstep, nothing)
+  end
+end

--- a/test/features.jl
+++ b/test/features.jl
@@ -755,6 +755,19 @@ end
   end[1] == Dict(1 => Fill(5, 1), 2 => Fill(1, 1))
 end
 
+@testset "range adjoints (#954)" begin
+  # ChainRules marks `(:)` non-differentiable, which silently dropped the gradient
+  # w.r.t. the endpoints of a real range. The endpoints carry a genuine gradient.
+  @test gradient(x -> (x:3)[1], 1.2) == (1.0,)
+  @test gradient(x -> (x:3)[end], 1.2) == (1.0,)
+  @test gradient(x -> sum(x:0.5:3), 1.0) == (5.0,)
+  # start:step:stop  ->  r[i] = start + (i-1)*step
+  @test gradient((a, s) -> (a:s:10)[3], 1.0, 2.0) == (1.0, 2.0)
+  @test gradient(x -> sum(abs2, x:0.7:5.0), 1.0)[1] ≈ 33.0
+  # integer ranges used for indexing/iteration still behave
+  @test gradient(x -> sum(x[1:2]), [1.0, 2.0, 3.0]) == ([1.0, 1.0, 0.0],)
+end
+
 @testset "tricky broadcasting" begin
   @test gradient(x -> sum(x .+ ones(2,2)), (1,2)) == ((2,2),)
   @test gradient(x -> sum(x .+ ones(2,2)), (1,)) == ((4,),)


### PR DESCRIPTION
Fixes #954.

`gradient(x -> (x:3)[1], 1.2)` returned `(nothing,)` instead of `(1.0,)`. ChainRules marks `(:)` as `@non_differentiable`, so the gradient w.r.t. the endpoints of a **real** range was silently dropped — even though those endpoints carry a genuine gradient.

This adds Zygote `@adjoint`s for `(:)(start, stop)` and `(:)(start, step, stop)` on real arguments. For `r = start:step:stop`, `r[i] = start + (i-1)*step`, so:
- `dstart = sum(Δ)`
- `dstep  = sum((i-1)*Δ[i])`
- `dstop  = nothing` (it only determines the length)

Integer ranges used for indexing/iteration are unaffected (their cotangent is `nothing`, so the pullback returns `nothing`). Verified numerically against FiniteDifferences; regression tests added in `test/features.jl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)