### PR TITLE
Deprecate implicit Params/Grads interface

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -177,32 +177,3 @@ julia> x = rand(5);
 julia> dmodel = gradient(model -> sum(model(x)), model)[1]
 (W = [0.652543 … 0.683588], b = [1.0, 1.0])
 ```
-
-## [Deprecated] Implicit Parameters
-
-Zygote also supports another way to take gradients, via *implicit parameters*.
-
-!!! warning "Deprecated"
-    The implicit-parameter interface (`Params`/`Grads`) is deprecated and will be removed
-    in a future release. Prefer the explicit style shown above. Calling `gradient`,
-    `withgradient`, `jacobian` or `pullback` with a `Params` argument now emits a
-    deprecation warning (visible when running Julia with `--depwarn=yes`).
-
-Here the loss function takes zero arguments, but the variables of interest are indicated by a special `Params` object. The function `linear` which depends on `W` and `b` is executed when the loss function `() -> sum(linear(x))` is called, and hence this dependence is visible to Zygote:
-
-```julia
-julia> W = rand(2, 5); b = rand(2);
-
-julia> linear(x) = W * x .+ b
-linear (generic function with 2 methods)
-
-julia> grads = gradient(() -> sum(linear(x)), Params([W, b]))
-Grads(...)
-
-julia> grads[W], grads[b] # access gradients using arrays as keys
-([0.652543 … 0.683588], [1.0, 1.0])
-```
-
-Here `grads` is a dictionary-like object, whose keys are the same parameters we indicated in `Params`. (In fact it wraps a dictionary using `objectid(W)` as keys, which does not change if the values in `W` are mutated).
-
-This implicit style was historically used by [Flux.jl](https://github.com/FluxML/Flux.jl), a closely related machine learning library, where `Flux.params(model)` returned a `Params` object containing all the parameters of all layers. Flux has since moved to the explicit style (differentiating a model passed as an argument), which is recommended for all new code; the implicit interface shown here is deprecated.

--- a/docs/src/limitations.md
+++ b/docs/src/limitations.md
@@ -3,7 +3,7 @@
 Zygote aims to support differentiating any Julia code, but it still has a few limitations.
 Notably, you might encounter errors when trying to differentiate:
 - array mutation,
-- `try`/`catch` statements,
+- `try`/`catch` statements when an exception is actually thrown,
 - "foreign call" expressions.
 
 This section gives examples where each of these errors occurs, as well as possible work-arounds.
@@ -74,7 +74,7 @@ Finally, there is also [`Zygote.Buffer`](@ref) which aims to handle the pattern 
 
 ## Try-catch statements
 
-Code containting try-catch blocks can be differentiated as long as no exception is actually thrown.
+Code containing try-catch blocks can be differentiated as long as no exception is actually thrown.
 
 ```julia
 julia> function safe_sqrt(x)

--- a/docs/src/utils.md
+++ b/docs/src/utils.md
@@ -20,8 +20,7 @@ in other words you could have written them easily yourself, but they live in
 Zygote for convenience.
 
 See `ChainRules.ignore_derivatives` if you want to exclude some of your code from the
