### PR TITLE
Accumulate host-structured cotangents against GPU arrays (#1512)

### DIFF
--- a/src/lib/broadcast.jl
+++ b/src/lib/broadcast.jl
@@ -471,3 +471,14 @@ using GPUArraysCore  # replaces @require CUDA block, weird indenting to preserve
   end
 
   pull_block_vert(sz, Δ::AbstractGPUArray, A::Number) = @allowscalar Δ[sz]
+
+  # Accumulating cotangents `accum`ulates by broadcasting `+`. When one cotangent
+  # is a host-backed structured array (e.g. the `Diagonal{<:Fill}` returned by
+  # the `tr` adjoint) and the other is a GPU array, that broadcast runs on the
+  # host and scalar-indexes the GPU array (`gradient(x -> sum(abs2,x) - tr(x), cu)`
+  # in #1512). Move the host operand onto the device first, then accumulate there.
+  _gpu_like(ref::AbstractGPUArray, y::AbstractGPUArray) = y
+  _gpu_like(ref::AbstractGPUArray, y::AbstractArray) = copyto!(similar(ref, eltype(y), size(y)), collect(y))
+  accum(x::AbstractGPUArray, y::AbstractGPUArray) = Base.broadcast_preserving_zero_d(accum, x, y)
+  accum(x::AbstractGPUArray, y::AbstractArray) = accum(x, _gpu_like(x, y))
+  accum(x::AbstractArray, y::AbstractGPUArray) = accum(_gpu_like(y, x), y)

--- a/test/cuda.jl
+++ b/test/cuda.jl
@@ -226,6 +226,18 @@ end
 
 end
 
+@testset "accum structured + GPU" begin
+  # https://github.com/FluxML/Zygote.jl/issues/1512 : the `tr` adjoint returns a
+  # host-backed `Diagonal{<:Fill}` cotangent; accumulating it against the dense
+  # GPU cotangent from `sum(abs2, x)` used to broadcast on the host and
+  # scalar-index the GPU array.
+  for x0 in (CUDA.zeros(Float32, 2, 2), cu(rand(Float32, 3, 3)))
+    g = gradient(x -> sum(abs2, x) - tr(x), x0)[1]
+    @test g isa CuArray
+    @test collect(g) ≈ gradient(x -> sum(abs2, x) - tr(x), collect(x0))[1]
+  end
+end
+
 @testset "sparse projection" begin
   # https://github.com/FluxML/Zygote.jl/issues/1313 : the gradient w.r.t. a
   # `CuSparseMatrixCSC` must stay sparse (with the primal's pattern) and match


### PR DESCRIPTION
Closes #1512.

`gradient(x -> sum(abs2, x) - tr(x), cu(...))` errored with scalar indexing. The `tr` adjoint returns a host-backed `Diagonal{<:Fill}` cotangent, and `accum`ulating it against the dense GPU cotangent from `sum(abs2, x)` broadcasts `+` on the host, scalar-indexing the GPU array.

This adds `accum` methods that move a host operand onto the device (via `copyto!(similar(gpu, ...), collect(host))`) before accumulating, so the addition runs on the GPU.

Verified on an RTX 5090 (CUDA.jl 6.2, Julia 1.12): the reproducer now returns a `CuArray` matching the CPU gradient; structured-array GPU gradient tests (`sqrt.(x')`, `exp.(Diagonal(x))`) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)