### PR TITLE
Fix `new` with fewer arguments than fields (#1517)

### DIFF
--- a/src/tools/builtins.jl
+++ b/src/tools/builtins.jl
@@ -6,7 +6,15 @@ macro __splatnew__(T, args)
   esc(Expr(:splatnew, T, args))
 end
 
-@inline __new__(T, args...) = @__splatnew__(T, args)
+# `__new__(T, args...)` must mirror `Expr(:new, T, args...)`, which — unlike
+# `splatnew` — permits *fewer* arguments than `T` has fields (the trailing fields
+# are then left undefined, exactly as Julia allows for inner constructors such as
+# `T(x) = new(x)`). Splatting a runtime tuple into a `:new` expression needs a
+# generated function, so we build the `:new` with one argument per element. (#1517)
+@generated function __new__(T, args...)
+  Expr(:block, Expr(:meta, :inline),
+       Expr(:new, :T, (:(args[$i]) for i in 1:length(args))...))
+end
 @inline __splatnew__(T, args) = @__splatnew__(T, args)
 
 literal_getindex(x, ::Val{i}) where i = getindex(x, i)

--- a/test/structures.jl
+++ b/test/structures.jl
@@ -61,6 +61,18 @@ end
   @test b(m) === nothing
 end
 
+# https://github.com/FluxML/Zygote.jl/issues/1517
+struct FewerArgs1517
+  x::Float64
+  y::Float64
+  FewerArgs1517(x) = new(x)  # inner constructor leaves `y` undefined
+end
+
+@testset "new with fewer arguments than fields (#1517)" begin
+  @test gradient(x -> FewerArgs1517(x).x * 2, 2.0) == (2.0,)
+  @test gradient(x -> 3 * FewerArgs1517(x).x, 5.0) == (3.0,)
+end
+
 @testset "threads" begin
     function threads1(x)
       ch = Channel(0)


### PR DESCRIPTION
## Summary

`MyStruct(x) = new(x)` for a struct with more fields than the supplied arguments threw `ArgumentError: new: too few arguments (expected 2)` under AD:

```julia
struct MyStruct
    x::Float64
    y::Float64
    MyStruct(x) = new(x)
end
gradient(x -> MyStruct(x).x * 2, 2.0)   # ERROR before, (2.0,) now
```

## Cause

`__new__(T, args...)` forwarded to `@__splatnew__`, i.e. `Expr(:splatnew, T, args)`. Unlike `Expr(:new, ...)`, `splatnew` requires exactly as many arguments as `T` has fields, so an inner constructor that leaves trailing fields undefined could not be reconstructed.

## Fix

Replace `__new__` with a generated function that builds an `Expr(:new, T, args...)` with one argument per supplied element, so trailing fields are left undefined exactly as Julia allows. `__splatnew__` (used for genuine `:splatnew` lowerings) is unchanged.

Fixes #1517.

🤖 Generated with [Claude Code](https://claude.com/claude-code)