### PR TITLE
Handle `nothing`/`AbstractZero` cotangent in `reshape` adjoint (#1567)

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -103,8 +103,16 @@ end
 @adjoint PermutedDimsArray(xs, dims) = PermutedDimsArray(xs, dims),
   Δ -> (PermutedDimsArray(Δ, invperm(dims)), nothing)
 
+# `Δ` is normally an array (or an `AbstractThunk`, which `reshape` handles), but it
+# can be a sentinel `nothing`/`AbstractZero` when `xs` is non-differentiable, e.g.
+# `reshape(::Array{Bool}, ...)` (#1567). `reshape` has no method for those, so pass
+# them straight through.
+_reshape_pullback(Δ, sz) = reshape(Δ, sz)
+_reshape_pullback(::Nothing, sz) = nothing
+_reshape_pullback(Δ::AbstractZero, sz) = Δ
+
 @adjoint reshape(xs, dims...) = reshape(xs, dims...),
-  Δ -> (reshape(Δ, size(xs)),map(_->nothing,dims)...)
+  Δ -> (_reshape_pullback(Δ, size(xs)), map(_->nothing,dims)...)
 
 @adjoint function repeat(xs; inner=ntuple(_->1, ndims(xs)), outer=ntuple(_->1, ndims(xs)))
   repeat(xs, inner = inner, outer = outer), function (Δ)

--- a/test/features.jl
+++ b/test/features.jl
@@ -720,6 +720,11 @@ end
   f866(x) = reshape(x, fill(2, 2)...)
   @test gradient(x->sum(f866(x)), rand(4))[1] == [1,1,1,1]
 
+  # https://github.com/FluxML/Zygote.jl/issues/1567
+  # reshape of a non-differentiable array gets a `nothing`/`AbstractZero` cotangent
+  @test gradient(w -> sum(w * reshape(rand(Bool, 12), 3, 4)), rand(2, 3))[1] |> size == (2, 3)
+  @test gradient(w -> sum(w * reshape(trues(6), 2, 3)), rand(4, 2))[1] |> size == (4, 2)
+
   # https://github.com/FluxML/Zygote.jl/issues/731
   f731(x) = sum([x' * x, x...])
   @test_broken gradient(f731, ones(3)) # MethodError: no method matching +(::Tuple{Float64, Float64, Float64}, ::Vector{Float64})


### PR DESCRIPTION
## Summary

```julia
gradient(w -> sum(w * reshape(rand(Bool, 12), 3, 4)), rand(2, 3))
# ERROR: MethodError: no method matching reshape(::Nothing, ::Tuple{Int64, Int64})
```

This also surfaced via Flux's `Embedding` / one-hot inputs (`reshape(::OneHotArray, …)`).

## Cause

When `reshape`'s array is non-differentiable (a `Bool`/one-hot array), the cotangent flowing into the reshape pullback is the sentinel `nothing` (or an `AbstractZero`), and `reshape` has no method for those.

## Fix

Route the pullback through `_reshape_pullback`, which reshapes genuine array/`AbstractThunk` cotangents and passes `nothing`/`AbstractZero` straight through.

Fixes #1567.

🤖 Generated with [Claude Code](https://claude.com/claude-code)