### PR TITLE
Use fast GPU `sum(f, x)` rule for GPU array wrappers (#1498)

### DIFF
--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -454,12 +454,15 @@ using GPUArraysCore  # replaces @require CUDA block, weird indenting to preserve
 
   # Make sure sum(f, ::CuArray) uses broadcast through forward-mode defined above
   # Not the ChainRules.rrule which will use the Zygote.Context and thus not be GPU compatible
-  function _pullback(cx::AContext, ::typeof(sum), f, xs::AbstractGPUArray)
+  # `AnyGPUArray` (rather than `AbstractGPUArray`) also covers GPU array wrappers
+  # such as `view`/`SubArray`, `Adjoint` and `Transpose`, whose generic
+  # `sum(f, x)` rrule otherwise scalar-indexes on the GPU. See #1498.
+  function _pullback(cx::AContext, ::typeof(sum), f, xs::AnyGPUArray)
     res, back = _pullback(cx, (f, xs) -> sum(f.(xs)), f, xs)
     return res, back ∘ unthunk_tangent
   end
   function _pullback(cx::AContext, ::Core.kwftype(typeof(sum)), kws, ::typeof(sum), f,
-                     xs::AbstractGPUArray)
+                     xs::AnyGPUArray)
     @assert !haskey(kws, :init) # TODO add init support (julia 1.6)
     res, back = _pullback(cx, (f, xs) -> sum(f.(xs); kws...), f, xs)
     sum_gpuarray_kw_pullback(Δ) = (nothing, nothing, back(unthunk_tangent(Δ))...)

--- a/test/cuda.jl
+++ b/test/cuda.jl
@@ -109,6 +109,16 @@ end
   @test collect(gradient(f, cu(ComplexF32[0.0 + 0.0im]))[1]) == ComplexF32[0.0 + 0.0im]
   ca = ComplexF32[3.0 + 4.0im, 0.0 + 0.0im, -1.0 + 0.0im]
   @test collect(gradient(f, cu(ca))[1]) ≈ gradient(f, ca)[1]
+
+  # https://github.com/FluxML/Zygote.jl/issues/1498 : `sum(f, x)` over a GPU
+  # array *wrapper* (here a logical `view`) used to scalar-index, because the
+  # fast forward-mode rule only matched bare `AbstractGPUArray`s.
+  let X = randn(Float32, 16, 16), iso = rand(Bool, 16, 16)
+    h(x, m) = sum(z -> abs2(1 - z), view(x, m))
+    g_gpu = gradient(x -> h(x, cu(iso)), cu(X))[1]
+    @test g_gpu isa CuArray
+    @test collect(g_gpu) ≈ gradient(x -> h(x, iso), X)[1]
+  end
 end
 
 @testset "jacobian" begin


### PR DESCRIPTION
Closes #1498.

`sum(f, view(cuarray, mask))` errored with scalar indexing. The forward-mode `sum(f, ::AbstractGPUArray)` rule that keeps the reduction on the GPU only matched bare GPU arrays, so wrappers like `SubArray`, `Adjoint` and `Transpose` fell back to the generic `sum(f, x)` rrule, which scalar-indexes on the GPU.

This widens the dispatch to `AnyGPUArray` (`Union{AbstractGPUArray, WrappedGPUArray}`), which also covers those wrappers.

Verified on an RTX 5090 (CUDA.jl 6.2, Julia 1.12): the logical-`view` reproducer now matches the CPU gradient, and the existing `sum(f, x)` tests (including the `Adjoint`-structure-preserving one) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)