-gradient calculation. This replaces previous Zygote-specific `ignore` and `dropgrad`
-functionality.
+gradient calculation.
 
 ```@docs
 Zygote.withgradient
@@ -32,51 +31,4 @@ Zygote.Buffer
 Zygote.forwarddiff
 Zygote.checkpointed
 Zygote.eager_update!
-```
-
-`Params` and `Grads` can be copied to and from arrays using the `copy!` function.
-
-## Working with Grads
-
-!!! warning "Deprecated"
-    `Params` and `Grads` are part of the implicit-parameter interface, which is deprecated
-    and will be removed in a future release. Prefer differentiating with explicit arguments;
-    the gradient of a nested model is then an ordinary (named) tuple, which supports the same
-    map/broadcast/accumulate operations shown below via
-    [Functors.jl](https://github.com/FluxML/Functors.jl)/[Optimisers.jl](https://github.com/FluxML/Optimisers.jl).
-
-Map, broadcast, and iteration are supported for the dictionary-like `Grads` objects.
-These operations are value based and preserve the keys.
-
-```julia
-using Zygote, Test
-
-w, x1, x2, b = rand(2), rand(2), rand(2), rand(2)
-
-gs1 = gradient(() -> sum(tanh.(w .* x1 .+ b)), Params([w, b]))
-gs2 = gradient(() -> sum(tanh.(w .* x2 .+ b)), Params([w, b]))
-
-# accumulate gradients
-gs = gs1 .+ gs2
-@test gs[w] ≈ gs1[w] + gs2[w]
-@test gs[b] ≈ gs1[b] + gs2[b]
-
-# gradients and IdDict interact nicely
-# note that an IdDict must be used for gradient algebra on the GPU
-gs .+= IdDict(p => randn(size(p)) for p in keys(gs))
-
-# clip gradients
-map(x -> clamp.(x, -0.1, 0.1), gs)
-
-# clip gradients in-place
-foreach(x -> clamp!(x, -0.1, 0.1), gs)
-
-for (p, g) in pairs(gs)
-  # do something with parameter `p` and corresponding gradient `g`
-end
-
-# note that gradients must be w.r.t. to the same parameter key set
-gs3 = gradient(() -> sum(tanh.(w .* x2)), Params([w]))
-# gs3 does not have the key b
-@test_throws ArgumentError gs1 .+ gs3
 ```

--- a/src/Zygote.jl
+++ b/src/Zygote.jl
@@ -14,12 +14,15 @@ using MacroTools
 using MacroTools: @forward
 
 import Distributed: pmap, CachingPool, workers
-export Params, withgradient, gradient, withjacobian, jacobian, hessian, diaghessian, pullback, pushforward, @code_adjoint
+
+export withgradient, gradient, withjacobian, jacobian, hessian, diaghessian, pullback, pushforward, @code_adjoint
 export rrule_via_ad
 
 const Numeric{T<:Number} = Union{T, AbstractArray{<:T}}
 
 include("deprecated.jl")
+export Params
+
 include("tools/buffer.jl")
 include("tools/builtins.jl")
 

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -373,3 +373,66 @@ end
   gs = gradient(()->sum(t[1]), ps)
   @test gs[t[1]] == ones(2, 2)
 end
+
+@testset "implicit params: mutable accum_param" begin
+  mutable struct MutAccum{T}; x::T; end
+  struct ImmAccum{T}; x::T; end
+
+  y1 = [3.0]
+  y2 = (MutAccum(y1),)
+  y3 = (ImmAccum(y1),)
+  @test gradient(() -> sum(y2[1].x)^2, Params([y1]))[y1] == [6.0]
+  @test gradient(() -> sum(y3[1].x)^2, Params([y1]))[y1] == [6.0]
+
+  @test gradient(() -> sum(y2[1].x .+ y2[1].x)^3, Params([y1]))[y1] == [216.0]
+  @test gradient(() -> sum(y3[1].x .+ y3[1].x)^3, Params([y1]))[y1] == [216.0]
+
+  i1 = 1
+  @test gradient(() -> sum(y2[i1].x .+ y2[1].x)^3, Params([y1]))[y1] == [216.0]
+  @test gradient(() -> sum(y3[i1].x .+ y3[1].x)^3, Params([y1]))[y1] == [216.0]
+end
+
+@testset "implicit params: broadcasted($op, Array, Bool)" for op in (+,-,*)
+  @testset "with $bool and sizes $s" for s in ((4,), (2,3)), bool in (true,false)
+    r = rand(Int8, s) .+ 0.0
+    z = fill(bool, s) .+ 0.0
+    gfun(args...) = gradient(() -> sum(op.(args...)), Params(filter(a->a isa Array, collect(args))))
+
+    g = gfun(r, z)
+    gres = gfun(r, bool)
+    @test gres[r] == g[r]
+
+    g = gfun(z, r)
+    gres = gfun(bool, r)
+    @test gres[r] == g[r]
+  end
+end
+
+@testset "implicit params: Dict iteration" begin
+  # https://github.com/FluxML/Zygote.jl/issues/1065
+  function sumkv(d)
+    s = zero(d["c"])
+    for (k, v) in d
+      s += v
+      k == :b && (s += v)
+    end
+    return sum(s)
+  end
+
+  function sumvals(d)
+    s = zero(d["c"])
+    for v in values(d)
+      s += v
+    end
+    return sum(s)
+  end
+
+  d_arr = Dict(:a => [3], :b => [4], "c" => [5])
+  ps = d_arr |> values |> collect |> Params
+
+  grads = gradient(() -> sumkv(d_arr), ps)
+  @test (grads[d_arr[:a]], grads[d_arr[:b]], grads[d_arr["c"]]) == ([1], [2], [1])
+
+  grads = gradient(() -> sumvals(d_arr), ps)
+  @test (grads[d_arr[:a]], grads[d_arr[:b]], grads[d_arr["c"]]) == ([1], [1], [1])
+end

--- a/test/features.jl
+++ b/test/features.jl
@@ -527,20 +527,14 @@ end
   y2 = (Mut(y1),)
   y3 = (Imm(y1),)
   @test_skip gradient(x -> sum(x[1].x)^2, y2)[1] == ((x = [6.0],),)  # fails on v0.6.0 v0.6.41... and with https://github.com/FluxML/Zygote.jl/pull/1453
-  @test gradient(() -> sum(y2[1].x)^2, Params([y1]))[y1] == [6.0]
   @test gradient(x -> sum(x[1].x)^2, y3)[1] == ((x = [6.0],),)
-  @test gradient(() -> sum(y3[1].x)^2, Params([y1]))[y1] == [6.0]
 
   @test gradient(x -> sum(x[1].x .+ x[1].x)^3, y2)[1] == ((x = [216.0],),)  # fails on v0.6.0 v0.6.41
-  @test gradient(() -> sum(y2[1].x .+ y2[1].x)^3, Params([y1]))[y1] == [216.0]
   @test gradient(x -> sum(x[1].x .+ x[1].x)^3, y3)[1] == ((x = [216.0],),)
-  @test gradient(() -> sum(y3[1].x .+ y3[1].x)^3, Params([y1]))[y1] == [216.0]
 
   i1 = 1
   @test gradient(x -> sum(x[i1].x .+ x[1].x)^3, y2)[1] == ((x = [216.0],),)  # fails on v0.6.0 v0.6.41
-  @test gradient(() -> sum(y2[i1].x .+ y2[1].x)^3, Params([y1]))[y1] == [216.0]
   @test gradient(x -> sum(x[i1].x .+ x[1].x)^3, y3)[1] == ((x = [216.0],),)
-  @test gradient(() -> sum(y3[i1].x .+ y3[1].x)^3, Params([y1]))[y1] == [216.0]
 end
 
 @testset "NamedTuples" begin

--- a/test/gradcheck_p4.jl
+++ b/test/gradcheck_p4.jl
@@ -286,18 +286,6 @@ end
       @test fun(z, r) == fun(bool, r)
       @test gfun(bool, r) == (nothing, gfun(z, r)[2])
     end
-
-    @testset "Implicit" begin
-      gfun(args...) = gradient(() -> sum(op.(args...)), Params(filter(a->a isa Array, collect(args))  ))
-
-      g = gfun(r, z)
-      gres = gfun(r, bool)
-      @test gres[r] == g[r]
-
-      g = gfun(z, r)
-      gres = gfun(bool, r)
-      @test gres[r] == g[r]
-    end
   end
 end
 

--- a/test/lib/base.jl
+++ b/test/lib/base.jl
@@ -51,15 +51,9 @@
         end
 
         d_num = Dict(:a => 3, :b => 4, "c" => 5)
-        d_arr = Dict(:a => [3], :b => [4], "c" => [5])
-        ps = d_arr |> values |> collect |> Params
 
         @test gradient(sumkv, d_num)[1] == Dict(:a => 1, :b => 2, "c" => 1)
-        grads = gradient(() -> sumkv(d_arr), ps)
-        @test (grads[d_arr[:a]], grads[d_arr[:b]], grads[d_arr["c"]]) == ([1], [2], [1])
 
         @test gradient(sumvals, d_num)[1] == Dict(:a => 1, :b => 1, "c" => 1)
-        grads = gradient(() -> sumvals(d_arr), ps)
-        @test (grads[d_arr[:a]], grads[d_arr[:b]], grads[d_arr["c"]]) == ([1], [1], [1])
     end
 end


### PR DESCRIPTION
## Summary

Continues the deprecation of the implicit-parameter (`Params`/`Grads`) interface (see [#1561](https://github.com/FluxML/Zygote.jl/issues/1561)) by moving it fully onto the deprecated path. Functionality is preserved for now — only its location and visibility change.

- **`src/Zygote.jl`**: `Params` is dropped from the main `export` list and re-exported right after `include("deprecated.jl")`, grouping it with the other legacy symbols.
- **Tests**: the remaining `Params`-based *gradient* tests are moved into `test/deprecated.jl`, so all implicit-params tests live in one place and can be removed together with the interface:
  - from `test/features.jl` (the `Params` cases in "mutable accum_param bugs"),
  - from `test/gradcheck_p4.jl` (the nested `"Implicit"` testset under `broadcasted(op, Array, Bool)`),
  - from `test/lib/base.jl` (the `Params` versions of the "Dict iteration" checks, [#1065](https://github.com/FluxML/Zygote.jl/issues/1065)).

  The explicit-gradient counterparts remain in their original files.
- **Docs**: remove the implicit-parameter sections from `docs/src/index.md` and `docs/src/utils.md`; minor wording fixes in `docs/src/limitations.md`.

## Testing

- `julia --project=test test/runtests.jl deprecated` — all pass (132/132).
- `julia --project=test test/runtests.jl lib gradcheck_p4` — SUCCESS.
- `features` still has the pre-existing `splats` (#1198) failures, confirmed identical on a clean tree and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)