### PR TITLE
Add `getproperty(::Cholesky, :factors)` adjoint (#1148)

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -622,6 +622,11 @@ end
     return ((uplo=nothing, info=nothing, factors=nothing),)
   end
 end
+@adjoint function literal_getproperty(C::Cholesky, ::Val{:factors})
+  return literal_getproperty(C, Val(:factors)), function(Δ)
+    return ((uplo=nothing, info=nothing, factors=Δ),)
+  end
+end
 @adjoint function literal_getproperty(C::Cholesky, ::Val{:U})
   return literal_getproperty(C, Val(:U)), function(Δ)
     Δ_factors = C.uplo == 'U' ? UpperTriangular(Δ) : LowerTriangular(copy(Δ'))

--- a/test/gradcheck_p2.jl
+++ b/test/gradcheck_p2.jl
@@ -106,6 +106,16 @@ import LogExpFunctions
     @test Zygote.pullback(g, X)[2]((factors=LowerTriangular(X),))[1] ≈
       Zygote.pullback(g, X)[2]((factors=Matrix(LowerTriangular(X)),))[1]
 
+    # https://github.com/FluxML/Zygote.jl/issues/1148
+    # `getproperty(C, :factors)` used to silently drop the gradient. Only the stored
+    # (uplo) triangle is meaningful, so the gradient must match the `.U`/`.L` adjoint
+    # there (the other triangle is LAPACK scratch and treated as non-differentiable).
+    @test gradient(X -> sum(triu(cholesky(X * X' + I).factors)), X)[1] ≈
+      gradient(X -> sum(cholesky(X * X' + I).U), X)[1]
+    let h(x) = sum(cholesky([4.0 1.0; 1.0 x]).factors)
+      @test gradient(h, 3.0)[1] ≈ FiniteDifferences.central_fdm(5, 1)(h, 3.0)
+    end
+
     # https://github.com/FluxML/Zygote.jl/issues/932
     @test gradcheck(rand(5, 5), rand(5)) do A, x
         C = cholesky(Symmetric(A' * A + I))


### PR DESCRIPTION
Fixes #1148.

Accessing `C.factors` of a `Cholesky` silently dropped the gradient (returned `nothing`), because there was no `literal_getproperty` adjoint for the `:factors` field — only `:U`, `:L`, `:uplo`, and `:info` had one.

This adds the missing adjoint, routing the cotangent into the `factors` slot:

```julia
@adjoint function literal_getproperty(C::Cholesky, ::Val{:factors})
  return literal_getproperty(C, Val(:factors)), function(Δ)
    return ((uplo=nothing, info=nothing, factors=Δ),)
  end
end
```

The downstream `cholesky` rrule then uses only the stored (uplo) triangle, exactly as the `.U`/`.L` adjoints do; the other triangle is LAPACK scratch and is treated as non-differentiable.

The regression test checks consistency with the `.U` adjoint (rather than a raw `gradtest` of `.factors`, which would incorrectly weight the scratch triangle) plus a FiniteDifferences check on a case where the scratch triangle is constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)