### PR TITLE
Project `Tuple` cotangents in `ProjectTo{AbstractArray}` (#1417)

### DIFF
--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -203,6 +203,12 @@ end
 # Restore splatted arrays
 _project(x::AbstractArray, dx::Tuple) = _project(x, reshape(collect(dx), axes(x)))
 
+# Splatting an array (`vcat(x...)`) makes its cotangent a `Tuple`, which can then be
+# handed to an array `rrule`'s own `ProjectTo` (bypassing the `_project` method just
+# above) and error, e.g. `vcat(vcat([x], 1)...)` (#1417, #599). Reshape it back to
+# the expected array shape before projecting.
+(project::ProjectTo{AbstractArray})(dx::Tuple) = project(reshape(collect(dx), project.axes))
+
 # Piracy:
 # CRC likes Tangent{AbstractArray}, but Zygote makes Tangent{Any}
 # in particular this would hit https://github.com/JuliaDiff/ChainRulesCore.jl/blob/2ec2549b73b22bc08f554dae864fb650cfb9c3d7/src/projection.jl#L139

--- a/test/features.jl
+++ b/test/features.jl
@@ -716,6 +716,17 @@ end
   # https://github.com/FluxML/Zygote.jl/issues/599
   @test gradient(w -> sum([w...]), [1,1])[1] isa AbstractVector
 
+  # https://github.com/FluxML/Zygote.jl/issues/1417
+  # splatting an array into vcat gives it a Tuple cotangent, which the vcat rrule
+  # then projects directly via `ProjectTo{AbstractArray}`
+  function loss1417(theta)
+    x1 = vcat([theta], 5)
+    x2 = vcat(x1...)
+    return x2[1]
+  end
+  @test gradient(loss1417, 1.0) == (1.0,)
+  @test gradient(x -> sum(vcat(x...)), [1.0, 2.0, 3.0])[1] == [1.0, 1.0, 1.0]
+
   # https://github.com/FluxML/Zygote.jl/issues/866
   f866(x) = reshape(x, fill(2, 2)...)
   @test gradient(x->sum(f866(x)), rand(4))[1] == [1,1,1,1]


### PR DESCRIPTION
## Summary

```julia
function loss(theta)
    x1 = vcat([theta], 5)
    x2 = vcat(x1...)
    return x2[1]
end
gradient(loss, 1)
# ERROR: MethodError: ProjectTo{AbstractArray}(::Tuple{Float64})
```

## Cause

Splatting an array (`vcat(x1...)`) makes its cotangent a `Tuple`. Zygote's `_project` already reshapes such tuples back to arrays, but a `vcat`/`hcat` rrule applies its *own* `ProjectTo` to each argument's cotangent directly, bypassing `_project`, and `ProjectTo{AbstractArray}` has no `Tuple` method.

## Fix

Add a `ProjectTo{AbstractArray}(::Tuple)` method that reshapes the tuple to the projector's axes before projecting, mirroring the existing `_project(::AbstractArray, ::Tuple)`.

Fixes #1417. Also helps #599.

🤖 Generated with [Claude Code](https://claude.com/claude-code)