### PR TITLE
Differentiate typed array literals and `;;` concatenation (#1413, #1572)

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -106,6 +106,33 @@ end
 @adjoint reshape(xs, dims...) = reshape(xs, dims...),
   Δ -> (reshape(Δ, size(xs)),map(_->nothing,dims)...)
 
+# Typed array literals (`Float32[1 0 0 x]`, `Float32[1 0; 0 x]`) and the `;;`/`;;;`
+# n-dimensional concatenation (`[x ;; 1]`) lower to `typed_hcat`/`typed_vcat`/
+# `typed_hvcat`/`hvncat`, none of which have a ChainRules rule, so Zygote tried to
+# differentiate their mutating `setindex!` fallback (#1413, #1572). Reuse the rules
+# for the untyped `hcat`/`vcat`/`hvcat`/`cat`, which produce numerically identical
+# values and identical cotangents (the element type only affects projection).
+for (typed, untyped) in ((:typed_hcat, :hcat), (:typed_vcat, :vcat))
+  @eval function _pullback(cx::AContext, ::typeof(Base.$typed), ::Type{T}, xs...) where {T}
+    y, back = _pullback(cx, $untyped, xs...)
+    $(Symbol(typed, :_pullback))(Δ) = (nothing, nothing, Base.tail(back(Δ))...)
+    return Base.$typed(T, xs...), $(Symbol(typed, :_pullback))
+  end
+end
+
+function _pullback(cx::AContext, ::typeof(Base.typed_hvcat), ::Type{T}, rows::Tuple{Vararg{Int}}, xs...) where {T}
+  y, back = _pullback(cx, hvcat, rows, xs...)
+  typed_hvcat_pullback(Δ) = (nothing, nothing, nothing, Base.tail(Base.tail(back(Δ)))...)
+  return Base.typed_hvcat(T, rows, xs...), typed_hvcat_pullback
+end
+
+function _pullback(cx::AContext, ::typeof(Base.hvncat), dim::Int, xs...)
+  catdims(args...) = cat(args...; dims = dim)
+  y, back = _pullback(cx, catdims, xs...)
+  hvncat_pullback(Δ) = (nothing, nothing, Base.tail(back(Δ))...)
+  return y, hvncat_pullback
+end
+
 @adjoint function repeat(xs; inner=ntuple(_->1, ndims(xs)), outer=ntuple(_->1, ndims(xs)))
   repeat(xs, inner = inner, outer = outer), function (Δ)
     Δ′ = zero(xs)

--- a/test/gradcheck_p3.jl
+++ b/test/gradcheck_p3.jl
@@ -176,6 +176,21 @@ end
   @test gradient(x -> hvcat((2,2),1,2,3,x)[4], 4.0) == (1.0,)
 end
 
+@testset "typed_hcat / typed_vcat / typed_hvcat / hvncat (#1413, #1572)" begin
+  # Typed array literals: Float32[...] -> typed_hcat / typed_hvcat / typed_vcat
+  @test gradient(x -> sum(Float32[1 0 0 x[1]]), [2.0f0])[1] == Float32[1]      # typed_hcat
+  @test gradient(x -> sum(Float32[1 0; 0 x[1]]), [2.0f0])[1] == Float32[1]     # typed_hvcat
+  @test gradient(x -> sum(Float64[x[1]; x[2]; 5]), [1.0, 2.0])[1] == [1, 1]    # typed_vcat
+  @test gradient(x -> sum(Float32[x[1] x[2] x[1]]), [3f0, 4f0])[1] == Float32[2, 1]  # x[1] used twice
+  # `;;` / `;;;` n-dimensional concatenation -> hvncat
+  @test gradient(x -> sum([x ;; 1.0]), 2.0) == (1.0,)
+  @test gradient(x -> sum([x ;;; 5.0]), 2.0) == (1.0,)
+  @test gradient(x -> sum([1.0, 2.0] .* [x ;; 2x]), 3.0) == (9.0,)
+  let b = rand(2)
+    @test gradtest(x -> [x ;; b], rand(2))
+  end
+end
+
 @testset "cat(..., dims = $dim)" for dim in 1:5
   catdim = (x...) -> cat(x..., dims = dim)
   @test gradtest(catdim, rand(5), rand(5))


### PR DESCRIPTION
## Summary

```julia
gradient(x -> sum(Float32[1 0 0 x[1]]), [2f0])   # ERROR: Mutating arrays is not supported
gradient(x -> sum([x ;; 1.0]), 2.0)              # ERROR: Mutating arrays is not supported
```

Typed literals (`Float32[1 0 0 x]`, `Float32[1 0; 0 x]`) and `;;`/`;;;` concatenation (`[x ;; 1]`) lower to `typed_hcat` / `typed_vcat` / `typed_hvcat` / `hvncat`, none of which has a ChainRules rule, so Zygote fell through to their mutating `setindex!` / `hvcat_fill!` implementations.

## Fix

Add `_pullback` methods that reuse the existing rules for the untyped `hcat` / `vcat` / `hvcat` / `cat`. These produce numerically identical values and identical cotangents — the element type only affects projection.

Covers the `typed_hcat`, `typed_vcat`, `typed_hvcat` and `hvncat(dim::Int, …)` (the `;;`/`;;;` forms) signatures. The block `hvncat(dims::Tuple, row_first, …)` form is not covered here.

Fixes #1413. Fixes #1572.

🤖 Generated with [Claude Code](https://claude.com/claude-code)