### PR TITLE
Move `Array`/`collect` cotangent back to the GPU (#1305)

### DIFF
--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -452,6 +452,18 @@ using GPUArraysCore  # replaces @require CUDA block, weird indenting to preserve
   @adjoint (::Type{T})(xs::Array) where {T <: AbstractGPUArray} =
     T(xs), Δ -> (convert(Array, Δ), )
 
+  # `Array`/`collect` move a GPU array to the host; their pullback must move the
+  # cotangent back to the device. Otherwise it stays a CPU array and a later
+  # operation that broadcasts it against the GPU primal (e.g. `A*x` in the
+  # original report) hits scalar indexing or fails to compile. See #1305.
+  # `copyto!(similar(xs, ...), Δ)` relocates without naming a specific GPU
+  # backend and without scalar indexing.
+  _gpu_cotangent(xs, Δ::AbstractGPUArray) = Δ
+  _gpu_cotangent(xs, Δ::AbstractArray) = copyto!(similar(xs, eltype(Δ), size(Δ)), Δ)
+
+  @adjoint Array(xs::AbstractGPUArray) = Array(xs), Δ -> (_gpu_cotangent(xs, Δ),)
+  @adjoint collect(xs::AbstractGPUArray) = collect(xs), Δ -> (_gpu_cotangent(xs, Δ),)
+
   # Make sure sum(f, ::CuArray) uses broadcast through forward-mode defined above
   # Not the ChainRules.rrule which will use the Zygote.Context and thus not be GPU compatible
   function _pullback(cx::AContext, ::typeof(sum), f, xs::AbstractGPUArray)

--- a/test/cuda.jl
+++ b/test/cuda.jl
@@ -23,9 +23,13 @@ end
   @test gradient((x,cy) -> sum(cu(x) * cy) + sum(cy'), r, cu(r))[2] isa CUDA.CuArray
   @test_skip gradient((x,cy) -> sum(cu(x[:,1])' * cy), r, cu(r))[2] isa CUDA.CuArray # generic_matmatmul!
 
-  # Other direction:
-  @test_skip gradient(x -> sum(Array(x)), cu(r))[1] isa CUDA.CuArray
-  @test_skip gradient((x,cy) -> sum(x * Array(cy)) + sum(cy'), r, cu(r))[2] isa CUDA.CuArray
+  # Other direction: https://github.com/FluxML/Zygote.jl/issues/1305 — `Array`/
+  # `collect` move a GPU array to the host, so their pullback must move the
+  # cotangent back to the device instead of leaving it a CPU array.
+  @test gradient(x -> sum(Array(x)), cu(r))[1] isa CUDA.CuArray
+  @test gradient(x -> sum(collect(x)), cu(r))[1] isa CUDA.CuArray
+  @test gradient((x,cy) -> sum(x * Array(cy)) + sum(cy'), r, cu(r))[2] isa CUDA.CuArray
+  @test collect(gradient(x -> sum(abs2, Array(x)), cu(r))[1]) ≈ gradient(x -> sum(abs2, Array(x)), r)[1]
 end
 
 @testset "broadcasting" begin


### PR DESCRIPTION
Closes #1305.

The pullback of `Array(::AbstractGPUArray)` (and `collect`) returned the cotangent unchanged, leaving it on the host. A later operation that broadcast it against the GPU primal then hit scalar indexing or failed to compile — the masked-minimum / `A*x` report in #1305.

This adds GPU-specific `Array`/`collect` adjoints that relocate the cotangent to the device via `copyto!(similar(xs, ...), Δ)`, mirroring the existing host-bound pullback for the `CuArray(::Array)` direction. The two "other direction" GPU-movement tests that were `@test_skip`ped are now enabled.

Verified on an RTX 5090 (CUDA.jl 6.2, Julia 1.12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)