### PR TITLE
Fix dropped gradient for `deepcopy` of a dict (#1113)

### DIFF
--- a/src/lib/base.jl
+++ b/src/lib/base.jl
@@ -41,6 +41,21 @@ function accum(a::AbstractDict, b::AbstractDict)
   return merge(a, b)
 end
 
+# A dict's gradient is tracked in the context cache keyed by the dict's *identity*
+# (see `grad_mut`). The generic `deepcopy` adjoint (`ȳ -> (ȳ,)`) doesn't bridge that
+# cache, so the gradient accumulated against the copy never reaches the original and
+# is silently dropped (issue #1113). Route it back into the original's cache slot.
+@adjoint function deepcopy(d::AbstractDict)
+  deepcopy(d), function (ȳ)
+    ȳ === nothing && return (nothing,)
+    grad = grad_mut(__context__, d)
+    for (k, v) in ȳ
+      grad[k] = accum(get(grad, k, nothing), v)
+    end
+    return (grad,)
+  end
+end
+
 @adjoint function getindex(d::AbstractDict, k)
   val = d[k]
   function dict_getindex_pullback(Δ)

--- a/test/features.jl
+++ b/test/features.jl
@@ -753,6 +753,12 @@ end
     nd = defensiveupdate(d, 5)
     return sum(nd[1]) + sum(nd[2])
   end[1] == Dict(1 => Fill(5, 1), 2 => Fill(1, 1))
+
+  # https://github.com/FluxML/Zygote.jl/issues/1113
+  # deepcopy of a dict constructed *inside* the differentiated function used to
+  # silently drop the gradient (the dict gradient is keyed by object identity).
+  @test gradient(x -> deepcopy(Dict(:a => x))[:a], 2.0) == (1.0,)
+  @test gradient(x -> (dc = deepcopy(Dict(:a => x, :b => 2x)); dc[:a] + 3 * dc[:b]), 2.0) == (7.0,)
 end
 
 @testset "tricky broadcasting" begin


### PR DESCRIPTION
Fixes #1113.

`gradient(x -> deepcopy(Dict(:a => x))[:a], 2.0)` returned `(nothing,)` instead of `(1.0,)`.

A dict's gradient is tracked in the context cache keyed by the dict's **object identity** (see `grad_mut`). The generic `deepcopy` adjoint (`ȳ -> (ȳ,)`) doesn't bridge that cache, so when a dict is constructed inside the differentiated function and then deepcopied, the gradient accumulated against the *copy* never reaches the *original* and is silently dropped.

This adds a `deepcopy(::AbstractDict)` adjoint that routes the accumulated gradient back into the original's cache slot:

```julia
@adjoint function deepcopy(d::AbstractDict)
  deepcopy(d), function (ȳ)
    ȳ === nothing && return (nothing,)
    grad = grad_mut(__context__, d)
    for (k, v) in ȳ
      grad[k] = accum(get(grad, k, nothing), v)
    end
    return (grad,)
  end
end
```

The existing `deepcopy`-of-an-input-dict case (#1233) still works; regression tests added in `test/features.jl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)